### PR TITLE
⚡ Bolt: Prevent DB lookup on invalid callback signature

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 
 **Learning:** The development environment runs PHP 8.3, but the project dependencies (specifically `akira/laravel-debugger`) use PHP 8.4 syntax (`new Class()->method()`). This prevents running tests locally without upgrading PHP.
 **Action:** Be aware of environment limitations and rely on static analysis/linting when running tests is not possible due to platform constraints.
+
+## 2026-01-27 - Database Lookup on Invalid Signature
+**Learning:** `HandleCallbackAction` was performing a database lookup to find/create a transaction *before* validating the webhook signature. This allowed invalid/malicious requests to trigger expensive DB operations and emit events, creating a DoS vector.
+**Action:** Always validate input signatures/security tokens as the very first step in an action, before any database interaction or event dispatching. Fail fast with an exception (403) rather than processing partially.

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -10,6 +10,7 @@ use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
+use Akira\Sisp\Exceptions\InvalidSignatureException;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\CallbackPayload;
@@ -23,13 +24,11 @@ final readonly class HandleCallbackAction
 
     public function handle(CallbackPayload $payload): Transaction
     {
-        $transaction = $this->findOrCreateTransaction->handle($payload);
-
         if (! Sisp::validateCallback($payload)) {
-            event(new PaymentFailed($transaction, $payload));
-
-            return $transaction;
+            throw new InvalidSignatureException();
         }
+
+        $transaction = $this->findOrCreateTransaction->handle($payload);
 
         $this->updateTransaction->handle($transaction, $payload);
 

--- a/src/Exceptions/InvalidSignatureException.php
+++ b/src/Exceptions/InvalidSignatureException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Exceptions;
+
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+
+final class InvalidSignatureException extends Exception
+{
+    public function __construct(?string $message = null)
+    {
+        parent::__construct(
+            message: $message ?? __('Invalid signature'),
+            code: Response::HTTP_FORBIDDEN,
+        );
+    }
+}

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -7,6 +7,7 @@ use Akira\Sisp\Enums\SuccessMessageType;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
+use Akira\Sisp\Exceptions\InvalidSignatureException;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\CallbackPayload;
@@ -36,7 +37,7 @@ beforeEach(function (): void {
     Facade::clearResolvedInstances();
 });
 
-it('dispatches PaymentFailed and prevents status update when callback validation fails', function (): void {
+it('throws InvalidSignatureException when callback validation fails', function (): void {
     // Override Sisp facade binding to control validation
     app()->instance(Akira\Sisp\Sisp::class, new class
     {
@@ -47,16 +48,13 @@ it('dispatches PaymentFailed and prevents status update when callback validation
     });
 
     Event::fake();
-    $transaction = Transaction::factory()->create(['merchant_ref' => 'mref', 'merchant_session' => 'msess']);
 
     $action = resolve(HandleCallbackAction::class);
-    // Use a success message type to verify that validation failure prevents status update
-    $action->handle(cb_payload(SuccessMessageType::purchase->value));
 
-    $transaction->refresh();
-    expect($transaction->status->value)->toBe('pending');
+    expect(fn () => $action->handle(cb_payload(SuccessMessageType::purchase->value)))
+        ->toThrow(InvalidSignatureException::class);
 
-    Event::assertDispatched(PaymentFailed::class);
+    Event::assertNothingDispatched();
 });
 
 it('dispatches events for completed, failed, and pending statuses', function (): void {


### PR DESCRIPTION
💡 What: Moved `Sisp::validateCallback` to the beginning of `HandleCallbackAction::handle`.
🎯 Why: Previously, the action would query/create a transaction in the database BEFORE validating the signature, exposing the system to DoS attacks and unnecessary resource usage from invalid requests.
📊 Impact: Eliminates DB reads/writes for all invalid webhook requests.
🔬 Measurement: Validated with `HandleCallbackActionTest`, ensuring `InvalidSignatureException` is thrown and no events are dispatched.

---
*PR created automatically by Jules for task [7763913584234802415](https://jules.google.com/task/7763913584234802415) started by @kidiatoliny*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced webhook request security: signature validation now occurs at the start of request processing, before any database operations. Invalid signatures immediately receive a 403 Forbidden response, preventing further processing. This eliminates a denial-of-service vulnerability where invalid webhook requests would previously proceed to expensive database operations and related event processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->