### PR TITLE
fix(3ds): prevent retry when required customer data is missing

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -94,6 +94,7 @@ return [
             'back_home' => 'Back to Home',
             'declined' => 'Declined',
             'retry_payment' => 'Try Again',
+            'retry_not_available' => 'This payment cannot be retried because required customer data is missing.',
             'cancel_payment' => 'Cancel',
         ],
     ],

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -94,6 +94,7 @@ return [
             'back_home' => 'Retour à l\'Accueil',
             'declined' => 'Refusé',
             'retry_payment' => 'Réessayer',
+            'retry_not_available' => 'Ce paiement ne peut pas être réessayé car des données client obligatoires sont manquantes.',
             'cancel_payment' => 'Annuler',
         ],
     ],

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -94,6 +94,7 @@ return [
             'back_home' => 'Voltar ao Início',
             'declined' => 'Recusado',
             'retry_payment' => 'Tentar Novamente',
+            'retry_not_available' => 'Este pagamento não pode ser tentado novamente porque faltam dados obrigatórios do cliente.',
             'cancel_payment' => 'Cancelar',
         ],
     ],

--- a/src/Actions/CanRetryPaymentAction.php
+++ b/src/Actions/CanRetryPaymentAction.php
@@ -26,9 +26,9 @@ final readonly class CanRetryPaymentAction
 
     private function isMissingRequiredThreeDSecureData(Transaction $transaction): bool
     {
-        return blank($transaction->getRawOriginal('customer_email'))
-            || blank($transaction->getRawOriginal('customer_country'))
-            || blank($transaction->getRawOriginal('customer_city'))
-            || blank($transaction->getRawOriginal('customer_address'));
+        return blank($transaction->customer_email)
+            || blank($transaction->customer_country)
+            || blank($transaction->customer_city)
+            || blank($transaction->customer_address);
     }
 }

--- a/src/Actions/CanRetryPaymentAction.php
+++ b/src/Actions/CanRetryPaymentAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions;
+
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Models\Transaction;
+
+final readonly class CanRetryPaymentAction
+{
+    public function __construct(private LoadConfig $config) {}
+
+    public function handle(Transaction $transaction): bool
+    {
+        if (! $this->config->isRetryAllowed()) {
+            return false;
+        }
+
+        if ($this->config->getIs3Dsec() !== '1') {
+            return true;
+        }
+
+        return ! $this->isMissingRequiredThreeDSecureData($transaction);
+    }
+
+    private function isMissingRequiredThreeDSecureData(Transaction $transaction): bool
+    {
+        return blank($transaction->getRawOriginal('customer_email'))
+            || blank($transaction->getRawOriginal('customer_country'))
+            || blank($transaction->getRawOriginal('customer_city'))
+            || blank($transaction->getRawOriginal('customer_address'));
+    }
+}

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
-use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Contracts\View\View;
@@ -15,7 +14,7 @@ final readonly class RenderPaymentResponseAction
     public function __construct(
         private GetPaymentErrorResponseAction $getErrorResponse,
         private GetPaymentResponseTranslationsAction $getTranslations,
-        private LoadConfig $config,
+        private CanRetryPaymentAction $canRetryPayment,
     ) {}
 
     public function renderBlade(Transaction $transaction, array $payload): View
@@ -27,7 +26,7 @@ final readonly class RenderPaymentResponseAction
             'transaction' => $transaction,
             'payload' => $payload,
             'error' => $this->getStructuredError($transaction),
-            'allowRetry' => $this->config->isRetryAllowed(),
+            'allowRetry' => $this->canRetryPayment->handle($transaction),
         ]);
     }
 
@@ -52,7 +51,7 @@ final readonly class RenderPaymentResponseAction
             ],
             'error' => $this->getStructuredError($transaction),
             'translations' => $this->getTranslations->handle(),
