### PR TITLE
fix(callback): reconcile signed transaction details

### DIFF
--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -6,6 +6,8 @@ namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Actions\Transaction\FindOrCreateTransactionAction;
 use Akira\Sisp\Actions\Transaction\UpdateTransactionAction;
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Contracts\SispCredentialsResolver;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
@@ -19,6 +21,8 @@ final readonly class HandleCallbackAction
     public function __construct(
         private FindOrCreateTransactionAction $findOrCreateTransaction,
         private UpdateTransactionAction $updateTransaction,
+        private SispCredentialsResolver $credentialsResolver,
+        private LoadConfig $config,
     ) {}
 
     public function handle(CallbackPayload $payload): Transaction
@@ -30,6 +34,14 @@ final readonly class HandleCallbackAction
             event(new PaymentFailed($transaction, $payload));
 
             $this->updateTransaction->handle($transaction, $payload);
+
+            return $transaction;
+        }
+
+        if (! $this->matchesTransaction($transaction, $payload)) {
+            $this->failTransaction($transaction, $payload);
+
+            event(new PaymentFailed($transaction, $payload));
 
             return $transaction;
         }
@@ -49,5 +61,47 @@ final readonly class HandleCallbackAction
             TransactionStatus::pending => event(new PaymentPending($transaction, $payload)),
             default => null, // @codeCoverageIgnore
         };
+    }
+
+    private function matchesTransaction(Transaction $transaction, CallbackPayload $payload): bool
+    {
+        return $this->transactionString($transaction, 'merchant_ref') === $payload->merchantRef
+            && $this->transactionString($transaction, 'merchant_session') === $payload->merchantSession
+            && $this->amountMatches($this->transactionAmount($transaction), $payload->amount)
+            && $this->transactionString($transaction, 'currency') === $payload->currency
+            && ($this->transactionString($transaction, 'transaction_code') ?: $this->config->getDefaultTransactionCode()) === $payload->transactionCode
+            && $this->credentialsResolver->resolve()->posId === $payload->posID;
+    }
+
+    private function amountMatches(float|int|string $expected, float|int|string $actual): bool
+    {
+        return (int) round((float) $expected * 1000) === (int) round((float) $actual * 1000);
+    }
+
+    private function failTransaction(Transaction $transaction, CallbackPayload $payload): void
+    {
+        $transaction->update([
+            'transaction_id' => $payload->transactionID,
+            'message_type' => $payload->messageType,
+            'merchant_response' => 'callback_details_mismatch',
+            'response_code' => $payload->merchantRespCp,
+            'fingerprint' => $payload->fingerprint,
+            'payload' => $transaction->payload,
+            'status' => TransactionStatus::failed,
+        ]);
+    }
+
+    private function transactionAmount(Transaction $transaction): float|int|string
+    {
+        $amount = $transaction->getAttribute('amount');
+
+        return is_float($amount) || is_int($amount) || is_string($amount) ? $amount : 0;
+    }
+
+    private function transactionString(Transaction $transaction, string $attribute): string
+    {
+        $value = $transaction->getAttribute($attribute);
+
+        return is_string($value) ? $value : '';
     }
 }

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -69,7 +69,7 @@ final readonly class HandleCallbackAction
             && $this->transactionString($transaction, 'merchant_session') === $payload->merchantSession
             && $this->amountMatches($this->transactionAmount($transaction), $payload->amount)
             && $this->transactionString($transaction, 'currency') === $payload->currency
-            && ($this->transactionString($transaction, 'transaction_code') ?: $this->config->getDefaultTransactionCode()) === $payload->transactionCode
+            && $this->transactionCode($transaction) === $payload->transactionCode
             && $this->credentialsResolver->resolve()->posId === $payload->posID;
     }
 
@@ -86,7 +86,6 @@ final readonly class HandleCallbackAction
             'merchant_response' => 'callback_details_mismatch',
             'response_code' => $payload->merchantRespCp,
             'fingerprint' => $payload->fingerprint,
