### PR TITLE
fix(retry): secure retry payment with signed URLs and ownership check

### DIFF
--- a/resources/js/react/pages/payment-response.tsx
+++ b/resources/js/react/pages/payment-response.tsx
@@ -57,6 +57,7 @@ interface PaymentResponseProps {
     error?: ErrorData | null;
     translations?: Translations;
     allowRetry?: boolean;
+    retryPaymentUrl?: string;
     invoice?: InvoiceData | null;
     payload: Record<string, any>;
 }
@@ -92,6 +93,7 @@ export default function PaymentResponse({
                                             error,
                                             translations = DEFAULT_TRANSLATIONS,
                                             allowRetry = true,
+                                            retryPaymentUrl,
                                             invoice,
                                             payload
                                         }: PaymentResponseProps) {
@@ -105,7 +107,7 @@ export default function PaymentResponse({
     });
 
     const handleRetryPayment = () => {
-        post('/sisp/retry-payment');
+        post(retryPaymentUrl ?? '/sisp/retry-payment');
     };
 
     useEffect(() => {

--- a/resources/views/payment-response.blade.php
+++ b/resources/views/payment-response.blade.php
@@ -80,9 +80,8 @@
 
         <div class="mt-8 space-y-2">
             @if($transaction->status === 'failed' && $allowRetry)
-                <form method="POST" action="{{ route('sisp.retry-payment') }}" class="w-full">
+                <form method="POST" action="{{ $retryPaymentUrl }}" class="w-full">
                     @csrf
-                    <input type="hidden" name="transaction_id" value="{{ $transaction->id }}">
                     <button type="submit" class="block w-full rounded-lg bg-blue-600 hover:bg-blue-700 px-4 py-2 text-center font-medium text-white transition">
                         {{ __('sisp::messages.payment.response.retry_payment') }}
                     </button>

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -8,6 +8,7 @@ use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 
 final readonly class RenderPaymentResponseAction
@@ -28,6 +29,7 @@ final readonly class RenderPaymentResponseAction
             'payload' => $payload,
             'error' => $this->getStructuredError($transaction),
             'allowRetry' => $this->config->isRetryAllowed(),
+            'retryPaymentUrl' => $this->retryPaymentUrl($transaction),
         ]);
     }
 
@@ -53,6 +55,7 @@ final readonly class RenderPaymentResponseAction
             'error' => $this->getStructuredError($transaction),
             'translations' => $this->getTranslations->handle(),
             'allowRetry' => $this->config->isRetryAllowed(),
+            'retryPaymentUrl' => $this->retryPaymentUrl($transaction),
             'invoice' => $invoice ? [
                 'invoice_number' => $invoice->invoice_number,
                 'pdf_url' => $invoice->pdf_url,
@@ -74,5 +77,14 @@ final readonly class RenderPaymentResponseAction
         }
 
         return $this->getErrorResponse->handle($errorType)->toArray();
+    }
+
+    private function retryPaymentUrl(Transaction $transaction): string
+    {
+        return URL::temporarySignedRoute(
+            'sisp.retry-payment',
+            now()->addMinutes(15),
+            ['transaction_id' => $transaction->id]
+        );
     }
 }

--- a/src/Http/Requests/RetryPaymentRequest.php
+++ b/src/Http/Requests/RetryPaymentRequest.php
@@ -32,7 +32,7 @@ final class RetryPaymentRequest extends FormRequest
         $customerEmail = $transaction->customer_email;
         $userEmail = data_get($user, 'email');
 
