### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix payment callback signature validation order

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was updating the transaction status based on the callback payload *before* validating the request signature (fingerprint). This allowed an attacker to forge a successful payment callback without knowing the secret key, as the system would mark the transaction as paid before rejecting the request.
 **Learning:** Logic order in callback handlers is critical. Always validate the authenticity of the request (signature, token, IP allowlist) before processing any data or updating state. It is a common mistake to "parse first, validate later" which can lead to state corruption.
 **Prevention:** Ensure that verification steps (signature checks, authentication) are the very first operations in any webhook or callback handler. Use "Guard Clauses" to return early if validation fails.
+
+## 2025-05-22 - [Pre-Validation Database Lookup & Event Trigger]
+**Vulnerability:** The callback handler performed a database lookup (`findOrCreateTransaction`) and dispatched an event (`PaymentFailed`) *before* validating the signature. This allowed unauthenticated payloads to trigger database queries (potential enumeration/DoS) and application events.
+**Learning:** Even if state updates are guarded, performing *any* expensive operation or side-effect (like DB lookups or events) before validation exposes the application to DoS and information leakage.
+**Prevention:** Validation must be strict and immediate. Do not resolve models or dispatch events until the payload is verified authentic.

--- a/peck.json
+++ b/peck.json
@@ -18,7 +18,8 @@
             "pnpm",
             "getters",
             "roadmap",
-            "addr"
+            "addr",
+            "pdfs"
         ],
         "paths": []
     }

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -10,6 +10,7 @@ use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
+use Akira\Sisp\Exceptions\InvalidSignatureException;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\CallbackPayload;
@@ -23,13 +24,11 @@ final readonly class HandleCallbackAction
 
     public function handle(CallbackPayload $payload): Transaction
     {
-        $transaction = $this->findOrCreateTransaction->handle($payload);
-
         if (! Sisp::validateCallback($payload)) {
-            event(new PaymentFailed($transaction, $payload));
-
-            return $transaction;
+            throw new InvalidSignatureException('Invalid payment response signature.');
         }
+
+        $transaction = $this->findOrCreateTransaction->handle($payload);
 
         $this->updateTransaction->handle($transaction, $payload);
 

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -24,9 +24,7 @@ final readonly class HandleCallbackAction
 
     public function handle(CallbackPayload $payload): Transaction
     {
-        if (! Sisp::validateCallback($payload)) {
-            throw new InvalidSignatureException('Invalid payment response signature.');
-        }
+        throw_unless(Sisp::validateCallback($payload), InvalidSignatureException::class, 'Invalid payment response signature.');
 
         $transaction = $this->findOrCreateTransaction->handle($payload);
 

--- a/src/Commands/DoctorCommand.php
+++ b/src/Commands/DoctorCommand.php
@@ -100,16 +100,16 @@ final class DoctorCommand extends Command
     {
         $this->info('📄 Invoice Status:');
 
-        $totalInvoices = Invoice::count();
+        $totalInvoices = Invoice::query()->count();
         $this->line("  Total invoices: <info>{$totalInvoices}</info>");
 
-        $paidInvoices = Invoice::where('status', InvoiceStatus::paid->value)->count();
+        $paidInvoices = Invoice::query()->where('status', InvoiceStatus::paid->value)->count();
         $this->line("  Paid invoices: <info>{$paidInvoices}</info>");
 
-        $invoicesWithPdf = Invoice::whereNotNull('pdf_path')->count();
+        $invoicesWithPdf = Invoice::query()->whereNotNull('pdf_path')->count();
         $this->line("  Invoices with PDF: <info>{$invoicesWithPdf}</info>");
 
-        $paidWithoutPdf = Invoice::where('status', InvoiceStatus::paid->value)
+        $paidWithoutPdf = Invoice::query()->where('status', InvoiceStatus::paid->value)
             ->whereNull('pdf_path')
             ->count();
 
@@ -117,7 +117,7 @@ final class DoctorCommand extends Command
             $this->warn("  ⚠️  {$paidWithoutPdf} paid invoices are missing PDFs");
 
             // Show sample
-            $sample = Invoice::where('status', InvoiceStatus::paid->value)
+            $sample = Invoice::query()->where('status', InvoiceStatus::paid->value)
                 ->whereNull('pdf_path')
                 ->with('transaction')
                 ->first();

--- a/src/Exceptions/InvalidSignatureException.php
+++ b/src/Exceptions/InvalidSignatureException.php
@@ -6,6 +6,4 @@ namespace Akira\Sisp\Exceptions;
 
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
-class InvalidSignatureException extends AccessDeniedHttpException
-{
-}
+final class InvalidSignatureException extends AccessDeniedHttpException {}

--- a/src/Exceptions/InvalidSignatureException.php
+++ b/src/Exceptions/InvalidSignatureException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class InvalidSignatureException extends AccessDeniedHttpException
+{
+}

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -7,6 +7,7 @@ use Akira\Sisp\Enums\SuccessMessageType;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
+use Akira\Sisp\Exceptions\InvalidSignatureException;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\CallbackPayload;
@@ -36,7 +37,7 @@ beforeEach(function (): void {
     Facade::clearResolvedInstances();
 });
 
-it('dispatches PaymentFailed and prevents status update when callback validation fails', function (): void {
+it('throws InvalidSignatureException when callback validation fails', function (): void {
     // Override Sisp facade binding to control validation
     app()->instance(Akira\Sisp\Sisp::class, new class
     {
@@ -47,16 +48,17 @@ it('dispatches PaymentFailed and prevents status update when callback validation
     });
 
     Event::fake();
-    $transaction = Transaction::factory()->create(['merchant_ref' => 'mref', 'merchant_session' => 'msess']);
+
+    // We do NOT create any transaction.
+    // If validation was second, FindOrCreateTransactionAction would throw ModelNotFoundException.
+    // Since we expect InvalidSignatureException, it proves validation is first.
 
     $action = resolve(HandleCallbackAction::class);
-    // Use a success message type to verify that validation failure prevents status update
-    $action->handle(cb_payload(SuccessMessageType::purchase->value));
 
-    $transaction->refresh();
-    expect($transaction->status->value)->toBe('pending');
+    expect(fn () => $action->handle(cb_payload(SuccessMessageType::purchase->value)))
+        ->toThrow(InvalidSignatureException::class);
 
-    Event::assertDispatched(PaymentFailed::class);
+    Event::assertNothingDispatched();
 });
 
 it('dispatches events for completed, failed, and pending statuses', function (): void {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Tests;
 
-use Akira\Debugger\DebuggerServiceProvider;
 use Akira\Sisp\SispServiceProvider;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -63,7 +62,6 @@ abstract class TestCase extends Orchestra
     {
         return [
             SispServiceProvider::class,
-            DebuggerServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `HandleCallbackAction` performed a database lookup and dispatched events before validating the callback signature. This allowed attackers to trigger database queries and events with invalid payloads (DoS/Enumeration risk).
🎯 Impact: Prevents unauthenticated payloads from interacting with the database or triggering application events.
🔧 Fix: Moved `Sisp::validateCallback` to the beginning of the `handle` method and throw `InvalidSignatureException` on failure.
✅ Verification: Added a test case in `tests/Actions/HandleCallbackActionTest.php` that verifies `InvalidSignatureException` is thrown and no transaction is looked up when validation fails.

Also included environment fixes in `tests/TestCase.php` to enable running tests.

---
*PR created automatically by Jules for task [17702169754844225578](https://jules.google.com/task/17702169754844225578) started by @kidiatoliny*