-            'payload' => $transaction->payload,
             'status' => TransactionStatus::failed,
         ]);
     }
@@ -103,5 +102,12 @@ final readonly class HandleCallbackAction
         $value = $transaction->getAttribute($attribute);
 
         return is_string($value) ? $value : '';
+    }
+
+    private function transactionCode(Transaction $transaction): string
+    {
+        $transactionCode = $this->transactionString($transaction, 'transaction_code');
+
+        return $transactionCode === '' ? $this->config->getDefaultTransactionCode() : $transactionCode;
     }
 }

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -32,7 +32,8 @@ function cb_payload(string $msgType): CallbackPayload
 }
 
 beforeEach(function (): void {
-    // Ensure facade resolves fresh with our bindings
+    config()->set('sisp.posID', 'POS1');
+
     Facade::clearResolvedInstances();
 });
 
@@ -46,7 +47,13 @@ it('dispatches PaymentFailed and skips status update when fingerprint is invalid
     });
 
     Event::fake();
-    $transaction = Transaction::factory()->create(['merchant_ref' => 'mref', 'merchant_session' => 'msess']);
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'mref',
+        'merchant_session' => 'msess',
+        'amount' => 10,
+        'currency' => '132',
+        'transaction_code' => '8',
+    ]);
 
     resolve(HandleCallbackAction::class)->handle(cb_payload(ErrorMessageType::invalidAmount->value));
 
@@ -57,16 +64,31 @@ it('dispatches PaymentFailed and skips status update when fingerprint is invalid
 });
 
 it('dispatches events for completed, failed, and pending statuses', function (): void {
-    // Override Sisp facade binding to control validation
     app()->instance(Akira\Sisp\Sisp::class, new class
     {
         public function validateCallback(CallbackPayload $payload): bool
         {
             return true;
         }
+
+        public function getDefaultTransactionCode(): string
+        {
+            return '8';
+        }
+
+        public function getPosId(): string
+        {
+            return 'POS1';
+        }
     });
 
-    Transaction::factory()->create(['merchant_ref' => 'mref', 'merchant_session' => 'msess']);
+    Transaction::factory()->create([
+        'merchant_ref' => 'mref',
+        'merchant_session' => 'msess',
+        'amount' => 10,
+        'currency' => '132',
+        'transaction_code' => '8',
+    ]);
 
     Event::fake();
     resolve(HandleCallbackAction::class)->handle(cb_payload(SuccessMessageType::purchase->value));

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -70,16 +70,6 @@ it('dispatches events for completed, failed, and pending statuses', function ():
         {
             return true;
         }
-
-        public function getDefaultTransactionCode(): string
-        {
-            return '8';
-        }
-
-        public function getPosId(): string
-        {
-            return 'POS1';
-        }
     });
 
     Transaction::factory()->create([

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Sisp as SispManager;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
+use Akira\Sisp\ValueObjects\SispCredentials;
 use Illuminate\Support\Facades\DB;
 
 beforeEach(function (): void {
     config()->set('sisp.sandbox', true);
 });
+
+function callback_controller_payload(Transaction $transaction, array $overrides = []): array
+{
+    return Sisp::generateSandboxPayload(PaymentRequestData::from(array_merge([
+        'amount' => $transaction->amount,
+        'merchantRef' => $transaction->merchant_ref,
+        'merchantSession' => $transaction->merchant_session,
+        'timeStamp' => '2024-01-01 00:00:00',
+        'currency' => $transaction->currency,
+        'transactionCode' => $transaction->transaction_code ?? '1',
+    ], $overrides)))->toArray();
+}
 
 it('redirects when user cancelled flag present', function (): void {
     config()->set('sisp.redirect_url', '/home');
@@ -98,4 +112,83 @@ it('skips duplicate lookup when callback payload has no transaction keys', funct
 
     $this->post(route('sisp.callback'), $payload->toArray())
         ->assertRedirect('/home');
+});
+
+it('records signed amount mismatches as failed without completing the transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-AMOUNT-MISMATCH',
+        'merchant_session' => 'MS-AMOUNT-MISMATCH',
+        'amount' => 20,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), callback_controller_payload($transaction, ['amount' => 25]))
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-AMOUNT-MISMATCH']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('callback_details_mismatch');
+});
+
+it('records signed currency mismatches as failed without completing the transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-CURRENCY-MISMATCH',
+        'merchant_session' => 'MS-CURRENCY-MISMATCH',
+        'amount' => 20,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), callback_controller_payload($transaction, ['currency' => '978']))
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-CURRENCY-MISMATCH']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('callback_details_mismatch');
+});
+
+it('records signed pos id mismatches as failed without completing the transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-POS-MISMATCH',
+        'merchant_session' => 'MS-POS-MISMATCH',
+        'amount' => 20,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $scoped = resolve(SispManager::class)->forCredentials(SispCredentials::from([
+        'pos_id' => 'OTHER_POS',
+        'pos_aut_code' => config('sisp.posAutCode'),
+        'currency' => '132',
+        'merchant_id' => config('sisp.merchantID'),
+        'url' => config('sisp.endpoint'),
+        'language_messages' => config('sisp.languageMessages'),
+        'fingerprint_version' => config('sisp.fingerPrintVersion'),
+        'is_3d_sec' => config('sisp.is3DSec'),
+        'sandbox' => true,
+        'url_merchant_response' => config('sisp.url_merchant_response'),
+    ]));
+
+    $payload = $scoped->generateSandboxPayload(PaymentRequestData::from([
+        'amount' => 20,
+        'merchantRef' => 'MR-POS-MISMATCH',
+        'merchantSession' => 'MS-POS-MISMATCH',
+        'timeStamp' => '2024-01-01 00:00:00',
+        'currency' => '132',
+        'transactionCode' => '1',
+    ]))->toArray();
+
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-POS-MISMATCH']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('callback_details_mismatch');
 });

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -192,3 +192,21 @@ it('records signed pos id mismatches as failed without completing the transactio
     expect($transaction->status->value)->toBe('failed')
         ->and($transaction->merchant_response)->toBe('callback_details_mismatch');
 });