-        if (! is_string($customerEmail) || $customerEmail === '' || ! is_string($userEmail) || $userEmail === '') {
+        if ($customerEmail === '' || ! is_string($userEmail) || $userEmail === '') {
             return false;
         }
 

--- a/src/Http/Requests/RetryPaymentRequest.php
+++ b/src/Http/Requests/RetryPaymentRequest.php
@@ -4,19 +4,45 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Http\Requests;
 
+use Akira\Sisp\Models\Transaction;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 
 final class RetryPaymentRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return true;
+        if (! URL::hasValidSignature($this)) {
+            return false;
+        }
+
+        $transaction = Transaction::query()->find($this->integer('transaction_id'));
+
+        if (! $transaction) {
+            return false;
+        }
+
+        $user = $this->user();
+
+        if ($user === null) {
+            return true;
+        }
+
+        $customerEmail = $transaction->customer_email;
+        $userEmail = data_get($user, 'email');
+
+        if (! is_string($customerEmail) || $customerEmail === '' || ! is_string($userEmail) || $userEmail === '') {
+            return false;
+        }
+
+        return Str::lower($customerEmail) === Str::lower($userEmail);
     }
 
     public function rules(): array
     {
         return [
-            'transaction_id' => ['required', 'integer', 'exists:sisp_transactions,id'],
+            'transaction_id' => ['required', 'integer'],
         ];
     }
 }

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Support\Facades\URL;
 
 it('retries payment and renders form', function (): void {
     $t = Transaction::factory()->create([
@@ -13,7 +15,9 @@ it('retries payment and renders form', function (): void {
         'currency' => '132',
     ]);
 
-    $response = $this->post(route('sisp.retry-payment'), ['transaction_id' => $t->id]);
+    $response = $this->post(
+        URL::temporarySignedRoute('sisp.retry-payment', now()->addMinutes(15), ['transaction_id' => $t->id])
+    );
     $response->assertStatus(200);
 });
 
@@ -26,7 +30,9 @@ it('updates merchant_session on transaction so callback can find it', function (
         'currency' => '132',
     ]);
 
-    $this->post(route('sisp.retry-payment'), ['transaction_id' => $t->id])
+    $this->post(
+        URL::temporarySignedRoute('sisp.retry-payment', now()->addMinutes(15), ['transaction_id' => $t->id])
+    )
         ->assertStatus(200);
 
     $t->refresh();
@@ -34,4 +40,47 @@ it('updates merchant_session on transaction so callback can find it', function (
     expect($t->merchant_session)
         ->not->toBe('MS-OLD')
         ->not->toBeEmpty();
+});
+
+it('denies unsigned retry requests', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_ref' => 'MR-UNSIGNED',
+        'merchant_session' => 'MS-UNSIGNED',
+    ]);
+
+    $this->post(route('sisp.retry-payment'), ['transaction_id' => $t->id])
+        ->assertForbidden();
+});
+
+it('denies retry for authenticated users who do not own the transaction', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'failed',
+        'customer_email' => 'owner@example.com',
+    ]);
+
+    $this->actingAs(new GenericUser([
+        'id' => 999,
+        'email' => 'attacker@example.com',
+    ]));
+
+    $this->post(
+        URL::temporarySignedRoute('sisp.retry-payment', now()->addMinutes(15), ['transaction_id' => $t->id])
+    )->assertForbidden();
+});
+
+it('allows retry for authenticated users who own the transaction', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'failed',
+        'customer_email' => 'owner@example.com',
+    ]);
+
+    $this->actingAs(new GenericUser([
+        'id' => 123,
+        'email' => 'owner@example.com',
+    ]));
+
+    $this->post(
+        URL::temporarySignedRoute('sisp.retry-payment', now()->addMinutes(15), ['transaction_id' => $t->id])
+    )->assertOk();
 });

--- a/tests/Http/RetryPaymentControllerTest.php
+++ b/tests/Http/RetryPaymentControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\URL;
 
 it('retries payment for an existing transaction', function (): void {
     $t = Transaction::factory()->create([
@@ -11,7 +12,9 @@ it('retries payment for an existing transaction', function (): void {
         'status' => 'failed',
     ]);
 
-    $this->post(route('sisp.retry-payment'), [
-        'transaction_id' => $t->id,
-    ])->assertOk();
+    $this->post(URL::temporarySignedRoute(
+        'sisp.retry-payment',
+        now()->addMinutes(15),
+        ['transaction_id' => $t->id]
+    ))->assertOk();
 });


### PR DESCRIPTION
## Summary

- Replace plain retry payment URL with temporary signed URLs (15-minute expiry) to prevent unauthorized replay attacks
- Add transaction ownership validation in `RetryPaymentRequest` -- authenticated users can only retry their own transactions
- Pass `retryPaymentUrl` from `RenderPaymentResponseAction` to both Blade and React views
- Remove `transaction_id` hidden input from Blade form (now embedded in the signed URL)

## Test plan

- [x] Added test: unsigned retry requests return 403
- [x] Added test: authenticated user who does not own the transaction gets 403
- [x] Added test: authenticated user who owns the transaction can retry
- [x] Updated existing retry tests to use signed URLs