### PR TITLE
fix(sandbox): block callback generation in production

### DIFF
--- a/src/Actions/BuildSandboxPayloadAction.php
+++ b/src/Actions/BuildSandboxPayloadAction.php
@@ -12,6 +12,7 @@ use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Illuminate\Support\Str;
+use LogicException;
 
 final readonly class BuildSandboxPayloadAction
 {
@@ -23,6 +24,8 @@ final readonly class BuildSandboxPayloadAction
     public function handle(PaymentRequestData $data, string $status = 'success'): CallbackPayload
     {
         $credentials = $this->resolver->resolve();
+
+        throw_unless($credentials->sandbox, LogicException::class, 'Sandbox payloads can only be generated when SISP sandbox mode is enabled.');
 
         $merchantRef = $data->merchantRef ?? Sisp::getMerchantReference();
         $merchantSession = $data->merchantSession ?? Sisp::getMerchantSession();

--- a/src/Http/Controllers/SandboxController.php
+++ b/src/Http/Controllers/SandboxController.php
@@ -13,6 +13,8 @@ final readonly class SandboxController
 {
     public function __invoke(Request $request): Response
     {
+        abort_unless(config('sisp.sandbox', false), 404);
+
         $status = $request->input('status', $request->query('status', 'success'));
 
         $paymentData = PaymentRequestData::from([

--- a/tests/Actions/BuildSandboxPayloadActionTest.php
+++ b/tests/Actions/BuildSandboxPayloadActionTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\BuildSandboxPayloadAction;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 
+beforeEach(function (): void {
+    config()->set('sisp.sandbox', true);
+});
+
 it('builds failed sandbox payload', function (): void {
     $data = PaymentRequestData::from([
         'amount' => 10.0,
@@ -28,4 +32,18 @@ it('builds sandbox payload for unknown status as P', function (): void {
 
     $payload = resolve(BuildSandboxPayloadAction::class)->handle($data, 'other');
     expect($payload->messageType)->toBe('P');
+});
+
+it('refuses to generate sandbox payloads when sandbox mode is disabled', function (): void {
+    config()->set('sisp.sandbox', false);
+
+    $data = PaymentRequestData::from([
+        'amount' => 5.0,
+        'merchantRef' => 'ref',
+        'merchantSession' => 'sess',
+        'currency' => '132',
+    ]);
+
+    expect(fn () => resolve(BuildSandboxPayloadAction::class)->handle($data))
+        ->toThrow(LogicException::class, 'Sandbox payloads can only be generated when SISP sandbox mode is enabled.');
 });

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -7,6 +7,10 @@ use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Illuminate\Support\Facades\DB;
 
+beforeEach(function (): void {
+    config()->set('sisp.sandbox', true);
+});
+
 it('redirects when user cancelled flag present', function (): void {
     config()->set('sisp.redirect_url', '/home');
     $this->post(route('sisp.callback'), ['UserCancelled' => true])

--- a/tests/Http/Middleware/PreventDuplicateCallbackTest.php
+++ b/tests/Http/Middleware/PreventDuplicateCallbackTest.php
@@ -7,6 +7,8 @@ use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 
 it('redirects duplicate callback requests after validation', function (): void {
+    config()->set('sisp.sandbox', true);
+
     Transaction::factory()->create([
         'merchant_ref' => 'MR-CB-DUP',
         'merchant_session' => 'MS-CB-DUP',

--- a/tests/Http/SandboxControllerTest.php
+++ b/tests/Http/SandboxControllerTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 it('returns auto-submitting html form for sandbox callback', function (): void {
+    config()->set('sisp.sandbox', true);
+
     $response = $this->get(route('sisp.sandbox', [
         'status' => 'success',
         'amount' => 12.34,
@@ -17,4 +19,15 @@ it('returns auto-submitting html form for sandbox callback', function (): void {
     $response->assertHeader('Content-Type', 'text/html; charset=utf-8');
     $response->assertSee('form', false);
     $response->assertSee('sisp/callback');
+});
+
+it('does not expose sandbox callback generation when sandbox mode is disabled', function (): void {
+    config()->set('sisp.sandbox', false);
+
+    $this->get(route('sisp.sandbox', [
+        'status' => 'success',
+        'amount' => 12.34,
+        'merchantRef' => 'MR-TEST',
+        'merchantSession' => 'MS-TEST',
+    ]))->assertNotFound();
 });

--- a/tests/Sisp/SispEventsTest.php
+++ b/tests/Sisp/SispEventsTest.php
@@ -11,6 +11,8 @@ use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Illuminate\Support\Facades\Event;
 
 beforeEach(function (): void {
+    config()->set('sisp.sandbox', true);
+
     Event::fake();
 });
 
@@ -46,7 +48,6 @@ it('dispatches PaymentPending for pending status', function (): void {
         'status' => 'pending',
     ]);
 
-    // Build a custom payload with unknown message type to force pending
     $data = [
         'messageType' => 'Z',
         'merchantRespCP' => '01',

--- a/tests/Sisp/SispTest.php
+++ b/tests/Sisp/SispTest.php
@@ -37,6 +37,8 @@ it('builds request payload via facade with deterministic fingerprint', function 
 });
 
 it('generates sandbox payload and validates callback', function (): void {
+    config()->set('sisp.sandbox', true);
+
     $data = PaymentRequestData::from([
         'amount' => 50.0,
         'merchantRef' => 'MR-CB',
@@ -71,7 +73,8 @@ it('stores a transaction and lists it via facade', function (): void {
 });
 
 it('handles payment callback and updates status', function (): void {
-    // Create a matching transaction in DB
+    config()->set('sisp.sandbox', true);
+
     $transaction = Transaction::factory()->create([
         'merchant_ref' => 'MR-CB2',
         'merchant_session' => 'MS-CB2',


### PR DESCRIPTION
Fixes #125.

## Summary
- Return 404 from `/sisp/sandbox` unless `sisp.sandbox` is explicitly enabled.
- Refuse programmatic sandbox payload generation when the resolved SISP credentials are not sandbox credentials.
- Update callback-related tests to opt into sandbox mode where they intentionally generate signed sandbox callbacks.
- Add regression coverage for disabled sandbox route access and disabled sandbox payload generation.

## Security impact
This prevents production deployments from exposing a public endpoint or helper path that can generate valid signed callback payloads with production credentials. The change is intentionally defensive at both the controller and payload-builder layers.

## Validation
- `vendor/bin/pest tests/Http/SandboxControllerTest.php tests/Actions/BuildSandboxPayloadActionTest.php tests/Sisp/SispTest.php tests/Http/CallbackControllerTest.php tests/Sisp/SispEventsTest.php tests/Http/Middleware/PreventDuplicateCallbackTest.php tests/Sisp/ScopedSispTest.php --compact`
- `composer test`

## Risk
Existing non-sandbox environments that call `Sisp::generateSandboxPayload()` directly will now receive a `LogicException`. That is expected for this security patch because sandbox callback generation should not be available with production credentials.
