### PR TITLE
test(package): mark node manifest private (#106)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "postcss": "^8.5.14",
     "tailwindcss": "^3.2.4",
     "vite": "^4.5.3"
-  }
+  },
+  "private": true
 }

--- a/tests/PackageMetadataTest.php
+++ b/tests/PackageMetadataTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+it('marks the node manifest as private tooling metadata', function (): void {
+    $package = json_decode(file_get_contents(dirname(__DIR__).'/package.json'), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($package['private'] ?? false)->toBeTrue()
+        ->and($package['scripts'] ?? [])->not->toHaveKey('release');
+});


### PR DESCRIPTION
## Problem
Fixes #106.

`package.json` still reported version `0.0.0`, which could be mistaken for a publishable npm package version even though this project releases through Composer/Git tags.

## Root cause
The Node manifest is used for frontend tooling, but it was not explicitly marked as private/non-publishable. That left the stale npm version looking like release metadata.

## Solution
Mark the Node manifest as private and add a package metadata regression test that asserts the manifest is private and does not expose a `release` script.

## Validation
- `./vendor/bin/pest tests/PackageMetadataTest.php --compact`
- `composer test`

## Risk / rollback
Low risk. This affects npm package metadata only and prevents accidental npm publishing. Rollback would remove the private guard and reopen the stale-version ambiguity.