+
+it('reconciles zero transaction codes without falling back to config default', function (): void {
+    config()->set('sisp.transaction_code', '1');
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-ZERO-CODE',
+        'merchant_session' => 'MS-ZERO-CODE',
+        'amount' => 20,
+        'currency' => '132',
+        'transaction_code' => '0',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), callback_controller_payload($transaction))
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-ZERO-CODE']));
+
+    expect($transaction->refresh()->status->value)->toBe('completed');
+});


### PR DESCRIPTION
Fixes #127.

## Problem
Callback fingerprint validation proves the payload was signed, but the handler did not compare the signed payment details against the stored transaction before mutating status. A valid signed callback with mismatched amount, currency, POS ID, or transaction code could complete a transaction with inconsistent local state.

## Root cause
`HandleCallbackAction` updated the transaction after fingerprint validation without reconciling the callback payload against the stored transaction and configured SISP credentials.

## Solution
- Reconcile merchant reference, merchant session, amount, currency, transaction code, and POS ID before successful status mutation.
- Record mismatched signed callbacks as `failed` with `callback_details_mismatch` instead of completing the transaction.
- Resolve POS ID through the active `SispCredentialsResolver` so scoped credentials remain supported.
- Add regression tests for signed amount, currency, and POS ID mismatch callbacks.

## Validation
- `vendor/bin/pest tests/Http/CallbackControllerTest.php tests/Actions/HandleCallbackActionTest.php tests/Sisp/SispTest.php tests/Sisp/SispEventsTest.php tests/Sisp/ScopedSispTest.php --compact`
- `composer test`

## Risk / rollback
This is a defensive payment-integrity change. The main compatibility risk is that callbacks with previously tolerated local/payment detail drift now fail instead of completing. Rollback would remove the reconciliation guard, but that would reopen the integrity issue.
