### PR TITLE
feat(ui): add button variants and improve accessibility in payment views

### DIFF
--- a/resources/views/components/redirect-button.blade.php
+++ b/resources/views/components/redirect-button.blade.php
@@ -1,3 +1,13 @@
-@props(['name'])
+@props(['name', 'variant' => 'success'])
 
-<a href="{{url(config('sisp.redirect_url'))}}" class="mt-10 inline-block text-white bg-green-500 px-4 py-2 rounded-xl hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 w-full transition-colors duration-200">{{ $name }}</a>
+@php
+    $variants = [
+        'success' => 'bg-green-500 hover:bg-green-600 focus:ring-green-500',
+        'neutral' => 'bg-zinc-500 hover:bg-zinc-600 focus:ring-zinc-500',
+        'primary' => 'bg-blue-500 hover:bg-blue-600 focus:ring-blue-500',
+    ];
+
+    $classes = $variants[$variant] ?? $variants['success'];
+@endphp
+
+<a href="{{url(config('sisp.redirect_url'))}}" {{ $attributes->merge(['class' => "mt-10 inline-block text-white px-4 py-2 rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-zinc-900 w-full transition-colors duration-200 $classes"]) }}>{{ $name }}</a>

--- a/resources/views/payment-response.blade.php
+++ b/resources/views/payment-response.blade.php
@@ -58,7 +58,7 @@
                 <div class="space-y-2 text-center">
                     <div class="flex justify-center">
                         <div class="rounded-full bg-yellow-100 dark:bg-yellow-950 p-4">
-                            <svg class="h-8 w-8 animate-spin text-yellow-600 dark:text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="h-8 w-8 animate-spin motion-reduce:animate-none text-yellow-600 dark:text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>
                         </div>

--- a/resources/views/purchase-cancelled.blade.php
+++ b/resources/views/purchase-cancelled.blade.php
@@ -9,7 +9,7 @@
 				{{ __('Dear customer, your purchase has been cancelled. For more information, do not hesitate to contact us.') }}
 			</p>
 			<div class="sisp-button-wrapper">
-				<x-sisp::redirect-button :name="__('Return Home')"/>
+				<x-sisp::redirect-button variant="neutral" :name="__('Return Home')"/>
 			</div>
 		</div>
 	</div>
@@ -21,7 +21,6 @@
           height: 100vh;
           padding: 1rem;
           background-color: #f9fafb;
-          animation: fadeInPage 0.6s ease-out forwards;
       }
 
       .dark .sisp-fullpage-container {
@@ -37,7 +36,6 @@
           max-width: 400px;
           width: 100%;
           text-align: center;
-          animation: fadeInUp 0.8s ease-out forwards;
       }
 
       .dark .sisp-fullpage-card {
@@ -49,7 +47,6 @@
           display: flex;
           justify-content: center;
           margin-bottom: 1.2rem;
-          animation: pulse 1.5s infinite;
       }
 
       .sisp-icon {
@@ -63,19 +60,42 @@
           font-weight: 800;
           color: #dc2626;
           margin-top: 0.5rem;
-          animation: fadeIn 0.9s ease-out;
       }
 
       .sisp-description {
           margin-top: 1rem;
           font-size: 1rem;
           line-height: 1.5;
-          animation: fadeIn 1.1s ease-out;
       }
 
       .sisp-button-wrapper {
           margin-top: 2rem;
-          animation: fadeIn 1.3s ease-out;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+          .sisp-fullpage-container {
+              animation: fadeInPage 0.6s ease-out forwards;
+          }
+
+          .sisp-fullpage-card {
+              animation: fadeInUp 0.8s ease-out forwards;
+          }
+
+          .sisp-icon-wrapper {
+              animation: pulse 1.5s infinite;
+          }
+
+          .sisp-title {
+              animation: fadeIn 0.9s ease-out;
+          }
+
+          .sisp-description {
+              animation: fadeIn 1.1s ease-out;
+          }
+
+          .sisp-button-wrapper {
+              animation: fadeIn 1.3s ease-out;
+          }
       }
 
       @keyframes fadeInPage {

--- a/resources/views/purchase-success.blade.php
+++ b/resources/views/purchase-success.blade.php
@@ -21,7 +21,6 @@
           height: 100vh;
           padding: 1rem;
           background-color: #f9fafb;
-          animation: fadeInPage 0.6s ease-out forwards;
       }
 
       .dark .sisp-fullpage-container {
@@ -37,7 +36,6 @@
           max-width: 400px;
           width: 100%;
           text-align: center;
-          animation: fadeInUp 0.8s ease-out forwards;
       }
 
       .dark .sisp-fullpage-card {
@@ -49,7 +47,6 @@
           display: flex;
           justify-content: center;
           margin-bottom: 1.2rem;
-          animation: pulse 1.5s infinite;
       }
 
       .sisp-icon {
@@ -65,7 +62,6 @@
           font-size: 1.75rem;
           font-weight: 800;
           margin-top: 0.5rem;
-          animation: fadeIn 0.9s ease-out;
       }
 
       .success-text {
@@ -76,12 +72,36 @@
           margin-top: 1rem;
           font-size: 1rem;
           line-height: 1.5;
-          animation: fadeIn 1.1s ease-out;
       }
 
       .sisp-button-wrapper {
           margin-top: 2rem;
-          animation: fadeIn 1.3s ease-out;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+          .sisp-fullpage-container {
+              animation: fadeInPage 0.6s ease-out forwards;
+          }
+
+          .sisp-fullpage-card {
+              animation: fadeInUp 0.8s ease-out forwards;
+          }
+
+          .sisp-icon-wrapper {
+              animation: pulse 1.5s infinite;
+          }
+
+          .sisp-title {
+              animation: fadeIn 0.9s ease-out;
+          }
+
+          .sisp-description {
+              animation: fadeIn 1.1s ease-out;
+          }
+
+          .sisp-button-wrapper {
+              animation: fadeIn 1.3s ease-out;
+          }
       }
 
       @keyframes fadeInPage {

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -13,9 +13,11 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Storage;
 
 /**
+ * @property string $customer_name
+ * @property CarbonInterface $created_at
  * @property-read  string|null $pdf_path
  * @property-read  InvoiceStatus $status
- * @property-read  Transaction $transaction
+ * @property-read  Transaction|null $transaction
  * @property-read  array $items
  * @property-read  int $items_count
  * @property-read  CarbonInterface $invoice_date


### PR DESCRIPTION
This PR introduces UX and accessibility improvements to the payment views:
1.  **Button Variants**: The `redirect-button` component now supports variants ('success', 'neutral', 'primary'). This allows the "Return Home" button on the "Purchase Cancelled" page to use a neutral color instead of green (which implies success).
2.  **Reduced Motion**: All infinite animations (pulse, spin) now respect the user's `prefers-reduced-motion` setting.
3.  **Dark Mode Accessibility**: Added specific focus ring offset colors for dark mode to ensure visibility on dark backgrounds.

---
*PR created automatically by Jules for task [4144661904934725511](https://jules.google.com/task/4144661904934725511) started by @kidiatoliny*