### PR TITLE
fix(cancel): require signed cancellation requests

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::match(['get', 'post'], 'sisp/callback', CallbackController::class)
     ->name('sisp.callback');
 
 Route::get('sisp/cancel', CancelTransactionController::class)
+    ->middleware(Illuminate\Routing\Middleware\ValidateSignature::class)
     ->name('sisp.cancel');
 
 Route::post('sisp/refund/{transaction}', RefundTransactionController::class)

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -3,15 +3,16 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\URL;
 
-it('cancels a pending transaction and redirects', function (): void {
+it('cancels a pending transaction from a signed request and redirects', function (): void {
     $t = Transaction::factory()->create([
         'status' => 'pending',
         'merchant_ref' => 'MR-C',
         'merchant_session' => 'MS-C',
     ]);
 
-    $this->get(route('sisp.cancel', [
+    $this->get(URL::signedRoute('sisp.cancel', [
         'reason' => 'user_cancelled',
         'merchantRef' => 'MR-C',
     ]))
@@ -28,7 +29,7 @@ it('handles non-cancellable transaction and flashes error', function (): void {
     ]);
 
     $this->withHeader('referer', '/checkout')
-        ->get(route('sisp.cancel', [
+        ->get(URL::signedRoute('sisp.cancel', [
             'reason' => 'user_cancelled',
             'merchantRef' => 'MR-C2',
         ]))
@@ -36,7 +37,7 @@ it('handles non-cancellable transaction and flashes error', function (): void {
         ->assertSessionHas('error');
 });
 
-it('cancels a pending transaction resolved by transaction_id', function (): void {
+it('cancels a pending transaction resolved by transaction_id from a signed request', function (): void {
     $t = Transaction::factory()->create([
         'status' => 'pending',
         'merchant_ref' => 'MR-C3',
@@ -44,7 +45,7 @@ it('cancels a pending transaction resolved by transaction_id', function (): void
         'transaction_id' => 'TXN-EXT-001',
     ]);
 
-    $this->get(route('sisp.cancel', [
+    $this->get(URL::signedRoute('sisp.cancel', [
         'reason' => 'user_cancelled',
         'transaction_id' => 'TXN-EXT-001',
     ]))
@@ -55,7 +56,38 @@ it('cancels a pending transaction resolved by transaction_id', function (): void
 
 it('handles missing transaction identifier and flashes error', function (): void {
     $this->withHeader('referer', '/checkout')
-        ->get(route('sisp.cancel'))
+        ->get(URL::signedRoute('sisp.cancel'))
         ->assertRedirect('/checkout')
         ->assertSessionHas('error', __('laravel-sisp::messages.validation.transaction_not_found'));
+});
+
+it('rejects unsigned merchant reference cancellation attempts', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'pending',
+        'merchant_ref' => 'MR-UNSIGNED',
+        'merchant_session' => 'MS-UNSIGNED',
+    ]);
+
+    $this->get(route('sisp.cancel', [
+        'reason' => 'user_cancelled',
+        'merchantRef' => 'MR-UNSIGNED',
+    ]))->assertForbidden();
+
+    expect($t->refresh()->status->value)->toBe('pending');
+});
+
+it('rejects unsigned transaction id cancellation attempts', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'pending',
+        'merchant_ref' => 'MR-TXN-UNSIGNED',
+        'merchant_session' => 'MS-TXN-UNSIGNED',
+        'transaction_id' => 'TXN-UNSIGNED-001',
+    ]);
+
+    $this->get(route('sisp.cancel', [
+        'reason' => 'user_cancelled',
+        'transaction_id' => 'TXN-UNSIGNED-001',
+    ]))->assertForbidden();
+
+    expect($t->refresh()->status->value)->toBe('pending');
 });


### PR DESCRIPTION
Fixes #126.

## Problem
The public `sisp.cancel` endpoint accepted request-controlled `merchantRef` or `transaction_id` values and cancelled matching pending transactions without any proof that the request was generated by the application.

## Root cause
The route had no signature, authentication, ownership check, or non-guessable token requirement before the controller resolved and mutated a transaction.

## Solution
- Require Laravel's signed URL validation middleware on `sisp.cancel`.
- Keep the existing signed cancellation behavior for `merchantRef` and `transaction_id` flows.
- Add regression tests proving unsigned cancellation attempts are rejected and leave transactions pending.

## Validation
- `vendor/bin/pest tests/Controllers/CancelTransactionControllerTest.php tests/Actions/CancelTransactionActionTest.php --compact`
- `composer test`

## Risk / rollback
This is a security-hardening behavior change: consumers must generate cancellation links with `URL::signedRoute('sisp.cancel', [...])`. Rollback is limited to removing the signed middleware, but that would reopen the unauthorized cancellation vector.
