### PR TITLE
fix(security): secure refund endpoint with configurable middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `HandleCallbackAction` performed a database lookup/creation (`findOrCreateTransaction`) using the payload data *before* validating the callback signature. This exposed the database to potential DoS attacks and timing attacks from unauthenticated sources.
 **Learning:** Even read-only database operations (or find-or-create) should be protected by signature validation when handling external callbacks. Processing untrusted input against the database is a security risk.
 **Prevention:** Strictly enforce "Validate First" policy. The very first line of code in a callback handler should be the signature validation. Do not touch the database or filesystem until the request is proven authentic.
+
+## 2025-01-30 - [Unprotected Package Routes]
+**Vulnerability:** The package exposed sensitive administrative routes (e.g., `sisp/refund`) via `routes/web.php` without any authentication or authorization middleware configured by default. This allowed any user to trigger refunds if they could guess the transaction ID, bypassing application-level security controls.
+**Learning:** Package routes are automatically registered in the host application. If they perform sensitive actions, they MUST use configurable middleware (defaulting to secure options like `web` and `auth`) to ensure they are protected according to the host application's security context. Hardcoding unprotected routes in a package assumes a level of trust that does not exist for public endpoints.
+**Prevention:** Always expose middleware configuration for package routes in the config file. Set secure defaults (e.g., `['web', 'auth']`) for any route that modifies state or exposes sensitive data.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "stevebauman/location": "^7.6"
   },
   "require-dev": {
-    "akira/laravel-debugger": "^1.0",
     "inertiajs/inertia-laravel": "^2.0",
     "larastan/larastan": "^3.0",
     "laravel/pint": "^1.14",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "stevebauman/location": "^7.6"
   },
   "require-dev": {
+    "akira/laravel-debugger": "^1.0",
     "inertiajs/inertia-laravel": "^2.0",
     "larastan/larastan": "^3.0",
     "laravel/pint": "^1.14",

--- a/config/sisp.php
+++ b/config/sisp.php
@@ -374,4 +374,18 @@ return [
         'cache_ttl_minutes' => env('SISP_GEOLOCATION_CACHE_TTL', 1440),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will be assigned to the various routes of the package.
+    | You can customize the middleware to add authentication, authorization,
+    | or custom checks.
+    |
+    */
+    'middleware' => [
+        'refund' => ['web', 'auth'],
+    ],
+
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,8 @@ Route::match(['get', 'post'], 'sisp/callback', CallbackController::class)
 Route::get('sisp/cancel', CancelTransactionController::class)
     ->name('sisp.cancel');
 
-Route::post('sisp/refund', RefundTransactionController::class)
+Route::post('sisp/refund/{transaction}', RefundTransactionController::class)
+    ->middleware(config('sisp.middleware.refund', ['web', 'auth']))
     ->name('sisp.refund');
 
 Route::match(['get', 'post'], 'sisp/sandbox', SandboxController::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ Route::get('sisp/cancel', CancelTransactionController::class)
     ->name('sisp.cancel');
 
 Route::post('sisp/refund/{transaction}', RefundTransactionController::class)
-    ->middleware(config('sisp.middleware.refund', ['web', 'auth']))
+    ->middleware(config()->string('sisp.middleware.refund', ['web', 'auth']))
     ->name('sisp.refund');
 
 Route::match(['get', 'post'], 'sisp/sandbox', SandboxController::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ Route::get('sisp/cancel', CancelTransactionController::class)
     ->name('sisp.cancel');
 
 Route::post('sisp/refund/{transaction}', RefundTransactionController::class)
-    ->middleware(config()->string('sisp.middleware.refund', ['web', 'auth']))
+    ->middleware(config()->array('sisp.middleware.refund', ['web', 'auth']))
     ->name('sisp.refund');
 
 Route::match(['get', 'post'], 'sisp/sandbox', SandboxController::class)

--- a/tests/Controllers/RefundTransactionControllerTest.php
+++ b/tests/Controllers/RefundTransactionControllerTest.php
@@ -14,7 +14,7 @@ it('refunds a completed transaction and returns json', function (): void {
     ]);
 
     $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund'), 'POST', ['amount' => 50.0, 'reason' => 'test']);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 50.0, 'reason' => 'test']);
 
     $response = $controller($t, $request);
 
@@ -30,7 +30,7 @@ it('returns 400 when refund amount exceeds transaction', function (): void {
     ]);
 
     $controller = resolve(RefundTransactionController::class);
-    $request = Request::create('/sisp/refund', 'POST', ['amount' => 150.0]);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 150.0]);
 
     $response = $controller($t, $request);
     expect($response->getStatusCode())->toBe(400);


### PR DESCRIPTION
The 'sisp/refund' route was previously exposed without any default middleware protection, allowing unauthenticated access if the transaction ID was known. This change:
1. Adds a 'middleware' section to 'config/sisp.php' with a default of ['web', 'auth'] for the refund route.
2. Updates 'routes/web.php' to use this middleware configuration.
3. Fixes the route definition to include the '{transaction}' parameter, enabling proper Route Model Binding.
4. Updates 'RefundTransactionControllerTest' to match the new route signature.
5. Adds a security journal entry in '.jules/sentinel.md'.

---
*PR created automatically by Jules for task [17954338041980754900](https://jules.google.com/task/17954338041980754900) started by @kidiatoliny*