### PR TITLE
⚡ Bolt: Memoize PostAutCode hash calculation

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -18,7 +18,8 @@
             "pnpm",
             "getters",
             "roadmap",
-            "addr"
+            "addr",
+            "pdfs"
         ],
         "paths": []
     }

--- a/src/Actions/PostAutCode.php
+++ b/src/Actions/PostAutCode.php
@@ -8,12 +8,17 @@ use Akira\Sisp\Configuration\LoadConfig;
 
 final readonly class PostAutCode
 {
-    public function __construct(private LoadConfig $config) {}
+    private string $hashedCode;
+
+    public function __construct(private LoadConfig $config)
+    {
+        // Optimization: Calculate hash once at construction time
+        // since posAutCode is static configuration.
+        $this->hashedCode = base64_encode(hash('sha512', $this->config->getPosAutCode(), true));
+    }
 
     public function handle(): string
     {
-        $posAutCode = $this->config->getPosAutCode();
-
-        return base64_encode(hash('sha512', $posAutCode, true));
+        return $this->hashedCode;
     }
 }

--- a/src/Commands/DoctorCommand.php
+++ b/src/Commands/DoctorCommand.php
@@ -123,6 +123,7 @@ final class DoctorCommand extends Command
                 ->first();
 
             if ($sample) {
+                /** @var Invoice $sample */
                 $this->newLine();
                 $this->line('  Sample invoice without PDF:');
                 $this->line("    Invoice: <info>#{$sample->invoice_number}</info>");

--- a/src/Commands/DoctorCommand.php
+++ b/src/Commands/DoctorCommand.php
@@ -100,16 +100,16 @@ final class DoctorCommand extends Command
     {
         $this->info('📄 Invoice Status:');
 
-        $totalInvoices = Invoice::count();
+        $totalInvoices = Invoice::query()->count();
         $this->line("  Total invoices: <info>{$totalInvoices}</info>");
 
-        $paidInvoices = Invoice::where('status', InvoiceStatus::paid->value)->count();
+        $paidInvoices = Invoice::query()->where('status', InvoiceStatus::paid->value)->count();
         $this->line("  Paid invoices: <info>{$paidInvoices}</info>");
 
-        $invoicesWithPdf = Invoice::whereNotNull('pdf_path')->count();
+        $invoicesWithPdf = Invoice::query()->whereNotNull('pdf_path')->count();
         $this->line("  Invoices with PDF: <info>{$invoicesWithPdf}</info>");
 
-        $paidWithoutPdf = Invoice::where('status', InvoiceStatus::paid->value)
+        $paidWithoutPdf = Invoice::query()->where('status', InvoiceStatus::paid->value)
             ->whereNull('pdf_path')
             ->count();
 
@@ -117,7 +117,7 @@ final class DoctorCommand extends Command
             $this->warn("  ⚠️  {$paidWithoutPdf} paid invoices are missing PDFs");
 
             // Show sample
-            $sample = Invoice::where('status', InvoiceStatus::paid->value)
+            $sample = Invoice::query()->where('status', InvoiceStatus::paid->value)
                 ->whereNull('pdf_path')
                 ->with('transaction')
                 ->first();

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -15,12 +15,14 @@ use Illuminate\Support\Facades\Storage;
 /**
  * @property-read  string|null $pdf_path
  * @property-read  InvoiceStatus $status
- * @property-read  Transaction $transaction
+ * @property-read  Transaction|null $transaction
  * @property-read  array $items
  * @property-read  int $items_count
  * @property-read  CarbonInterface $invoice_date
  * @property-read  CarbonInterface|null $due_date
  * @property-read  string $invoice_number
+ * @property-read  string $customer_name
+ * @property-read  CarbonInterface $created_at
  */
 final class Invoice extends Model
 {


### PR DESCRIPTION
**💡 What:**
Optimized `PostAutCode` action by moving the SHA512 hash calculation of the `posAutCode` configuration from the `handle()` method to the `__construct()` method.

**🎯 Why:**
The `posAutCode` is a static configuration value. Calculating its hash is a relatively expensive operation (SHA512). Previously, this was recalculated every time `handle()` was invoked. In high-throughput scenarios or batch processing where `GenerateFingerprintAction` is called frequently, this redundancy accumulates.

**📊 Impact:**
- Eliminates repetitive hashing of static data.
- Improves performance of payment request generation and response validation.

**🔬 Measurement:**
- Verified via `PostAutCodeTest` that the output remains correct.
- Verified via full test suite that no regressions were introduced.


---
*PR created automatically by Jules for task [16983013569581464644](https://jules.google.com/task/16983013569581464644) started by @kidiatoliny*