### PR TITLE
fix(routes): correct route model binding mismatch in cancel transaction endpoint

### DIFF
--- a/src/Http/Controllers/CancelTransactionController.php
+++ b/src/Http/Controllers/CancelTransactionController.php
@@ -16,16 +16,20 @@ final readonly class CancelTransactionController
         private CancelTransactionAction $cancelTransaction,
     ) {}
 
-    public function __invoke(Transaction $transaction, Request $request): RedirectResponse
+    public function __invoke(Request $request): RedirectResponse
     {
+        $validated = $request->validate([
+            'merchantRef' => ['required', 'string'],
+        ]);
+
+        $transaction = Transaction::where('merchant_ref', $validated['merchantRef'])->firstOrFail();
+
         $reason = $request->query('reason', 'user_cancelled');
 
         try {
-
             $this->cancelTransaction->handle($transaction, $reason);
 
-            return to_route('sisp.callback', ['ref' => $request->input('merchantRef')]);
-
+            return to_route('sisp.callback', ['ref' => $validated['merchantRef']]);
         } catch (LogicException $e) {
             return back()->with('error', $e->getMessage());
         }

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -2,34 +2,51 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Http\Controllers\CancelTransactionController;
 use Akira\Sisp\Models\Transaction;
-use Illuminate\Http\Request;
 
 it('cancels a pending transaction and redirects', function (): void {
-    $t = Transaction::factory()->create([
+    Transaction::factory()->create([
         'status' => 'pending',
         'merchant_ref' => 'MR-C',
         'merchant_session' => 'MS-C',
     ]);
 
-    $controller = resolve(CancelTransactionController::class);
-    $request = Request::create('/sisp/cancel?reason=user_cancelled&merchantRef=MR-C', 'GET');
-    $response = $controller($t, $request);
+    $response = $this->get(route('sisp.cancel', [
+        'merchantRef' => 'MR-C',
+        'reason' => 'user_cancelled',
+    ]));
 
-    expect($response->isRedirect())->toBeTrue();
+    $response->assertRedirect();
+});
+
+it('returns 404 when merchantRef does not match any transaction', function (): void {
+    $response = $this->get(route('sisp.cancel', [
+        'merchantRef' => 'NONEXISTENT',
+        'reason' => 'user_cancelled',
+    ]));
+
+    $response->assertNotFound();
+});
+
+it('returns validation error when merchantRef is missing', function (): void {
+    $response = $this->get(route('sisp.cancel'));
+
+    $response->assertRedirect();
+    $response->assertSessionHasErrors(['merchantRef']);
 });
 
 it('handles non-cancellable transaction and flashes error', function (): void {
-    $t = Transaction::factory()->create([
+    Transaction::factory()->create([
         'status' => 'completed',
         'merchant_ref' => 'MR-C2',
         'merchant_session' => 'MS-C2',
     ]);
 
-    $controller = resolve(CancelTransactionController::class);
-    $request = Request::create('/sisp/cancel?reason=user_cancelled&merchantRef=MR-C2', 'GET');
-    $response = $controller($t, $request);
+    $response = $this->get(route('sisp.cancel', [
+        'merchantRef' => 'MR-C2',
+        'reason' => 'user_cancelled',
+    ]));
 
-    expect($response->isRedirect())->toBeTrue();
+    $response->assertRedirect();
+    $response->assertSessionHas('error');
 });


### PR DESCRIPTION
## Summary

- Replaced implicit route model binding on `Transaction` in `CancelTransactionController` with explicit lookup via `merchantRef` query parameter, matching how the route is actually called
- Added validation for the required `merchantRef` parameter before querying the database
- Updated tests to use HTTP-level assertions (`$this->get(route(...))`) instead of directly instantiating the controller, covering the new 404 and validation error cases

## Test plan

- [ ] Cancelling a pending transaction with a valid `merchantRef` redirects successfully
- [ ] Requesting cancel with a non-existent `merchantRef` returns 404
- [ ] Requesting cancel without `merchantRef` returns a redirect with validation errors
- [ ] Attempting to cancel a non-cancellable (completed) transaction redirects back with an error flash