### PR TITLE
fix(retry): require postal code for 3ds retries

### DIFF
--- a/src/Actions/CanRetryPaymentAction.php
+++ b/src/Actions/CanRetryPaymentAction.php
@@ -29,6 +29,7 @@ final readonly class CanRetryPaymentAction
         return blank($transaction->customer_email)
             || blank($transaction->customer_country)
             || blank($transaction->customer_city)
-            || blank($transaction->customer_address);
+            || blank($transaction->customer_address)
+            || blank($transaction->getAttribute('customer_postal_code'));
     }
 }

--- a/src/Actions/CanRetryPaymentAction.php
+++ b/src/Actions/CanRetryPaymentAction.php
@@ -29,7 +29,6 @@ final readonly class CanRetryPaymentAction
         return blank($transaction->customer_email)
             || blank($transaction->customer_country)
             || blank($transaction->customer_city)
-            || blank($transaction->customer_address)
-            || blank($transaction->getAttribute('customer_postal_code'));
+            || blank($transaction->customer_address);
     }
 }

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -10,11 +10,6 @@ use Akira\Sisp\ValueObjects\PaymentRequestData;
 
 final readonly class RetryPaymentAction
 {
-    /**
-     * SISP 3DS requires a non-null postal code on retries.
-     */
-    private const string FALLBACK_POSTAL_CODE = '0000';
-
     public function __construct(private BuildRequestPayloadAction $buildRequestPayload) {}
 
     public function handle(Transaction $transaction): PaymentRequest
@@ -41,8 +36,15 @@ final readonly class RetryPaymentAction
             customerCountry: $transaction->customer_country,
             customerCity: $transaction->customer_city,
             customerAddress: $transaction->customer_address,
-            customerPostalCode: $transaction->customer_postal_code ?? self::FALLBACK_POSTAL_CODE,
+            customerPostalCode: $this->customerPostalCode($transaction),
             customerPhone: $transaction->customer_phone,
         );
+    }
+
+    private function customerPostalCode(Transaction $transaction): ?string
+    {
+        $postalCode = $transaction->getAttribute('customer_postal_code');
+
+        return is_string($postalCode) ? $postalCode : null;
     }
 }

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -10,6 +10,8 @@ use Akira\Sisp\ValueObjects\PaymentRequestData;
 
 final readonly class RetryPaymentAction
 {
+    private const string FALLBACK_POSTAL_CODE = '0000';
+
     public function __construct(private BuildRequestPayloadAction $buildRequestPayload) {}
 
     public function handle(Transaction $transaction): PaymentRequest
@@ -41,10 +43,10 @@ final readonly class RetryPaymentAction
         );
     }
 
-    private function customerPostalCode(Transaction $transaction): ?string
+    private function customerPostalCode(Transaction $transaction): string
     {
         $postalCode = $transaction->getAttribute('customer_postal_code');
 
-        return is_string($postalCode) ? $postalCode : null;
+        return is_string($postalCode) && $postalCode !== '' ? $postalCode : self::FALLBACK_POSTAL_CODE;
     }
 }

--- a/tests/Actions/CanRetryPaymentActionTest.php
+++ b/tests/Actions/CanRetryPaymentActionTest.php
@@ -29,6 +29,7 @@ it('blocks retry when 3DS is enabled and required customer data is missing', fun
         'customer_country' => null,
         'customer_city' => null,
         'customer_address' => null,
+        'customer_postal_code' => null,
     ]);
 
     $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
@@ -47,11 +48,31 @@ it('allows retry when 3DS is enabled and required customer data exists', functio
         'customer_country' => 'cv',
         'customer_city' => 'Praia',
         'customer_address' => 'Rua Principal',
+        'customer_postal_code' => '7600',
     ]);
 
     $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
 
     expect($canRetry)->toBeTrue();
