### PR TITLE
fix(refund): add authorization check to refund transaction endpoint

### DIFF
--- a/src/Http/Controllers/RefundTransactionController.php
+++ b/src/Http/Controllers/RefundTransactionController.php
@@ -18,6 +18,13 @@ final readonly class RefundTransactionController
 
     public function __invoke(Transaction $transaction, Request $request): JsonResponse
     {
+        if (! $this->isAuthorizedForTransaction($request, $transaction)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Unauthorized to refund this transaction.',
+            ], 403);
+        }
+
         $refundAmount = (float) $request->input('amount');
         $reason = $request->input('reason', 'user_refund');
 
@@ -35,5 +42,27 @@ final readonly class RefundTransactionController
                 'message' => $e->getMessage(),
             ], 400);
         }
+    }
+
+    private function isAuthorizedForTransaction(Request $request, Transaction $transaction): bool
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->can('refund', $transaction)) {
+            return true;
+        }
+
+        $userEmail = data_get($user, 'email');
+        $transactionEmail = (string) ($transaction->customer_email ?? '');
+
+        if (! is_string($userEmail) || mb_trim($userEmail) === '' || mb_trim($transactionEmail) === '') {
+            return false;
+        }
+
+        return strcasecmp(mb_trim($userEmail), mb_trim($transactionEmail)) === 0;
     }
 }

--- a/tests/Controllers/RefundTransactionControllerTest.php
+++ b/tests/Controllers/RefundTransactionControllerTest.php
@@ -11,10 +11,20 @@ it('refunds a completed transaction and returns json', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
     $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 50.0, 'reason' => 'test']);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public string $email = 'buyer@example.com';
+
+        public function can(string $ability, mixed $subject): bool
+        {
+            return false;
+        }
+    });
 
     $response = $controller($t, $request);
 
@@ -27,11 +37,114 @@ it('returns 400 when refund amount exceeds transaction', function (): void {
     $t = Transaction::factory()->create([
         'status' => 'completed',
         'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
     $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 150.0]);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public string $email = 'buyer@example.com';
+
+        public function can(string $ability, mixed $subject): bool
+        {
+            return false;
+        }
+    });
 
     $response = $controller($t, $request);
     expect($response->getStatusCode())->toBe(400);
+});
+
+it('returns 403 when user is not authorized for the transaction', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
+    ]);
+
+    $controller = resolve(RefundTransactionController::class);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public string $email = 'intruder@example.com';
+
+        public function can(string $ability, mixed $subject): bool
+        {
+            return false;
+        }
+    });
+
+    $response = $controller($t, $request);
+
+    expect($response->getStatusCode())->toBe(403);
+    $data = $response->getData(true);
+    expect($data['success'])->toBeFalse();
+});
+
+it('returns 403 when no authenticated user is present', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
+    ]);
+
+    $controller = resolve(RefundTransactionController::class);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
+
+    $response = $controller($t, $request);
+
+    expect($response->getStatusCode())->toBe(403);
+    $data = $response->getData(true);
+    expect($data['success'])->toBeFalse();
+});
+
+it('returns 403 when user has no email and no refund ability', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
+    ]);
+
+    $controller = resolve(RefundTransactionController::class);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public function can(string $ability, mixed $subject): bool
+        {
+            return false;
+        }
+    });
+
+    $response = $controller($t, $request);
+
+    expect($response->getStatusCode())->toBe(403);
+    $data = $response->getData(true);
+    expect($data['success'])->toBeFalse();
+});
+
+it('allows authorized users through can refund ability', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
+    ]);
+
+    $controller = resolve(RefundTransactionController::class);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0, 'reason' => 'policy_allowed']);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public string $email = 'intruder@example.com';
+
+        public function can(string $ability, mixed $subject): bool
+        {
+            return $ability === 'refund' && $subject instanceof Transaction;
+        }
+    });
+
+    $response = $controller($t, $request);
+    $data = $response->getData(true);
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($data['success'])->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- Adds user authorization to `RefundTransactionController` before processing refunds
- Users are authorized if they have the `refund` policy ability OR if their email matches the transaction's `customer_email`
- Returns 403 with a JSON error when the user is unauthorized or unauthenticated

## Test plan
- [x] Existing refund tests updated to include authenticated users
- [x] Added test: returns 403 for mismatched email without policy ability
- [x] Added test: returns 403 when no user is authenticated
- [x] Added test: returns 403 when user has no email and no ability
- [x] Added test: allows refund when user has `refund` policy ability