### PR TITLE
fix(refund): remove email fallback authorization

### DIFF
--- a/src/Http/Controllers/RefundTransactionController.php
+++ b/src/Http/Controllers/RefundTransactionController.php
@@ -52,17 +52,6 @@ final readonly class RefundTransactionController
             return false;
         }
 
-        if ($user->can('refund', $transaction)) {
-            return true;
-        }
-
-        $userEmail = data_get($user, 'email');
-        $transactionEmail = (string) ($transaction->customer_email ?? '');
-
-        if (! is_string($userEmail) || mb_trim($userEmail) === '' || mb_trim($transactionEmail) === '') {
-            return false;
-        }
-
-        return strcasecmp(mb_trim($userEmail), mb_trim($transactionEmail)) === 0;
+        return $user->can('refund', $transaction);
     }
 }

--- a/tests/Controllers/RefundTransactionControllerTest.php
+++ b/tests/Controllers/RefundTransactionControllerTest.php
@@ -22,7 +22,7 @@ it('refunds a completed transaction and returns json', function (): void {
 
         public function can(string $ability, mixed $subject): bool
         {
-            return false;
+            return $ability === 'refund' && $subject instanceof Transaction;
         }
     });
 
@@ -48,7 +48,7 @@ it('returns 400 when refund amount exceeds transaction', function (): void {
 
         public function can(string $ability, mixed $subject): bool
         {
-            return false;
+            return $ability === 'refund' && $subject instanceof Transaction;
         }
     });
 
@@ -80,6 +80,32 @@ it('returns 403 when user is not authorized for the transaction', function (): v
     expect($response->getStatusCode())->toBe(403);
     $data = $response->getData(true);
     expect($data['success'])->toBeFalse();
+});
+
+it('returns 403 when customer email matches but user lacks refund ability', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
+    ]);
+
+    $controller = resolve(RefundTransactionController::class);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public string $email = 'buyer@example.com';
+
+        public function can(string $ability, mixed $subject): bool
+        {
+            return false;
+        }
+    });
+
+    $response = $controller($t, $request);
+
+    expect($response->getStatusCode())->toBe(403)
+        ->and($response->getData(true)['success'])->toBeFalse()
+        ->and($t->refresh()->status)->toBe(TransactionStatus::completed);
 });
 
 it('returns 403 when no authenticated user is present', function (): void {


### PR DESCRIPTION
Fixes #128.

## Problem
Refund authorization accepted a matching `transaction.customer_email` as a fallback when the authenticated user did not have explicit `refund` permission. That allowed a normal authenticated customer to refund a completed transaction if they knew the route ID.

## Root cause
`RefundTransactionController::isAuthorizedForTransaction()` returned true when the user's email matched the transaction customer email, even if `user->can('refund', $transaction)` returned false.

## Solution
- Remove the customer-email fallback from refund authorization.
- Require an authenticated user with explicit `refund` ability for the transaction.
- Update existing success/error refund tests to grant explicit refund ability where needed.
- Add a regression test proving matching customer email without refund ability returns 403 and leaves the transaction unchanged.

## Validation
- `vendor/bin/pest tests/Controllers/RefundTransactionControllerTest.php tests/Actions/RefundTransactionActionTest.php --compact`
- `composer test`

## Risk / rollback
This is a security-hardening change. Applications that relied on customer-email equality to permit refunds must replace that behavior with an explicit policy/gate. Rolling back would restore the IDOR-style refund authorization bypass.
