### PR TITLE
fix(retry): regenerate merchant session and timestamp

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,19 +67,7 @@ parameters:
 			path: src/Actions/RenderPaymentResponseAction.php
 
 		-
-			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$created_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/RetryPaymentAction.php
-
-		-
 			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$currency\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/RetryPaymentAction.php
-
-		-
-			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$merchant_session\.$#'
 			identifier: property.notFound
 			count: 1
 			path: src/Actions/RetryPaymentAction.php

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -10,6 +10,11 @@ use Akira\Sisp\ValueObjects\PaymentRequestData;
 
 final readonly class RetryPaymentAction
 {
+    /**
+     * SISP 3DS requires a non-null postal code on retries.
+     */
+    private const FALLBACK_POSTAL_CODE = '0000';
+
     public function __construct(private BuildRequestPayloadAction $buildRequestPayload) {}
 
     public function handle(Transaction $transaction): PaymentRequest
@@ -36,7 +41,7 @@ final readonly class RetryPaymentAction
             customerCountry: $transaction->customer_country,
             customerCity: $transaction->customer_city,
             customerAddress: $transaction->customer_address,
-            customerPostalCode: $transaction->customer_postal_code ?? '0000',
+            customerPostalCode: $transaction->customer_postal_code ?? self::FALLBACK_POSTAL_CODE,
             customerPhone: $transaction->customer_phone,
         );
     }

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -13,7 +13,7 @@ final readonly class RetryPaymentAction
     /**
      * SISP 3DS requires a non-null postal code on retries.
      */
-    private const FALLBACK_POSTAL_CODE = '0000';
+    private const string FALLBACK_POSTAL_CODE = '0000';
 
     public function __construct(private BuildRequestPayloadAction $buildRequestPayload) {}
 

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -24,13 +24,20 @@ final readonly class RetryPaymentAction
         return new PaymentRequestData(
             amount: $transaction->amount,
             merchantRef: $transaction->merchant_ref,
-            merchantSession: $transaction->merchant_session,
-            timeStamp: $transaction->created_at->format('Y-m-d H:i:s'),
+            merchantSession: null,
+            timeStamp: null,
             currency: $transaction->currency,
             transactionCode: $transaction->transaction_code,
             token: '',
             entityCode: '',
             referenceNumber: '',
+            locale: $transaction->locale,
+            customerEmail: $transaction->customer_email,
+            customerCountry: $transaction->customer_country,
+            customerCity: $transaction->customer_city,
+            customerAddress: $transaction->customer_address,
+            customerPostalCode: $transaction->customer_postal_code ?? '0000',
+            customerPhone: $transaction->customer_phone,
         );
     }
 }

--- a/tests/Actions/RetryPaymentActionTest.php
+++ b/tests/Actions/RetryPaymentActionTest.php
@@ -37,7 +37,8 @@ it('includes all transaction details', function (): void {
     $paymentRequest = $this->action->handle($transaction);
 
     expect($paymentRequest->merchantRef)->toBe('CUSTOM-REF-123')
-        ->and($paymentRequest->merchantSession)->toBe('CUSTOM-SESS-456')
+        ->and($paymentRequest->merchantSession)->not->toBe('CUSTOM-SESS-456')
+        ->and($paymentRequest->merchantSession)->not->toBe('')
         ->and($paymentRequest->currency)->toBe('CVE');
 });
 


### PR DESCRIPTION
## Summary
- regenerate `merchantSession` and `timeStamp` on payment retry by passing `null` in `RetryPaymentAction`
- preserve merchant reference and customer fields for 3DS payload generation on retry
- update retry action test expectations to validate regenerated session behavior

## Validation
- `./vendor/bin/pest tests/Actions/RetryPaymentActionTest.php`
- `./vendor/bin/pest tests/Actions/BuildRequestPayloadActionTest.php`
