### PR TITLE
fix(routes): add configurable web middleware to payment route for CSRF protection

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -385,6 +385,7 @@ return [
     |
     */
     'middleware' => [
+        'payment' => ['web'],
         'refund' => ['web', 'auth'],
     ],
 

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -135,12 +135,15 @@ Customize middleware assigned to package routes in `config/sisp.php`:
 
 ```php
 'middleware' => [
+    // Applied to POST /sisp/payment (includes CSRF verification via web group)
+    'payment' => ['web'],
+
     // Applied to POST /sisp/refund/{transaction}
     'refund' => ['web', 'auth'],
 ],
 ```
 
-Use this to enforce authentication/authorization for refunds.
+Use this to enforce CSRF/authentication/authorization behavior per route.
 
 ## Security Configuration
 

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -181,6 +181,7 @@ The refund route middleware is configurable via `config/sisp.php`:
 
 ```php
 'middleware' => [
+    'payment' => ['web'], // Includes CSRF verification for POST /sisp/payment
     'refund' => ['web', 'auth'],
 ],
 ```

--- a/docs/07-security.md
+++ b/docs/07-security.md
@@ -145,6 +145,8 @@ How it works:
 - Redirects to `/` with an error message when blocked
 
 This middleware is applied to `POST /sisp/payment` by default.
+`POST /sisp/payment` also uses the `web` middleware group by default (`config('sisp.middleware.payment')`),
+so Laravel CSRF validation is enforced for browser-authenticated requests.
 
 ## Request Metadata Collection
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -993,6 +993,7 @@ POST   /sisp/sandbox           -> SandboxController
 GET    /sisp/countries         -> CountriesController
 ```
 
+Payment route middleware is configurable via `config('sisp.middleware.payment')` (defaults to `['web']` for CSRF protection).
 Refund route middleware is configurable via `config('sisp.middleware.refund')`.
 
 Route names:

--- a/rector.php
+++ b/rector.php
@@ -27,6 +27,9 @@ return RectorConfig::configure()
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
+    ->withParallel(
+        timeoutSeconds: 600,
+    )
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/config',

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use Akira\Sisp\Http\Controllers\SandboxController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('sisp/payment', PaymentController::class)
+    ->middleware(config()->array('sisp.middleware.payment', ['web']))
     ->middleware(Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class)
     ->name('sisp.payment');
 

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Routing\Router;
+
 it('creates transaction and renders payment form', function (): void {
     config()->set('sisp.rate_limiting.enabled', false);
 
@@ -17,7 +19,10 @@ it('creates transaction and renders payment form', function (): void {
         'customer_email' => 'john@example.test',
     ];
 
-    $response = $this->post(route('sisp.payment'), $payload);
+    $token = 'csrf-token-payment-create';
+    $response = $this
+        ->withSession(['_token' => $token])
+        ->post(route('sisp.payment'), [...$payload, '_token' => $token]);
 
     $response->assertOk();
     $response->assertSee('sisp-payment-form');
@@ -44,7 +49,17 @@ it('blocks duplicate transactions via middleware', function (): void {
         ]],
     ];
 
-    $response = $this->post(route('sisp.payment'), $payload);
+    $token = 'csrf-token-payment-duplicate';
+    $response = $this
+        ->withSession(['_token' => $token])
+        ->post(route('sisp.payment'), [...$payload, '_token' => $token]);
 
     $response->assertRedirect('/');
+});
+
+it('applies web middleware to payment route for csrf protection', function (): void {
+    $route = resolve(Router::class)->getRoutes()->getByName('sisp.payment');
+
+    expect($route)->not->toBeNull()
+        ->and($route->gatherMiddleware())->toContain('web');
 });


### PR DESCRIPTION
## Summary

- Adds configurable `web` middleware group to `POST /sisp/payment` via `config('sisp.middleware.payment')`, ensuring CSRF verification is enforced by default for browser-authenticated payment requests
- Updates documentation (configuration, transaction management, security, API reference) to reflect the new middleware option
- Adds tests verifying CSRF token handling and that the `web` middleware is applied to the payment route
- Increases Rector parallel timeout to 600 seconds

## Test plan

- [ ] Verify `POST /sisp/payment` enforces CSRF validation with the `web` middleware group
- [ ] Verify middleware is configurable via `config('sisp.middleware.payment')`
- [ ] Run `php artisan test --filter=PaymentControllerTest` to confirm all tests pass