### PR TITLE
fix: lower PHP requirement to 8.3 and fix TransactionItem table resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SISP_MERCHANT_ID=your_merchant_id
 
 ## System Requirements
 
-- PHP 8.4 or higher
+- PHP 8.3 or higher
 - Laravel 12 or higher
 - PostgreSQL or MySQL database
 - Node.js for frontend assets (if using Inertia)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^8.4",
+    "php": "^8.3",
     "akira/laravel-pdf-invoices": "^1.1",
     "illuminate/contracts": "^12.0",
     "pinkary-project/type-guard": "^0.1.0",

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- PHP 8.4 or higher
+- PHP 8.3 or higher
 - Laravel 12 or higher
 - Composer
 - Database (PostgreSQL or MySQL)

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -392,7 +392,7 @@ Laravel 12+
 
 ### What PHP versions are supported?
 
-PHP 8.4+
+PHP 8.3+
 
 ## Still Have Questions?
 

--- a/rector.php
+++ b/rector.php
@@ -24,7 +24,7 @@ return RectorConfig::configure()
     ])
     ->withComposerBased(laravel: true)
     ->withCache(
-        cacheDirectory: '/tmp/rector',
+        cacheDirectory: __DIR__.'/.context/rector-cache',
         cacheClass: FileCacheStorage::class,
     )
     ->withPaths([
@@ -36,6 +36,7 @@ return RectorConfig::configure()
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
     ])
+    ->withoutParallel()
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/src/Actions/StoreTransactionItemsAction.php
+++ b/src/Actions/StoreTransactionItemsAction.php
@@ -33,6 +33,6 @@ final readonly class StoreTransactionItemsAction
             $items
         );
 
-        DB::table(new TransactionItem()->getTable())->insert($records);
+        DB::table((new TransactionItem())->getTable())->insert($records);
     }
 }


### PR DESCRIPTION
## Summary

- Lowers minimum PHP version requirement from 8.4 to 8.3 across `composer.json`, README, and documentation
- Fixes operator precedence bug in `StoreTransactionItemsAction` where `new TransactionItem()->getTable()` was missing parentheses around the constructor call
- Updates rector config to use a local cache directory and disable parallel processing

## Test plan

- [ ] Verify `composer install` works on PHP 8.3
- [ ] Confirm `StoreTransactionItemsAction` correctly resolves the transaction items table name
- [ ] Run existing test suite to ensure no regressions