### PR TITLE
fix(rate-limit): allow configured threshold

### DIFF
--- a/src/Models/RateLimit.php
+++ b/src/Models/RateLimit.php
@@ -40,7 +40,7 @@ final class RateLimit extends Model
 
     public function isLimitExceeded(): bool
     {
-        return $this->hits >= $this->limit;
+        return $this->hits > $this->limit;
     }
 
     public function recordHit(): self

--- a/tests/Actions/CheckRateLimitActionTest.php
+++ b/tests/Actions/CheckRateLimitActionTest.php
@@ -7,9 +7,7 @@ use Akira\Sisp\Exceptions\RateLimitExceededException;
 use Akira\Sisp\Models\RateLimit;
 
 beforeEach(function (): void {
-    // Ensure array cache for deterministic behavior
     config()->set('cache.default', 'array');
-    // Enable rate limiting by default for these tests
     config()->set('sisp.rate_limiting.enabled', true);
 });
 
@@ -22,15 +20,13 @@ it('returns immediately when disabled', function (): void {
 it('blocks after exceeding the limit and sets cache key', function (): void {
     $action = resolve(CheckRateLimitAction::class);
 
-    // Small window to exercise the block path
     $identifier = '1.1.1.1';
-    $limit = 2; // allow only 2 requests
-    $window = 60; // seconds
+    $limit = 2;
+    $window = 60;
 
-    // First hit creates entry and records hit
+    $action->handle('ip', $identifier, null, $limit, $window);
     $action->handle('ip', $identifier, null, $limit, $window);
 
-    // Second hit should exceed and throw
     $thrown = false;
     try {
         $action->handle('ip', $identifier, null, $limit, $window);
@@ -39,9 +35,9 @@ it('blocks after exceeding the limit and sets cache key', function (): void {
     }
     expect($thrown)->toBeTrue();
 
-    // Model is marked blocked
     $rl = RateLimit::query()->where('identifier', $identifier)->first();
-    expect($rl->is_blocked)->toBeTrue();
+    expect($rl->hits)->toBe(3)
+        ->and($rl->is_blocked)->toBeTrue();
 });
 
 it('resets when window elapsed then counts again', function (): void {
@@ -49,7 +45,6 @@ it('resets when window elapsed then counts again', function (): void {
     $identifier = '2.2.2.2';
     $windowSeconds = 60;
 
-    // Create a record in the past so it is reset
     $rl = RateLimit::query()->create([
         'identifier' => $identifier,
         'limit_type' => 'ip',
@@ -61,7 +56,6 @@ it('resets when window elapsed then counts again', function (): void {
         'is_blocked' => false,
     ]);
 
-    // Next handle should reset and then record a hit without throwing
     $action->handle('ip', $identifier, null, 10, $windowSeconds);
 
     $fresh = RateLimit::query()->find($rl->id);

--- a/tests/Models/RateLimitTest.php
+++ b/tests/Models/RateLimitTest.php
@@ -23,6 +23,10 @@ it('records hits, checks limits, resets and blocks', function (): void {
 
     $rl->refresh();
     expect($rl->hits)->toBe(2)
+        ->and($rl->isLimitExceeded())->toBeFalse();
+
+    $rl->recordHit()->refresh();
+    expect($rl->hits)->toBe(3)
         ->and($rl->isLimitExceeded())->toBeTrue();
 
     $rl->block(30)->refresh();


### PR DESCRIPTION
Fixes #113.

## Problem
A configured rate limit of `2` was treated as allowing only the first request. The second request reached `hits == limit` and was blocked immediately.

## Root cause
`RateLimit::isLimitExceeded()` used `hits >= limit` after `CheckRateLimitAction` had already recorded the current hit. That made the threshold itself fail instead of failing only after the threshold was exceeded.

## Solution
- Change the exceeded check to `hits > limit`.
- Update the action test so two hits are allowed when limit is `2` and the third hit blocks.
- Update the model test to assert the threshold is still allowed and `limit + 1` is exceeded.

## Validation
- `vendor/bin/pest tests/Actions/CheckRateLimitActionTest.php tests/Models/RateLimitTest.php tests/Actions/CheckRateLimitDefaultsTest.php tests/Http/Middleware/EnforceSispRateLimitsTest.php --compact`
- `composer test`

## Risk / rollback
This relaxes rate-limit blocking to match the documented meaning of `limit` as allowed requests per window. If a deployment depended on the old stricter behavior, lower the configured limit by one as a temporary rollback.
