### PR TITLE
test(fingerprint): use known response vector (#103)

### DIFF
--- a/tests/Actions/ValidateFingerprintActionTest.php
+++ b/tests/Actions/ValidateFingerprintActionTest.php
@@ -10,12 +10,11 @@ beforeEach(function (): void {
     $this->action = resolve(ValidatePaymentResponseFingerprintAction::class);
 });
 
-it(/**
- * @throws Exception
- */ 'fingerprint is computed with correct field order', function (): void {
+it('accepts a known SISP response fingerprint vector', function (): void {
     $payloadData = [
         'messageType' => 'S',
         'merchantRespCP' => '01',
+        'merchantRespTid' => '987654321',
         'merchantRespMerchantRef' => 'R20251112123456',
         'merchantRespMerchantSession' => 'S20251112123456',
         'merchantRespPurchaseAmount' => '1000',
@@ -30,17 +29,13 @@ it(/**
         'reloadCode' => '',
     ];
 
-    $expectedAmount = (int) ((float) 1000 * 1000);
-    expect($expectedAmount)->toBe(1000000);
-
-    $payload = CallbackPayload::from($payloadData);
-    $fingerprint = resolve(PaymentResponseFingerPrintAction::class)->handle($payload);
-    $payloadData['resultFingerPrint'] = $fingerprint;
+    $payloadData['resultFingerPrint'] = 'f21S7MCbbqbco+LdminDXubQwQGwRL/UIOB28GDUJqjnOaKGG7ZZIAYobEVFweAcwPkRyh9Z1orbk1YfKMYNHg==';
     $payload = CallbackPayload::from($payloadData);
 
     $response = $this->action->handle($payload);
 
-    expect($response)->toBeTrue();
+    expect($payload->fingerprint)->toBe('f21S7MCbbqbco+LdminDXubQwQGwRL/UIOB28GDUJqjnOaKGG7ZZIAYobEVFweAcwPkRyh9Z1orbk1YfKMYNHg==')
+        ->and($response)->toBeTrue();
 });
 
 it('fingerprint rejects altered amount', function (): void {

--- a/tests/Actions/ValidateFingerprintActionTest.php
+++ b/tests/Actions/ValidateFingerprintActionTest.php
@@ -34,8 +34,7 @@ it('accepts a known SISP response fingerprint vector', function (): void {
 
     $response = $this->action->handle($payload);
 
-    expect($payload->fingerprint)->toBe('f21S7MCbbqbco+LdminDXubQwQGwRL/UIOB28GDUJqjnOaKGG7ZZIAYobEVFweAcwPkRyh9Z1orbk1YfKMYNHg==')
-        ->and($response)->toBeTrue();
+    expect($response)->toBeTrue();
 });
 
 it('fingerprint rejects altered amount', function (): void {


### PR DESCRIPTION
## Problem
Fixes #103.

The fingerprint validation test computed `resultFingerPrint` with the same production action that validation delegates to. If the implementation drifted from the SISP contract, the test could stay green while both generation and validation were wrong.

## Root cause
The test used `PaymentResponseFingerPrintAction` as its oracle instead of a fixed protocol vector.

## Solution
Replace the self-referential assertion with a known callback payload and a fixed expected base64 SHA-512 fingerprint. The validation action must now accept that literal vector without using the production fingerprint generator to build the expected value.

## Validation
- `./vendor/bin/pest tests/Actions/ValidateFingerprintActionTest.php --compact`
- `composer test`

## Risk / rollback
Test-only change. Rollback would restore the self-referential oracle and reopen the coverage gap.
