### PR TITLE
fix(invoice): handle nullable due_date in PDF generation

### DIFF
--- a/src/Actions/GenerateInvoicePdfAction.php
+++ b/src/Actions/GenerateInvoicePdfAction.php
@@ -47,9 +47,12 @@ final readonly class GenerateInvoicePdfAction
             ->buyer($buyer)
             ->invoiceNumber($invoice->invoice_number)
             ->issuedAt($invoice->invoice_date)
-            ->dueAt($invoice->due_date)
             ->locale(str_replace('-', '_', $transaction->locale))
             ->currency('ECV');
+
+        if ($invoice->due_date !== null) {
+            $invoiceBuilder->dueAt($invoice->due_date);
+        }
 
         foreach ($transaction->items as $item) {
             $itemData = ItemBuilder::make()

--- a/tests/Invoices/GenerateInvoicePdfDueDateTest.php
+++ b/tests/Invoices/GenerateInvoicePdfDueDateTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\PdfInvoices\Contracts\PdfGeneratorContract;
+use Akira\PdfInvoices\DTO\InvoiceData as DtoInvoiceData;
+use Akira\Sisp\Actions\GenerateInvoiceAction;
+use Akira\Sisp\Actions\GenerateInvoicePdfAction;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Storage;
+
+final class CapturingPdfGenerator implements PdfGeneratorContract
+{
+    public ?DtoInvoiceData $lastInvoice = null;
+
+    public function generate(DtoInvoiceData $invoice, string $template = 'modern'): string
+    {
+        $this->lastInvoice = $invoice;
+
+        return '%PDF-DUE-DATE%';
+    }
+
+    public function save(DtoInvoiceData $invoice, string $template = 'modern', ?string $path = null): string
+    {
+        return '%PDF-SAVED%';
+    }
+}
+
+it('generates invoice pdf when due date is null', function (): void {
+    $pdfGenerator = new CapturingPdfGenerator();
+    app()->instance(PdfGeneratorContract::class, $pdfGenerator);
+    Storage::fake('public');
+
+    $transaction = Transaction::factory()->create();
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+    $invoice->update(['due_date' => null]);
+
+    $relativePath = resolve(GenerateInvoicePdfAction::class)->handle($invoice);
+
+    Storage::disk('public')->assertExists($relativePath);
+    expect($pdfGenerator->lastInvoice)->not->toBeNull()
+        ->and($pdfGenerator->lastInvoice?->dueAt)->toBeNull();
+});
+
+it('passes due date to invoice builder when due date is present', function (): void {
+    $pdfGenerator = new CapturingPdfGenerator();
+    app()->instance(PdfGeneratorContract::class, $pdfGenerator);
+    Storage::fake('public');
+
+    $transaction = Transaction::factory()->create();
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+
+    resolve(GenerateInvoicePdfAction::class)->handle($invoice);
+
+    expect($pdfGenerator->lastInvoice)->not->toBeNull()
+        ->and($pdfGenerator->lastInvoice?->dueAt?->toDateString())->toBe($invoice->due_date?->toDateString());
+});


### PR DESCRIPTION
## Summary

- Makes `due_date` optional in `GenerateInvoicePdfAction` by only calling `dueAt()` on the invoice builder when the value is non-null
- Prevents errors when generating PDFs for invoices that have no due date
- Adds tests covering both nullable and present due date scenarios

Fixes #76