-            'allowRetry' => $this->config->isRetryAllowed(),
+            'allowRetry' => $this->canRetryPayment->handle($transaction),
             'invoice' => $invoice ? [
                 'invoice_number' => $invoice->invoice_number,
                 'pdf_url' => $invoice->pdf_url,

--- a/src/Http/Requests/RetryPaymentRequest.php
+++ b/src/Http/Requests/RetryPaymentRequest.php
@@ -26,10 +26,13 @@ final class RetryPaymentRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function (Validator $validator): void {
-            $transactionId = $this->integer('transaction_id');
-            $transaction = Transaction::query()->findOrFail($transactionId);
+            if ($validator->errors()->has('transaction_id')) {
+                return;
+            }
 
-            if (! resolve(CanRetryPaymentAction::class)->handle($transaction)) {
+            $transaction = Transaction::query()->find($this->integer('transaction_id'));
+
+            if (! $transaction || ! resolve(CanRetryPaymentAction::class)->handle($transaction)) {
                 $validator->errors()->add(
                     'transaction_id',
                     __('sisp::messages.payment.response.retry_not_available')

--- a/src/Http/Requests/RetryPaymentRequest.php
+++ b/src/Http/Requests/RetryPaymentRequest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Http\Requests;
 
+use Akira\Sisp\Actions\CanRetryPaymentAction;
+use Akira\Sisp\Models\Transaction;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
 
 final class RetryPaymentRequest extends FormRequest
 {
@@ -18,5 +21,20 @@ final class RetryPaymentRequest extends FormRequest
         return [
             'transaction_id' => ['required', 'integer', 'exists:sisp_transactions,id'],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $transactionId = $this->integer('transaction_id');
+            $transaction = Transaction::query()->findOrFail($transactionId);
+
+            if (! resolve(CanRetryPaymentAction::class)->handle($transaction)) {
+                $validator->errors()->add(
+                    'transaction_id',
+                    __('sisp::messages.payment.response.retry_not_available')
+                );
+            }
+        });
     }
 }

--- a/tests/Actions/CanRetryPaymentActionTest.php
+++ b/tests/Actions/CanRetryPaymentActionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\CanRetryPaymentAction;
+use Akira\Sisp\Models\Transaction;
+
+it('allows retry when 3DS is disabled and retry is enabled', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '0',
+    ]);
+
+    $transaction = Transaction::factory()->failed()->create();
+
+    $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
+
+    expect($canRetry)->toBeTrue();
+});
+
+it('blocks retry when 3DS is enabled and required customer data is missing', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '1',
+    ]);
+
+    $transaction = Transaction::factory()->failed()->create([
+        'customer_email' => null,
+        'customer_country' => null,
+        'customer_city' => null,
+        'customer_address' => null,
+    ]);
+
+    $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
+
+    expect($canRetry)->toBeFalse();
+});
+
+it('allows retry when 3DS is enabled and required customer data exists', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '1',
+    ]);
+
+    $transaction = Transaction::factory()->failed()->create([
+        'customer_email' => 'john@example.test',
+        'customer_country' => 'cv',
+        'customer_city' => 'Praia',
+        'customer_address' => 'Rua Principal',
+    ]);
+
+    $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
+
+    expect($canRetry)->toBeTrue();
+});
+
+it('blocks retry when retry is disabled by configuration', function (): void {
+    config([
+        'sisp.allow_retry' => false,
+        'sisp.is_3dsec' => '0',
+    ]);
+
+    $transaction = Transaction::factory()->failed()->create();
+
+    $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
+
+    expect($canRetry)->toBeFalse();
+});

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -24,3 +24,21 @@ it('renderInertia falls back to blade when Inertia is absent', function (): void
     // Inertia is available in this testbench; expect Inertia response
     expect($result)->toBeInstanceOf(Inertia\Response::class);
 });
+
+it('sets allowRetry to false when 3DS is enabled and transaction is missing required customer data', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '1',
+    ]);
+
+    $t = Transaction::factory()->failed()->create([
+        'customer_email' => null,
+        'customer_country' => null,
+        'customer_city' => null,
+        'customer_address' => null,
+    ]);
+
+    $view = resolve(RenderPaymentResponseAction::class)->renderBlade($t, []);
+
+    expect($view->getData()['allowRetry'])->toBeFalse();
+});

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -35,3 +35,21 @@ it('updates merchant_session on transaction so callback can find it', function (
         ->not->toBe('MS-OLD')
         ->not->toBeEmpty();
 });
+
+it('rejects retry when 3DS is enabled and required customer data is missing', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '1',
+    ]);
+
+    $t = Transaction::factory()->failed()->create([
+        'customer_email' => null,
+        'customer_country' => null,
+        'customer_city' => null,
+        'customer_address' => null,
+    ]);
+
+    $this->from('/sisp/callback?ref='.$t->merchant_ref)
+        ->post(route('sisp.retry-payment'), ['transaction_id' => $t->id])
+        ->assertSessionHasErrors(['transaction_id']);
+});

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -36,6 +36,11 @@ it('updates merchant_session on transaction so callback can find it', function (
         ->not->toBeEmpty();
 });
 
+it('returns validation error without triggering after callback when transaction does not exist', function (): void {
+    $this->post(route('sisp.retry-payment'), ['transaction_id' => 999999])
+        ->assertSessionHasErrors(['transaction_id']);
+});
+
 it('rejects retry when 3DS is enabled and required customer data is missing', function (): void {
     config([
         'sisp.allow_retry' => true,


### PR DESCRIPTION
## Summary

- Add `CanRetryPaymentAction` to validate whether a failed 3DS payment can be retried based on the presence of required customer data (email, country, city, address)
- Replace direct `LoadConfig::isRetryAllowed()` check in `RenderPaymentResponseAction` with the new action, so the retry button is hidden when data is missing
- Add `withValidator` hook in `RetryPaymentRequest` to block retry attempts server-side when customer data is incomplete
- Add `retry_not_available` translation messages in EN, FR, and PT

## Why

When 3D Secure is enabled, the payment gateway requires customer email, country, city, and address. If a transaction was created without these fields (e.g. via a simple checkout flow), retrying would always fail at the gateway. This change prevents users from attempting a retry that cannot succeed.

## Test plan

- [x] `CanRetryPaymentActionTest` covers all scenarios (3DS on/off, data present/missing, config disabled)
- [x] `RenderPaymentResponseActionTest` verifies `allowRetry` is false when 3DS data is missing
- [x] `RetryPaymentControllerTest` verifies the retry endpoint rejects requests with missing data