+});
+
+it('blocks retry when 3DS postal code is missing', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '1',
+    ]);
+
+    $transaction = Transaction::factory()->failed()->create([
+        'customer_email' => 'john@example.test',
+        'customer_country' => 'cv',
+        'customer_city' => 'Praia',
+        'customer_address' => 'Rua Principal',
+        'customer_postal_code' => null,
+    ]);
+
+    $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
+
+    expect($canRetry)->toBeFalse();
 });
 
 it('blocks retry when retry is disabled by configuration', function (): void {

--- a/tests/Actions/CanRetryPaymentActionTest.php
+++ b/tests/Actions/CanRetryPaymentActionTest.php
@@ -56,7 +56,7 @@ it('allows retry when 3DS is enabled and required customer data exists', functio
     expect($canRetry)->toBeTrue();
 });
 
-it('blocks retry when 3DS postal code is missing', function (): void {
+it('allows retry when only the 3DS postal code is missing', function (): void {
     config([
         'sisp.allow_retry' => true,
         'sisp.is_3dsec' => '1',
@@ -72,7 +72,7 @@ it('blocks retry when 3DS postal code is missing', function (): void {
 
     $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
 
-    expect($canRetry)->toBeFalse();
+    expect($canRetry)->toBeTrue();
 });
 
 it('blocks retry when retry is disabled by configuration', function (): void {

--- a/tests/Actions/RetryPaymentActionTest.php
+++ b/tests/Actions/RetryPaymentActionTest.php
@@ -56,3 +56,25 @@ it('creates valid payment request with data from transaction', function (): void
     expect($paymentRequest->amount)->toBe(50000.0)
         ->and($paymentRequest->transactionCode)->toBe('1');
 });
+
+it('uses the documented fallback postal code when retry is built directly without one', function (): void {
+    config(['sisp.is_3dsec' => '1']);
+
+    $transaction = Transaction::factory()->create([
+        'amount' => 50000.0,
+        'merchant_ref' => 'REF-789',
+        'merchant_session' => 'SESS-789',
+        'currency' => 'CVE',
+        'transaction_code' => '1',
+        'customer_email' => 'customer@example.test',
+        'customer_country' => '132',
+        'customer_city' => 'Praia',
+        'customer_address' => 'Rua Principal',
+        'customer_postal_code' => null,
+    ]);
+
+    $paymentRequest = $this->action->handle($transaction);
+    $purchaseRequest = json_decode(base64_decode((string) $paymentRequest->purchaseRequest), true);
+
+    expect($purchaseRequest['billAddrPostCode'])->toBe('0000');
+});

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -52,6 +52,7 @@ it('rejects retry when 3DS is enabled and required customer data is missing', fu
         'customer_country' => null,
         'customer_city' => null,
         'customer_address' => null,
+        'customer_postal_code' => null,
     ]);
 
     $this->from('/sisp/callback?ref='.$t->merchant_ref)


### PR DESCRIPTION
Fixes #109.

## Problem
3DS retry eligibility and retry payload building were not aligned with the SISP `purchaseRequest` contract for postal codes.

## Root cause
`billAddrPostCode` is required inside the 3DS `purchaseRequest`, but SISP allows the default value `0000` when the customer does not provide a postal code. The retry flow needed to avoid building a payload with an empty postal code while still allowing retry when postal code is the only missing customer field.

## Solution
- Keep email, country, city, and address as required retry eligibility fields for 3DS retries.
- Allow retry when only `customer_postal_code` is missing.
- Normalize missing or empty retry postal code to the SISP fallback value `0000` before building the 3DS payload.
- Add regression coverage for both retry eligibility and direct retry payload building.

## Validation
- `vendor/bin/pest tests/Actions/CanRetryPaymentActionTest.php tests/Actions/RetryPaymentActionTest.php tests/Controllers/RetryPaymentControllerTest.php tests/Actions/BuildRequestPayloadActionTest.php --compact`
- `composer test`

## Risk / rollback
This preserves retry behavior for transactions missing only postal code while ensuring the generated 3DS `purchaseRequest` contains a non-empty `billAddrPostCode` value.
