### PR TITLE
fix(cancel): resolve transaction from request instead of route model binding

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -100,5 +100,6 @@ return [
     'validation' => [
         'invalid_payment_response' => 'Invalid payment response',
         'invalid_fingerprint' => 'Invalid payment fingerprint',
+        'transaction_not_found' => 'Transaction not found',
     ],
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -100,5 +100,6 @@ return [
     'validation' => [
         'invalid_payment_response' => 'Réponse de paiement invalide',
         'invalid_fingerprint' => 'Empreinte digitale de paiement invalide',
+        'transaction_not_found' => 'Transaction introuvable',
     ],
 ];

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -100,5 +100,6 @@ return [
     'validation' => [
         'invalid_payment_response' => 'Resposta de pagamento inválida',
         'invalid_fingerprint' => 'Impressão digital de pagamento inválida',
+        'transaction_not_found' => 'Transação não encontrada',
     ],
 ];

--- a/src/Http/Controllers/CancelTransactionController.php
+++ b/src/Http/Controllers/CancelTransactionController.php
@@ -16,18 +16,39 @@ final readonly class CancelTransactionController
         private CancelTransactionAction $cancelTransaction,
     ) {}
 
-    public function __invoke(Transaction $transaction, Request $request): RedirectResponse
+    public function __invoke(Request $request): RedirectResponse
     {
         $reason = $request->query('reason', 'user_cancelled');
+        $transaction = $this->resolveTransaction($request);
+
+        if (! $transaction instanceof Transaction) {
+            return back()->with('error', __('Transaction not found'));
+        }
 
         try {
-
             $this->cancelTransaction->handle($transaction, $reason);
 
-            return to_route('sisp.callback', ['ref' => $request->input('merchantRef')]);
+            return to_route('sisp.callback', ['ref' => $transaction->merchant_ref]);
 
         } catch (LogicException $e) {
             return back()->with('error', $e->getMessage());
         }
+    }
+
+    private function resolveTransaction(Request $request): ?Transaction
+    {
+        $merchantRef = $request->input('merchantRef');
+        if (is_string($merchantRef) && $merchantRef !== '') {
+            return Transaction::query()
+                ->where('merchant_ref', $merchantRef)
+                ->first();
+        }
+
+        $transactionId = $request->input('transaction_id');
+        if (! $transactionId) {
+            return null;
+        }
+
+        return Transaction::query()->find($transactionId);
     }
 }

--- a/src/Http/Controllers/CancelTransactionController.php
+++ b/src/Http/Controllers/CancelTransactionController.php
@@ -49,6 +49,6 @@ final readonly class CancelTransactionController
             return null;
         }
 
-        return Transaction::query()->find($transactionId);
+        return Transaction::query()->where('transaction_id', $transactionId)->first();
     }
 }

--- a/src/Http/Controllers/CancelTransactionController.php
+++ b/src/Http/Controllers/CancelTransactionController.php
@@ -22,7 +22,7 @@ final readonly class CancelTransactionController
         $transaction = $this->resolveTransaction($request);
 
         if (! $transaction instanceof Transaction) {
-            return back()->with('error', __('Transaction not found'));
+            return back()->with('error', __('laravel-sisp::messages.validation.transaction_not_found'));
         }
 
         try {
@@ -45,7 +45,7 @@ final readonly class CancelTransactionController
         }
 
         $transactionId = $request->input('transaction_id');
-        if (! $transactionId) {
+        if (! is_string($transactionId) || $transactionId === '') {
             return null;
         }
 

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -36,6 +36,22 @@ it('handles non-cancellable transaction and flashes error', function (): void {
         ->assertSessionHas('error');
 });
 
+it('cancels a pending transaction resolved by transaction_id', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'pending',
+        'merchant_ref' => 'MR-C3',
+        'merchant_session' => 'MS-C3',
+    ]);
+
+    $this->get(route('sisp.cancel', [
+        'reason' => 'user_cancelled',
+        'transaction_id' => $t->id,
+    ]))
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-C3']));
+
+    expect($t->refresh()->status->value)->toBe('cancelled');
+});
+
 it('handles missing transaction identifier and flashes error', function (): void {
     $this->withHeader('referer', '/checkout')
         ->get(route('sisp.cancel'))

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Http\Controllers\CancelTransactionController;
 use Akira\Sisp\Models\Transaction;
-use Illuminate\Http\Request;
 
 it('cancels a pending transaction and redirects', function (): void {
     $t = Transaction::factory()->create([
@@ -13,23 +11,34 @@ it('cancels a pending transaction and redirects', function (): void {
         'merchant_session' => 'MS-C',
     ]);
 
-    $controller = resolve(CancelTransactionController::class);
-    $request = Request::create('/sisp/cancel?reason=user_cancelled&merchantRef=MR-C', 'GET');
-    $response = $controller($t, $request);
+    $this->get(route('sisp.cancel', [
+        'reason' => 'user_cancelled',
+        'merchantRef' => 'MR-C',
+    ]))
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-C']));
 
-    expect($response->isRedirect())->toBeTrue();
+    expect($t->refresh()->status->value)->toBe('cancelled');
 });
 
 it('handles non-cancellable transaction and flashes error', function (): void {
-    $t = Transaction::factory()->create([
+    Transaction::factory()->create([
         'status' => 'completed',
         'merchant_ref' => 'MR-C2',
         'merchant_session' => 'MS-C2',
     ]);
 
-    $controller = resolve(CancelTransactionController::class);
-    $request = Request::create('/sisp/cancel?reason=user_cancelled&merchantRef=MR-C2', 'GET');
-    $response = $controller($t, $request);
+    $this->withHeader('referer', '/checkout')
+        ->get(route('sisp.cancel', [
+            'reason' => 'user_cancelled',
+            'merchantRef' => 'MR-C2',
+        ]))
+        ->assertRedirect('/checkout')
+        ->assertSessionHas('error');
+});
 
-    expect($response->isRedirect())->toBeTrue();
+it('handles missing transaction identifier and flashes error', function (): void {
+    $this->withHeader('referer', '/checkout')
+        ->get(route('sisp.cancel'))
+        ->assertRedirect('/checkout')
+        ->assertSessionHas('error', 'Transaction not found');
 });

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -41,11 +41,12 @@ it('cancels a pending transaction resolved by transaction_id', function (): void
         'status' => 'pending',
         'merchant_ref' => 'MR-C3',
         'merchant_session' => 'MS-C3',
+        'transaction_id' => 'TXN-EXT-001',
     ]);
 
     $this->get(route('sisp.cancel', [
         'reason' => 'user_cancelled',
-        'transaction_id' => $t->id,
+        'transaction_id' => 'TXN-EXT-001',
     ]))
         ->assertRedirect(route('sisp.callback', ['ref' => 'MR-C3']));
 

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -57,5 +57,5 @@ it('handles missing transaction identifier and flashes error', function (): void
     $this->withHeader('referer', '/checkout')
         ->get(route('sisp.cancel'))
         ->assertRedirect('/checkout')
-        ->assertSessionHas('error', 'Transaction not found');
+        ->assertSessionHas('error', __('laravel-sisp::messages.validation.transaction_not_found'));
 });


### PR DESCRIPTION
## Summary

- Removes route model binding from `CancelTransactionController` in favor of resolving the transaction from request parameters (`merchantRef` or `transaction_id`)
- Adds a `resolveTransaction()` method that looks up the transaction by `merchant_ref` first, then falls back to `transaction_id`
- Returns a user-friendly error when no transaction can be found
- Updates tests to use full HTTP request assertions instead of direct controller invocation

Fixes #71