### PR TITLE
fix(composer): guard testbench autoload hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     }
   },
   "scripts": {
-    "post-autoload-dump": "@composer run prepare",
+    "post-autoload-dump": "@php scripts/prepare-testbench.php",
     "clear": "@php vendor/bin/testbench package:purge-laravel-sisp --ansi",
     "prepare": "@php vendor/bin/testbench package:discover --ansi",
     "build": [

--- a/peck.json
+++ b/peck.json
@@ -20,7 +20,8 @@
             "roadmap",
             "addr",
             "pdfs",
-            "decrypted"
+            "decrypted",
+            "testbench"
         ],
         "paths": []
     }

--- a/scripts/prepare-testbench.php
+++ b/scripts/prepare-testbench.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+$binary = getenv('SISP_TESTBENCH_BINARY') ?: __DIR__.'/../vendor/bin/testbench';
+
+if (getenv('COMPOSER_DEV_MODE') === '0') {
+    exit(0);
+}
+
+if (! file_exists($binary)) {
+    exit(0);
+}
+
+passthru(escapeshellarg(PHP_BINARY).' '.escapeshellarg($binary).' package:discover --ansi', $exitCode);
+
+exit($exitCode);

--- a/tests/ComposerScriptsTest.php
+++ b/tests/ComposerScriptsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('guards the autoload hook from dev-only testbench dependency', function (): void {
+    $composer = json_decode(
+        file_get_contents(__DIR__.'/../composer.json'),
+        true,
+        flags: JSON_THROW_ON_ERROR,
+    );
+
+    expect($composer['scripts']['post-autoload-dump'])->toBe('@php scripts/prepare-testbench.php')
+        ->and($composer['scripts']['prepare'])->toBe('@php vendor/bin/testbench package:discover --ansi');
+});
+
+it('skips package discovery when testbench is unavailable', function (): void {
+    $script = escapeshellarg(__DIR__.'/../scripts/prepare-testbench.php');
+    $missingBinary = escapeshellarg(sys_get_temp_dir().'/missing-testbench-binary');
+
+    exec("SISP_TESTBENCH_BINARY={$missingBinary} ".escapeshellarg(PHP_BINARY)." {$script}", result_code: $exitCode);
+
+    expect($exitCode)->toBe(0);
+});
+
+it('skips package discovery when composer runs without dev dependencies', function (): void {
+    $script = escapeshellarg(__DIR__.'/../scripts/prepare-testbench.php');
+
+    exec('COMPOSER_DEV_MODE=0 '.escapeshellarg(PHP_BINARY)." {$script}", result_code: $exitCode);
+
+    expect($exitCode)->toBe(0);
+});


### PR DESCRIPTION
Fixes #102.

## Problem
`post-autoload-dump` always ran `composer run prepare`, and `prepare` invokes `vendor/bin/testbench`. That binary and its classes are dev-only, so production-style Composer operations with `--no-dev` could fail during release/install validation.

## Root cause
The Composer autoload hook was wired directly to a Testbench command without checking whether Composer was running with dev dependencies enabled.

## Solution
- Route `post-autoload-dump` through `scripts/prepare-testbench.php`.
- Skip package discovery when `COMPOSER_DEV_MODE=0` or when the Testbench binary is unavailable.
- Keep `composer prepare` as the explicit dev command for package discovery.
- Add regression tests covering the Composer script wiring and both skip paths.
- Add `testbench` to the Peck dictionary because it is now referenced in a project script path.

## Validation
- `composer validate --strict --no-check-publish`
- `vendor/bin/pest tests/ComposerScriptsTest.php --compact`
- `composer dump-autoload --no-dev --no-interaction`
- `composer dump-autoload --no-interaction`
- `composer test`

## Risk / rollback
Low. Dev installs still run Testbench discovery through the guarded hook, while no-dev installs now skip the dev-only command. Rollback is restoring `post-autoload-dump` to `@composer run prepare`, but that reintroduces the no-dev failure.
