### PR TITLE
v0.7.0 — Payment correctness and test reliability hardening

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,7 @@ jobs:
           tools: composer:v2
 
       - name: Install Aspell
+        timeout-minutes: 5
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "laravel-sisp",
   "version": "0.0.0",
   "description": "[![Latest Version on Packagist](https://img.shields.io/packagist/v/akira-io/laravel-sisp.svg?style=flat-square)](https://packagist.org/packages/akira-io/laravel-sisp) [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/akira-io/laravel-sisp/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/akira-io/laravel-sisp/actions?query=workflow%3Arun-tests+branch%3Amain) [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/akira-io/laravel-sisp/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/akira-io/laravel-sisp/actions?query=workflow%3A\"Fix+PHP+code+style+issues\"+branch%3Amain) [![Total Downloads](https://img.shields.io/packagist/dt/akira-io/laravel-sisp.svg?style=flat-square)](https://packagist.org/packages/akira-io/laravel-sisp)",
-  "main": "index.js",
   "directories": {
     "test": "tests"
   },

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "postcss": "^8.5.14",
     "tailwindcss": "^3.2.4",
     "vite": "^4.5.3"
-  }
+  },
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "vite-plugin-laravel": "^0.3.1"
   },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,18 +55,6 @@ parameters:
 			path: src/Actions/RenderPaymentResponseAction.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$invoice_number\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/RenderPaymentResponseAction.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$pdf_url\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/RenderPaymentResponseAction.php
-
-		-
 			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$currency\.$#'
 			identifier: property.notFound
 			count: 1

--- a/src/Actions/Generators/MerchantReferenceGeneratorAction.php
+++ b/src/Actions/Generators/MerchantReferenceGeneratorAction.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions\Generators;
 
 use Akira\Sisp\Contracts\Generator;
-use Illuminate\Support\Str;
 
 final readonly class MerchantReferenceGeneratorAction implements Generator
 {
     public function __invoke(): string
     {
-        return Str::uuid()->toString();
+        return 'R'.now()->format('YmdHis');
     }
 }

--- a/src/Actions/Generators/MerchantSessionGeneratorAction.php
+++ b/src/Actions/Generators/MerchantSessionGeneratorAction.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions\Generators;
 
 use Akira\Sisp\Contracts\Generator;
-use Illuminate\Support\Str;
 
 final readonly class MerchantSessionGeneratorAction implements Generator
 {
     public function __invoke(): string
     {
-        return Str::random(32);
+        return 'S'.now()->format('YmdHis');
     }
 }

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Enums\ErrorMessageType;
+use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Contracts\View\View;
 use Inertia\Inertia;
@@ -52,8 +53,11 @@ final readonly class RenderPaymentResponseAction
             'error' => $this->getStructuredError($transaction),
             'translations' => $this->getTranslations->handle(),
             'allowRetry' => $this->canRetryPayment->handle($transaction),
-            'invoice' => $invoice ? [
+            'invoice' => $invoice instanceof Invoice ? [
                 'invoice_number' => $invoice->invoice_number,
+                'invoice_date' => $invoice->invoice_date->toDateString(),
+                'status' => $invoice->status->value,
+                'pdf_path' => $invoice->pdf_path,
                 'pdf_url' => $invoice->pdf_url,
             ] : null,
             'payload' => $payload,

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Actions;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\InertiaAvailability;
 use Illuminate\Contracts\View\View;
 use Inertia\Inertia;
 
@@ -16,6 +17,7 @@ final readonly class RenderPaymentResponseAction
         private GetPaymentErrorResponseAction $getErrorResponse,
         private GetPaymentResponseTranslationsAction $getTranslations,
         private CanRetryPaymentAction $canRetryPayment,
+        private InertiaAvailability $inertiaAvailability,
     ) {}
 
     public function renderBlade(Transaction $transaction, array $payload): View
@@ -33,8 +35,8 @@ final readonly class RenderPaymentResponseAction
 
     public function renderInertia(Transaction $transaction, array $payload, string $component = 'Sisp/PaymentResponse'): mixed
     {
-        if (! class_exists(Inertia::class)) {
-            return $this->renderBlade($transaction, $payload); // @codeCoverageIgnore
+        if (! $this->inertiaAvailability->available()) {
+            return $this->renderBlade($transaction, $payload);
         }
 
         $invoice = $transaction->invoice;

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akira\Sisp\Configuration;
 
 use Illuminate\Contracts\Config\Repository;
-use Illuminate\Support\Str;
 
 final readonly class LoadConfig
 {
@@ -50,16 +49,16 @@ final readonly class LoadConfig
 
     public function getMerchantReference(): string
     {
-        $configured = $this->config->get('sisp.merchant_ref');
+        $generator = $this->config->get('sisp.generators.merchantReference');
 
-        return $configured ?? 'R'.Str::uuid()->toString();
+        return resolve($generator)();
     }
 
     public function getMerchantSession(): string
     {
-        $configured = $this->config->get('sisp.merchant_session');
+        $generator = $this->config->get('sisp.generators.merchantSession');
 
-        return $configured ?? 'S'.Str::random(32);
+        return resolve($generator)();
     }
 
     public function getTimeStamp(): string

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Configuration;
 
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Str;
 
 final readonly class LoadConfig
 {
@@ -51,14 +52,14 @@ final readonly class LoadConfig
     {
         $configured = $this->config->get('sisp.merchant_ref');
 
-        return $configured ?? 'R'.date('YmdHis');
+        return $configured ?? 'R'.Str::uuid()->toString();
     }
 
     public function getMerchantSession(): string
     {
         $configured = $this->config->get('sisp.merchant_session');
 
-        return $configured ?? 'S'.date('YmdHis');
+        return $configured ?? 'S'.Str::random(32);
     }
 
     public function getTimeStamp(): string

--- a/src/Support/InertiaAvailability.php
+++ b/src/Support/InertiaAvailability.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Support;
+
+use Inertia\Inertia;
+
+final readonly class InertiaAvailability
+{
+    public function __construct(private bool $available = true) {}
+
+    public function available(): bool
+    {
+        return $this->available && class_exists(Inertia::class);
+    }
+}

--- a/src/ValueObjects/CallbackPayload.php
+++ b/src/ValueObjects/CallbackPayload.php
@@ -86,7 +86,7 @@ final readonly class CallbackPayload
     public function withoutFingerprint(): array
     {
         $data = $this->toArray();
-        unset($data['fingerprint']);
+        unset($data['resultFingerPrint']);
 
         return $data;
     }

--- a/tests/Actions/BuildRequestPayloadActionTest.php
+++ b/tests/Actions/BuildRequestPayloadActionTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Actions\BuildRequestPayloadAction;
-use Akira\Sisp\Actions\GenerateFingerprintAction;
 use Akira\Sisp\Exceptions\MissingThreeDSecureDataException;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 
@@ -11,7 +10,6 @@ it('builds payment request payload using defaults and generated fingerprint', fu
 
     $action = resolve(BuildRequestPayloadAction::class);
 
-    // Provide all fields to ensure determinism
     $data = PaymentRequestData::from([
         'amount' => 123.45,
         'merchantRef' => 'MR-123',
@@ -27,17 +25,6 @@ it('builds payment request payload using defaults and generated fingerprint', fu
 
     $request = $action->handle($data);
     $arr = $request->toArray();
-
-    // Compute expected fingerprint using actual generator
-    $expectedFingerprint = resolve(GenerateFingerprintAction::class)->handle([
-        'timeStamp' => '2024-01-01 00:00:00',
-        'amount' => 123.45,
-        'merchantRef' => 'MR-123',
-        'merchantSession' => 'MS-456',
-        'posID' => config('sisp.posID'),
-        'currency' => '132',
-        'transactionCode' => '1',
-    ]);
 
     expect($arr)
         ->toHaveKeys([
@@ -60,7 +47,7 @@ it('builds payment request payload using defaults and generated fingerprint', fu
         ->and($arr['entityCode'])->toBe('ENT')
         ->and($arr['referenceNumber'])->toBe('REF')
         ->and($arr['locale'])->toBe('pt_PT')
-        ->and($arr['fingerprint'])->toBe($expectedFingerprint);
+        ->and($arr['fingerprint'])->toBe('aVX+WpYP7A9AqZs9clZMtoW1R2gci+QaZuQ1cRRgdKNzVFcx/48eJa9ow8DyWlFa918qJdGMsxxJ6z1guRordQ==');
 });
 
 it('does not include purchaseRequest when 3DS is disabled', function (): void {
@@ -115,7 +102,6 @@ it('throws exception when 3DS enabled but customer data incomplete', function ()
     $data = PaymentRequestData::from([
         'amount' => 100.0,
         'customer_email' => 'test@example.com',
-        // Missing: country, city, address, postal_code
     ]);
 
     expect(fn () => $action->handle($data))
@@ -131,7 +117,6 @@ it('exception message lists missing fields', function (): void {
         'amount' => 100.0,
         'customer_email' => 'test@example.com',
         'customer_city' => 'Praia',
-        // Missing: country, address, postal_code
     ]);
 
     try {

--- a/tests/Actions/GenerateFingerprintActionTest.php
+++ b/tests/Actions/GenerateFingerprintActionTest.php
@@ -8,7 +8,7 @@ beforeEach(function (): void {
     $this->action = resolve(GenerateFingerprintAction::class);
 });
 
-it('fingerprint is generated with correct order', function (): void {
+it('generates the known SISP request fingerprint vector', function (): void {
     $data = [
         'timeStamp' => '2024-01-15 14:30:00',
         'amount' => 100.50,
@@ -20,8 +20,8 @@ it('fingerprint is generated with correct order', function (): void {
     ];
 
     $fingerprint = $this->action->handle($data);
-    expect($fingerprint)->not->toBeEmpty()
-        ->and(mb_strlen((string) $fingerprint))->toBeGreaterThan(0);
+
+    expect($fingerprint)->toBe('xoYJjgMu1BZN/pZHxIj2GL9gyulZjByJ/moOMc6iDd/N962z6GYHGqZfnIQKoxfxpUiM79NvA6WrasgecGAqJg==');
 });
 
 it('amount is converted to integer milliseconds', function (): void {

--- a/tests/Actions/Generators/MerchantReferenceGeneratorActionTest.php
+++ b/tests/Actions/Generators/MerchantReferenceGeneratorActionTest.php
@@ -3,12 +3,17 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Actions\Generators\MerchantReferenceGeneratorAction;
+use Illuminate\Support\Facades\Date;
 
-it('generates a valid uuid merchant reference', function (): void {
-    $gen = resolve(MerchantReferenceGeneratorAction::class);
-    $ref = $gen();
+it('generates a SISP merchant reference with the recommended timestamp format', function (): void {
+    Date::setTestNow('2026-05-23 10:11:12');
 
-    expect($ref)->toBeString()
-        ->and(mb_strlen($ref))->toBe(36)
-        ->and((bool) preg_match('/^[0-9a-f\-]{36}$/i', $ref))->toBeTrue();
+    try {
+        $gen = resolve(MerchantReferenceGeneratorAction::class);
+        $ref = $gen();
+
+        expect($ref)->toBe('R20260523101112');
+    } finally {
+        Date::setTestNow();
+    }
 });

--- a/tests/Actions/Generators/MerchantSessionGeneratorActionTest.php
+++ b/tests/Actions/Generators/MerchantSessionGeneratorActionTest.php
@@ -3,11 +3,17 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Actions\Generators\MerchantSessionGeneratorAction;
+use Illuminate\Support\Facades\Date;
 
-it('generates a random 32 length merchant session', function (): void {
-    $gen = resolve(MerchantSessionGeneratorAction::class);
-    $session = $gen();
+it('generates a SISP merchant session with the recommended timestamp format', function (): void {
+    Date::setTestNow('2026-05-23 10:11:12');
 
-    expect($session)->toBeString()
-        ->and(mb_strlen($session))->toBe(32);
+    try {
+        $gen = resolve(MerchantSessionGeneratorAction::class);
+        $session = $gen();
+
+        expect($session)->toBe('S20260523101112');
+    } finally {
+        Date::setTestNow();
+    }
 });

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\HandleCallbackAction;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Enums\SuccessMessageType;
+use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
@@ -37,7 +38,7 @@ beforeEach(function (): void {
     Facade::clearResolvedInstances();
 });
 
-it('dispatches PaymentFailed and skips status update when fingerprint is invalid', function (): void {
+it('dispatches PaymentFailed and marks the transaction failed when fingerprint is invalid', function (): void {
     app()->instance(Akira\Sisp\Sisp::class, new class
     {
         public function validateCallback(CallbackPayload $payload): bool
@@ -53,6 +54,7 @@ it('dispatches PaymentFailed and skips status update when fingerprint is invalid
         'amount' => 10,
         'currency' => '132',
         'transaction_code' => '8',
+        'status' => TransactionStatus::pending,
     ]);
 
     resolve(HandleCallbackAction::class)->handle(cb_payload(ErrorMessageType::invalidAmount->value));

--- a/tests/Actions/RenderPaymentResponseActionInvoiceTest.php
+++ b/tests/Actions/RenderPaymentResponseActionInvoiceTest.php
@@ -5,18 +5,30 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\RenderPaymentResponseAction;
 use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
+use Inertia\Support\Header;
 
 it('renderInertia includes invoice data when present', function (): void {
     $t = Transaction::factory()->create();
 
-    $invoice = Invoice::query()->create([
+    Invoice::query()->create([
         'transaction_id' => $t->id,
         'invoice_number' => 'INV-000001',
-        'invoice_date' => now()->toDateString(),
+        'invoice_date' => '2026-05-23',
         'status' => 'pending',
         'pdf_path' => 'invoices/test.pdf',
     ]);
 
     $resp = resolve(RenderPaymentResponseAction::class)->renderInertia($t, []);
-    expect($resp)->toBeInstanceOf(Inertia\Response::class);
+    $request = request();
+    $request->headers->set(Header::INERTIA, 'true');
+    $data = $resp->toResponse($request)->getData(true);
+
+    expect($resp)->toBeInstanceOf(Inertia\Response::class)
+        ->and($data['props']['invoice'])->toMatchArray([
+            'invoice_number' => 'INV-000001',
+            'invoice_date' => '2026-05-23',
+            'status' => 'pending',
+            'pdf_path' => 'invoices/test.pdf',
+        ])
+        ->and($data['props']['invoice']['pdf_url'])->toContain('invoices/test.pdf');
 });

--- a/tests/Actions/RenderPaymentResponseActionNullErrorTest.php
+++ b/tests/Actions/RenderPaymentResponseActionNullErrorTest.php
@@ -11,5 +11,6 @@ it('getStructuredError returns null for unknown message type', function (): void
     ]);
 
     $view = resolve(RenderPaymentResponseAction::class)->renderBlade($t, []);
-    expect($view->name())->toBe('sisp::payment-response');
+    expect($view->name())->toBe('sisp::payment-response')
+        ->and($view->getData()['error'])->toBeNull();
 });

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\RenderPaymentResponseAction;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\InertiaAvailability;
+use Illuminate\Contracts\View\View;
 
 it('renders blade view with structured error when message type is error', function (): void {
     $t = Transaction::factory()->create([
@@ -23,13 +25,26 @@ it('renders blade view with structured error when message type is error', functi
         ]);
 });
 
-it('renderInertia falls back to blade when Inertia is absent', function (): void {
+it('renderInertia returns an inertia response when Inertia is available', function (): void {
     $t = Transaction::factory()->create([
         'message_type' => null,
     ]);
 
     $result = resolve(RenderPaymentResponseAction::class)->renderInertia($t, ['a' => 1]);
     expect($result)->toBeInstanceOf(Inertia\Response::class);
+});
+
+it('renderInertia falls back to blade when Inertia is absent', function (): void {
+    app()->instance(InertiaAvailability::class, new InertiaAvailability(false));
+
+    $t = Transaction::factory()->create([
+        'message_type' => null,
+    ]);
+
+    $result = resolve(RenderPaymentResponseAction::class)->renderInertia($t, ['a' => 1]);
+
+    expect($result)->toBeInstanceOf(View::class)
+        ->and($result->name())->toBe('sisp::payment-response');
 });
 
 it('sets allowRetry to false when 3DS is enabled and transaction is missing required customer data', function (): void {

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -12,7 +12,15 @@ it('renders blade view with structured error when message type is error', functi
     ]);
 
     $view = resolve(RenderPaymentResponseAction::class)->renderBlade($t, ['foo' => 'bar']);
-    expect($view->name())->toBe('sisp::payment-response');
+    $error = $view->getData()['error'];
+
+    expect($view->name())->toBe('sisp::payment-response')
+        ->and($error)->toMatchArray([
+            'code' => ErrorMessageType::invalidAmount->value,
+            'label' => 'Invalid amount',
+            'category' => 'validation',
+            'action' => 'check-payment-details',
+        ]);
 });
 
 it('renderInertia falls back to blade when Inertia is absent', function (): void {
@@ -21,7 +29,6 @@ it('renderInertia falls back to blade when Inertia is absent', function (): void
     ]);
 
     $result = resolve(RenderPaymentResponseAction::class)->renderInertia($t, ['a' => 1]);
-    // Inertia is available in this testbench; expect Inertia response
     expect($result)->toBeInstanceOf(Inertia\Response::class);
 });
 

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -17,7 +17,7 @@ it('renders blade view with structured error when message type is error', functi
     expect($view->name())->toBe('sisp::payment-response')
         ->and($error)->toMatchArray([
             'code' => ErrorMessageType::invalidAmount->value,
-            'label' => 'Invalid amount',
+            'label' => ErrorMessageType::invalidAmount->label(),
             'category' => 'validation',
             'action' => 'check-payment-details',
         ]);

--- a/tests/Actions/ValidateFingerprintActionTest.php
+++ b/tests/Actions/ValidateFingerprintActionTest.php
@@ -10,12 +10,11 @@ beforeEach(function (): void {
     $this->action = resolve(ValidatePaymentResponseFingerprintAction::class);
 });
 
-it(/**
- * @throws Exception
- */ 'fingerprint is computed with correct field order', function (): void {
+it('accepts a known SISP response fingerprint vector', function (): void {
     $payloadData = [
         'messageType' => 'S',
         'merchantRespCP' => '01',
+        'merchantRespTid' => '987654321',
         'merchantRespMerchantRef' => 'R20251112123456',
         'merchantRespMerchantSession' => 'S20251112123456',
         'merchantRespPurchaseAmount' => '1000',
@@ -30,17 +29,13 @@ it(/**
         'reloadCode' => '',
     ];
 
-    $expectedAmount = (int) ((float) 1000 * 1000);
-    expect($expectedAmount)->toBe(1000000);
-
-    $payload = CallbackPayload::from($payloadData);
-    $fingerprint = resolve(PaymentResponseFingerPrintAction::class)->handle($payload);
-    $payloadData['resultFingerPrint'] = $fingerprint;
+    $payloadData['resultFingerPrint'] = 'f21S7MCbbqbco+LdminDXubQwQGwRL/UIOB28GDUJqjnOaKGG7ZZIAYobEVFweAcwPkRyh9Z1orbk1YfKMYNHg==';
     $payload = CallbackPayload::from($payloadData);
 
     $response = $this->action->handle($payload);
 
-    expect($response)->toBeTrue();
+    expect($payload->fingerprint)->toBe('f21S7MCbbqbco+LdminDXubQwQGwRL/UIOB28GDUJqjnOaKGG7ZZIAYobEVFweAcwPkRyh9Z1orbk1YfKMYNHg==')
+        ->and($response)->toBeTrue();
 });
 
 it('fingerprint rejects altered amount', function (): void {

--- a/tests/Actions/ValidateFingerprintActionTest.php
+++ b/tests/Actions/ValidateFingerprintActionTest.php
@@ -34,8 +34,7 @@ it('accepts a known SISP response fingerprint vector', function (): void {
 
     $response = $this->action->handle($payload);
 
-    expect($payload->fingerprint)->toBe('f21S7MCbbqbco+LdminDXubQwQGwRL/UIOB28GDUJqjnOaKGG7ZZIAYobEVFweAcwPkRyh9Z1orbk1YfKMYNHg==')
-        ->and($response)->toBeTrue();
+    expect($response)->toBeTrue();
 });
 
 it('fingerprint rejects altered amount', function (): void {

--- a/tests/Commands/LaravelSispInstallCommandForceTest.php
+++ b/tests/Commands/LaravelSispInstallCommandForceTest.php
@@ -10,23 +10,27 @@ it('publishes inertia/vue/assets/blade with force', function (): void {
         'sisp-inertia-components' => [
             'source' => __DIR__.'/../../resources/js/react/pages/payment-response.tsx',
             'target' => resource_path('js/pages/sisp/payment-response.tsx'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-vue-components' => [
             'source' => __DIR__.'/../../resources/js/vue/pages/PaymentResponse.vue',
             'target' => resource_path('js/pages/sisp/PaymentResponse.vue'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-assets' => [
             'source' => __DIR__.'/../../resources/css/sisp.css',
             'target' => public_path('vendor/sisp/css/sisp.css'),
+            'targetDirectory' => public_path('vendor/sisp/css'),
         ],
         'sisp-views' => [
             'source' => __DIR__.'/../../resources/views/payment-response.blade.php',
             'target' => resource_path('views/vendor/sisp/payment-response.blade.php'),
+            'targetDirectory' => resource_path('views/vendor/sisp'),
         ],
     ];
 
     withInstallCommandFsLock(function () use ($targets): void {
-        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+        withPublishedPathBackups(array_unique(array_column($targets, 'targetDirectory')), function () use ($targets): void {
             foreach ($targets as $tag => $paths) {
                 File::ensureDirectoryExists(dirname($paths['target']));
                 file_put_contents($paths['target'], 'stale');

--- a/tests/Commands/LaravelSispInstallCommandForceTest.php
+++ b/tests/Commands/LaravelSispInstallCommandForceTest.php
@@ -2,16 +2,40 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 
 it('publishes inertia/vue/assets/blade with force', function (): void {
-    $cmd = resolve(LaravelSispInstallCommand::class);
-    $ref = new ReflectionClass($cmd);
+    $targets = [
+        'sisp-inertia-components' => [
+            'source' => __DIR__.'/../../resources/js/react/pages/payment-response.tsx',
+            'target' => resource_path('js/pages/sisp/payment-response.tsx'),
+        ],
+        'sisp-vue-components' => [
+            'source' => __DIR__.'/../../resources/js/vue/pages/PaymentResponse.vue',
+            'target' => resource_path('js/pages/sisp/PaymentResponse.vue'),
+        ],
+        'sisp-assets' => [
+            'source' => __DIR__.'/../../resources/css/sisp.css',
+            'target' => public_path('vendor/sisp/css/sisp.css'),
+        ],
+        'sisp-views' => [
+            'source' => __DIR__.'/../../resources/views/payment-response.blade.php',
+            'target' => resource_path('views/vendor/sisp/payment-response.blade.php'),
+        ],
+    ];
 
-    foreach (['publishInertiaComponents', 'publishVueComponents', 'publishAssets', 'publishBladeViews'] as $method) {
-        $m = $ref->getMethod($method);
-        $m->invoke($cmd, true);
-    }
+    withInstallCommandFsLock(function () use ($targets): void {
+        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+            foreach ($targets as $tag => $paths) {
+                File::ensureDirectoryExists(dirname($paths['target']));
+                file_put_contents($paths['target'], 'stale');
 
-    expect(true)->toBeTrue();
+                expect(Artisan::call('vendor:publish', ['--tag' => $tag]))->toBe(0)
+                    ->and(file_get_contents($paths['target']))->toBe('stale')
+                    ->and(Artisan::call('vendor:publish', ['--tag' => $tag, '--force' => true]))->toBe(0)
+                    ->and(file_get_contents($paths['target']))->toBe(file_get_contents($paths['source']));
+            }
+        });
+    });
 });

--- a/tests/Commands/LaravelSispInstallCommandHandleTest.php
+++ b/tests/Commands/LaravelSispInstallCommandHandleTest.php
@@ -8,17 +8,14 @@ it('drives handle() through inertia prompts via config toggles', function (): vo
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
-            // Ensure inertia is detected via vite config containing react
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteTs);
             file_put_contents($viteJs, "export default { plugins: ['react'] }");
 
-            // Drive confirmations using config (test mode)
             config()->set('sisp.tests.publish_config', true);
             config()->set('sisp.tests.force_config', false);
             config()->set('sisp.tests.publish_migrations', true);
             config()->set('sisp.tests.force_migrations', false);
-            // Avoid publishing to keep tests fast/stable under parallel
             config()->set('sisp.tests.publish_inertia', false);
             config()->set('sisp.tests.force_inertia', false);
             config()->set('sisp.tests.run_migrations', true);
@@ -35,8 +32,7 @@ it('drives handle() through blade prompts via config toggles', function (): void
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
-            // Ensure blade is detected (no react/inertia indicators)
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteJs);
             @unlink($viteTs);
 

--- a/tests/Commands/LaravelSispInstallCommandMoreTest.php
+++ b/tests/Commands/LaravelSispInstallCommandMoreTest.php
@@ -2,18 +2,48 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Illuminate\Support\Facades\Artisan;
 
 it('publishes config and migrations with and without force', function (): void {
-    $cmd = resolve(LaravelSispInstallCommand::class);
-    $ref = new ReflectionClass($cmd);
+    $configPath = config_path('sisp.php');
+    $migrationDirectory = database_path('migrations');
 
-    foreach ([false, true] as $force) {
-        foreach (['publishConfig', 'publishMigrations'] as $method) {
-            $m = $ref->getMethod($method);
-            $m->invoke($cmd, $force);
-        }
-    }
+    withInstallCommandFsLock(function () use ($configPath, $migrationDirectory): void {
+        withPublishedPathBackups([$configPath, $migrationDirectory], function () use ($configPath): void {
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-config', '--force' => true]))->toBe(0)
+                ->and($configPath)->toBeFile()
+                ->and(file_get_contents($configPath))->toBe(file_get_contents(__DIR__.'/../../config/sisp.php'));
 
-    expect(true)->toBeTrue();
+            file_put_contents($configPath, 'stale');
+
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-config']))->toBe(0)
+                ->and(file_get_contents($configPath))->toBe('stale')
+                ->and(Artisan::call('vendor:publish', ['--tag' => 'sisp-config', '--force' => true]))->toBe(0)
+                ->and(file_get_contents($configPath))->toBe(file_get_contents(__DIR__.'/../../config/sisp.php'));
+
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-migrations', '--force' => true]))->toBe(0);
+
+            $migrationPath = publishedSispMigrationPath();
+            expect($migrationPath)->toBeString()
+                ->and($migrationPath)->toBeFile()
+                ->and(file_get_contents($migrationPath))->toBe(file_get_contents(__DIR__.'/../../database/migrations/create_laravel_sisp_table.php'));
+
+            file_put_contents($migrationPath, 'stale');
+
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-migrations']))->toBe(0)
+                ->and(file_get_contents($migrationPath))->toBe('stale')
+                ->and(Artisan::call('vendor:publish', ['--tag' => 'sisp-migrations', '--force' => true]))->toBe(0)
+                ->and(file_get_contents($migrationPath))->toBe(file_get_contents(__DIR__.'/../../database/migrations/create_laravel_sisp_table.php'));
+        });
+    });
 });
+
+function publishedSispMigrationPath(): string
+{
+    $matches = glob(database_path('migrations/*create_laravel_sisp_table.php'));
+
+    expect($matches)->not->toBeFalse()
+        ->and($matches)->not->toBeEmpty();
+
+    return reset($matches);
+}

--- a/tests/Commands/LaravelSispInstallCommandPublishTest.php
+++ b/tests/Commands/LaravelSispInstallCommandPublishTest.php
@@ -10,23 +10,27 @@ it('publishes blade views, inertia components, vue components and assets', funct
         'sisp-views' => [
             'source' => __DIR__.'/../../resources/views/payment-form.blade.php',
             'target' => resource_path('views/vendor/sisp/payment-form.blade.php'),
+            'targetDirectory' => resource_path('views/vendor/sisp'),
         ],
         'sisp-inertia-components' => [
             'source' => __DIR__.'/../../resources/js/react/pages/payment-form.tsx',
             'target' => resource_path('js/pages/sisp/payment-form.tsx'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-vue-components' => [
             'source' => __DIR__.'/../../resources/js/vue/pages/PaymentForm.vue',
             'target' => resource_path('js/pages/sisp/PaymentForm.vue'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-assets' => [
             'source' => __DIR__.'/../../resources/css/sisp.css',
             'target' => public_path('vendor/sisp/css/sisp.css'),
+            'targetDirectory' => public_path('vendor/sisp/css'),
         ],
     ];
 
     withInstallCommandFsLock(function () use ($targets): void {
-        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+        withPublishedPathBackups(array_unique(array_column($targets, 'targetDirectory')), function () use ($targets): void {
             foreach ($targets as $tag => $paths) {
                 File::delete($paths['target']);
 

--- a/tests/Commands/LaravelSispInstallCommandPublishTest.php
+++ b/tests/Commands/LaravelSispInstallCommandPublishTest.php
@@ -2,15 +2,38 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 
 it('publishes blade views, inertia components, vue components and assets', function (): void {
-    $cmd = resolve(LaravelSispInstallCommand::class);
-    $ref = new ReflectionClass($cmd);
+    $targets = [
+        'sisp-views' => [
+            'source' => __DIR__.'/../../resources/views/payment-form.blade.php',
+            'target' => resource_path('views/vendor/sisp/payment-form.blade.php'),
+        ],
+        'sisp-inertia-components' => [
+            'source' => __DIR__.'/../../resources/js/react/pages/payment-form.tsx',
+            'target' => resource_path('js/pages/sisp/payment-form.tsx'),
+        ],
+        'sisp-vue-components' => [
+            'source' => __DIR__.'/../../resources/js/vue/pages/PaymentForm.vue',
+            'target' => resource_path('js/pages/sisp/PaymentForm.vue'),
+        ],
+        'sisp-assets' => [
+            'source' => __DIR__.'/../../resources/css/sisp.css',
+            'target' => public_path('vendor/sisp/css/sisp.css'),
+        ],
+    ];
 
-    foreach (['publishBladeViews', 'publishInertiaComponents', 'publishVueComponents', 'publishAssets'] as $method) {
-        $m = $ref->getMethod($method);
-        $m->invoke($cmd, false);
-        expect(true)->toBeTrue();
-    }
+    withInstallCommandFsLock(function () use ($targets): void {
+        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+            foreach ($targets as $tag => $paths) {
+                File::delete($paths['target']);
+
+                expect(Artisan::call('vendor:publish', ['--tag' => $tag]))->toBe(0)
+                    ->and($paths['target'])->toBeFile()
+                    ->and(file_get_contents($paths['target']))->toBe(file_get_contents($paths['source']));
+            }
+        });
+    });
 });

--- a/tests/Commands/LaravelSispInstallCommandTest.php
+++ b/tests/Commands/LaravelSispInstallCommandTest.php
@@ -8,8 +8,7 @@ use Illuminate\Support\Facades\Artisan;
 it('detects inertia stack when composer requires inertia', function (): void {
     withInstallCommandFsLock(function (): void {
         $composerPath = base_path('composer.json');
-        withFileBackups([$composerPath], function () use ($composerPath): void {
-            // Create a composer.json that includes inertia
+        withInstallCommandProjectBackups(function () use ($composerPath): void {
             file_put_contents($composerPath, json_encode([
                 'require' => [
                     'inertiajs/inertia-laravel' => '^2.0',
@@ -33,17 +32,15 @@ it('falls back to blade when no inertia indicators are present', function (): vo
         $inertiaConfig = base_path('config/inertia.php');
         $composerPath = base_path('composer.json');
 
-        withFileBackups([$viteTs, $viteJs, $inertiaConfig, $composerPath], function () use (
+        withInstallCommandProjectBackups(function () use (
             $viteTs,
             $viteJs,
             $inertiaConfig,
             $composerPath
         ): void {
-            // Ensure vite configs do not contain react
             @unlink($viteTs);
             @unlink($viteJs);
             @unlink($inertiaConfig);
-            // Overwrite composer.json without inertia requirement
             file_put_contents($composerPath, json_encode([
                 'require' => [
                     'php' => '^8.4',
@@ -70,7 +67,7 @@ it('detects inertia stack via vite config containing react', function (): void {
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteTs);
             file_put_contents($viteJs, "export default { plugins: ['react'] }");
             $cmd = resolve(LaravelSispInstallCommand::class);
@@ -86,7 +83,7 @@ it('detects inertia stack via vite.config.ts containing react', function (): voi
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteJs);
             file_put_contents($viteTs, "export default { plugins: ['react'] }");
             $cmd = resolve(LaravelSispInstallCommand::class);

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -9,12 +9,15 @@ beforeEach(function (): void {
 });
 
 it('returns sane defaults and configured values for getters', function (): void {
-    // Defaults generated values
-    expect($this->cfg->getMerchantReference())->toStartWith('R')
-        ->and($this->cfg->getMerchantSession())->toStartWith('S')
+    $merchantReferences = array_map(fn (): string => $this->cfg->getMerchantReference(), range(1, 5));
+    $merchantSessions = array_map(fn (): string => $this->cfg->getMerchantSession(), range(1, 5));
+
+    expect($merchantReferences)->each->toStartWith('R')
+        ->and($merchantReferences)->toHaveCount(count(array_unique($merchantReferences)))
+        ->and($merchantSessions)->each->toStartWith('S')
+        ->and($merchantSessions)->toHaveCount(count(array_unique($merchantSessions)))
         ->and($this->cfg->getTimeStamp())->toMatch('/^\d{4}-\d{2}-\d{2} /');
 
-    // Config-driven values
     config()->set('sisp.currency', 'XYZ');
     config()->set('sisp.language_messages', 'PT');
     config()->set('sisp.fingerprint_version', '9');
@@ -27,7 +30,6 @@ it('returns sane defaults and configured values for getters', function (): void 
         ->and($this->cfg->getDefaultTransactionCode())->toBe('42')
         ->and($this->cfg->getUri())->toBe('https://example.test');
 
-    // Invoice-related config
     config()->set('sisp.invoice', [
         'number_format' => 'date-based',
         'prefix' => 'INVX',

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -9,13 +9,8 @@ beforeEach(function (): void {
 });
 
 it('returns sane defaults and configured values for getters', function (): void {
-    $merchantReferences = array_map(fn (): string => $this->cfg->getMerchantReference(), range(1, 5));
-    $merchantSessions = array_map(fn (): string => $this->cfg->getMerchantSession(), range(1, 5));
-
-    expect($merchantReferences)->each->toStartWith('R')
-        ->and($merchantReferences)->toHaveCount(count(array_unique($merchantReferences)))
-        ->and($merchantSessions)->each->toStartWith('S')
-        ->and($merchantSessions)->toHaveCount(count(array_unique($merchantSessions)))
+    expect($this->cfg->getMerchantReference())->toMatch('/^R\d{14}$/')
+        ->and($this->cfg->getMerchantSession())->toMatch('/^S\d{14}$/')
         ->and($this->cfg->getTimeStamp())->toMatch('/^\d{4}-\d{2}-\d{2} /');
 
     config()->set('sisp.currency', 'XYZ');
@@ -85,4 +80,39 @@ it('reads boolean flags for features and security', function (): void {
         ->and($this->cfg->getRateLimitPerIp())->toBe(5)
         ->and($this->cfg->getRateLimitWindowSeconds())->toBe(60)
         ->and($this->cfg->getGeolocationProvider())->toBe('ip2location');
+});
+
+it('uses configured merchant identifier generators', function (): void {
+    app()->singleton('sisp.test.merchantReference', fn (): object => new class
+    {
+        private int $next = 0;
+
+        public function __invoke(): string
+        {
+            $this->next++;
+
+            return 'CUSTOM-REF-'.$this->next;
+        }
+    });
+
+    app()->singleton('sisp.test.merchantSession', fn (): object => new class
+    {
+        private int $next = 0;
+
+        public function __invoke(): string
+        {
+            $this->next++;
+
+            return 'CUSTOM-SESSION-'.$this->next;
+        }
+    });
+
+    config()->set('sisp.generators.merchantReference', 'sisp.test.merchantReference');
+    config()->set('sisp.generators.merchantSession', 'sisp.test.merchantSession');
+
+    $merchantReferences = array_map(fn (): string => $this->cfg->getMerchantReference(), range(1, 3));
+    $merchantSessions = array_map(fn (): string => $this->cfg->getMerchantSession(), range(1, 3));
+
+    expect($merchantReferences)->toBe(['CUSTOM-REF-1', 'CUSTOM-REF-2', 'CUSTOM-REF-3'])
+        ->and($merchantSessions)->toBe(['CUSTOM-SESSION-1', 'CUSTOM-SESSION-2', 'CUSTOM-SESSION-3']);
 });

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-it('can test', function (): void {
-    expect(true)->toBeTrue();
+it('boots package routes and serves countries data', function (): void {
+    $response = $this->get(route('sisp.countries'));
+
+    $response->assertOk()
+        ->assertJsonPath('cv.numeric', '132')
+        ->assertJsonPath('cv.name', 'Cabo Verde');
 });

--- a/tests/Exceptions/ExceptionsTest.php
+++ b/tests/Exceptions/ExceptionsTest.php
@@ -6,6 +6,7 @@ use Akira\Sisp\Exceptions\BlacklistedIdentifierException;
 use Akira\Sisp\Exceptions\InvalidPaymentResponseException;
 use Akira\Sisp\Exceptions\RateLimitExceededException;
 use Akira\Sisp\Exceptions\TransactionNotFoundException;
+use Symfony\Component\HttpFoundation\Response;
 
 it('instantiates custom exceptions with default codes', function (): void {
     $e1 = new RateLimitExceededException();
@@ -15,7 +16,10 @@ it('instantiates custom exceptions with default codes', function (): void {
 
     expect($e1->getCode())->toBe(429)
         ->and($e1->getMessage())->not->toBe('')
+        ->and($e2->getCode())->toBe(Response::HTTP_BAD_REQUEST)
         ->and($e2->getMessage())->not->toBe('')
+        ->and($e3->getCode())->toBe(Response::HTTP_UNPROCESSABLE_ENTITY)
         ->and($e3->getMessage())->not->toBe('')
+        ->and($e4->getCode())->toBe(Response::HTTP_FORBIDDEN)
         ->and($e4->getMessage())->toBe('Blocked');
 });

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -25,6 +25,22 @@ function callback_controller_payload(Transaction $transaction, array $overrides 
     ], $overrides)))->toArray();
 }
 
+function callback_query_reads_transactions_table(string $query): bool
+{
+    $normalizedQuery = str_replace(['`', '"', '[', ']'], '', mb_strtolower($query));
+
+    return preg_match('/\bfrom\s+(?:[a-z0-9_]+\.)?transactions\b/', $normalizedQuery) === 1;
+}
+
+it('detects transaction table lookups across database grammars', function (string $query): void {
+    expect(callback_query_reads_transactions_table($query))->toBeTrue();
+})->with([
+    'sqlite quoted table' => ['select * from "transactions" where "merchant_ref" = ?'],
+    'mysql quoted table' => ['select * from `transactions` where `merchant_ref` = ?'],
+    'unquoted table' => ['select * from transactions where merchant_ref = ?'],
+    'qualified quoted table' => ['select * from `main`.`transactions` where `merchant_ref` = ?'],
+]);
+
 it('redirects when user cancelled flag present', function (): void {
     config()->set('sisp.redirect_url', '/home');
     $this->post(route('sisp.callback'), ['UserCancelled' => true])
@@ -103,7 +119,7 @@ it('rejects invalid callback payload before transaction lookups', function (): v
     $queries = collect(DB::getQueryLog())->pluck('query');
 
     expect($queries->filter(
-        fn (string $query): bool => str_contains(mb_strtolower($query), 'from "transactions"')
+        fn (string $query): bool => callback_query_reads_transactions_table($query)
     ))->toHaveCount(0);
 });
 
@@ -117,9 +133,10 @@ it('skips duplicate lookup when callback payload has no transaction keys', funct
         'timeStamp' => '2024-01-01 00:00:00',
         'currency' => '132',
         'transactionCode' => '1',
-    ]));
+    ]))->toArray();
+    unset($payload['merchantRespMerchantRef'], $payload['merchantRespMerchantSession']);
 
-    $this->post(route('sisp.callback'), $payload->toArray())
+    $this->post(route('sisp.callback'), $payload)
         ->assertRedirect('/home');
 });
 

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -65,6 +65,15 @@ it('handles POST callback and redirects to GET with ref', function (): void {
 
     $this->post(route('sisp.callback'), $payload->toArray())
         ->assertRedirect(route('sisp.callback', ['ref' => 'MR-G2']));
+
+    $t->refresh();
+
+    expect($t->status->value)->toBe('completed')
+        ->and($t->transaction_id)->toBe($payload->transactionID)
+        ->and($t->message_type)->toBe($payload->messageType)
+        ->and($t->merchant_response)->toBe($payload->merchantResponse)
+        ->and($t->response_code)->toBe($payload->merchantRespCp)
+        ->and($t->fingerprint)->toBe($payload->fingerprint);
 });
 
 it('rejects invalid callback payload before transaction lookups', function (): void {

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Akira\Sisp\Models\Transaction;
+
 it('creates transaction and renders payment form', function (): void {
     config()->set('sisp.rate_limiting.enabled', false);
 
@@ -22,11 +24,24 @@ it('creates transaction and renders payment form', function (): void {
     $response->assertOk();
     $response->assertSee('sisp-payment-form');
     $response->assertSee(trans('sisp::payment.manual_redirect_button'));
+
+    $transaction = Transaction::query()->sole();
+
+    expect($transaction->amount)->toBe(100.0)
+        ->and($transaction->currency)->toBe('132')
+        ->and($transaction->status->value)->toBe('pending')
+        ->and($transaction->customer_name)->toBe('John')
+        ->and($transaction->customer_email)->toBe('john@example.test')
+        ->and($transaction->merchant_ref)->not->toBe('')
+        ->and($transaction->merchant_session)->not->toBe('')
+        ->and($transaction->items)->toHaveCount(1)
+        ->and($transaction->items->first()->product_name)->toBe('Test')
+        ->and($transaction->items->first()->quantity)->toBe(1)
+        ->and((float) $transaction->items->first()->total_price)->toBe(100.0);
 });
 
 it('blocks duplicate transactions via middleware', function (): void {
-    // Existing processed transaction
-    Akira\Sisp\Models\Transaction::factory()->create([
+    Transaction::factory()->create([
         'merchant_ref' => 'MR-DUP',
         'merchant_session' => 'MS-DUP',
         'status' => 'completed',

--- a/tests/Http/RetryPaymentControllerTest.php
+++ b/tests/Http/RetryPaymentControllerTest.php
@@ -9,9 +9,19 @@ it('retries payment for an existing transaction', function (): void {
         'amount' => 123.0,
         'currency' => '132',
         'status' => 'failed',
+        'merchant_session' => 'old-session',
+        'transaction_code' => '1',
     ]);
 
     $this->post(route('sisp.retry-payment'), [
         'transaction_id' => $t->id,
     ])->assertOk();
+
+    $t->refresh();
+
+    expect($t->merchant_session)->not->toBe('old-session')
+        ->and($t->merchant_session)->not->toBe('')
+        ->and($t->amount)->toBe(123.0)
+        ->and($t->currency)->toBe('132')
+        ->and($t->status->value)->toBe('failed');
 });

--- a/tests/Invoices/GenerateInvoicePdfItemsTest.php
+++ b/tests/Invoices/GenerateInvoicePdfItemsTest.php
@@ -12,9 +12,12 @@ use Illuminate\Support\Facades\Storage;
 
 final class TestPdfGeneratorItems implements PdfGeneratorContract
 {
+    public ?DtoInvoiceData $lastInvoice = null;
+
     public function generate(DtoInvoiceData $invoice, string $template = 'modern'): string
     {
-        // return static content regardless of items
+        $this->lastInvoice = $invoice;
+
         return '%PDF-WITH-ITEMS%';
     }
 
@@ -25,19 +28,40 @@ final class TestPdfGeneratorItems implements PdfGeneratorContract
 }
 
 it('includes transaction items when generating invoice PDF', function (): void {
-    app()->instance(PdfGeneratorContract::class, new TestPdfGeneratorItems());
+    $pdfGenerator = new TestPdfGeneratorItems();
+    app()->instance(PdfGeneratorContract::class, $pdfGenerator);
     Storage::fake('public');
 
-    $t = Transaction::factory()->create([
+    $transaction = Transaction::factory()->create([
         'customer_name' => 'John',
         'customer_email' => 'john@example.test',
     ]);
 
-    // Ensure items exist so the foreach in action is executed
-    TransactionItem::factory()->forTransaction($t)->count(2)->create();
+    TransactionItem::factory()->forTransaction($transaction)->create([
+        'product_name' => 'Adult ticket',
+        'quantity' => 2,
+        'unit_price_cents' => 1250,
+        'total_price_cents' => 2500,
+    ]);
+    TransactionItem::factory()->forTransaction($transaction)->create([
+        'product_name' => 'Child ticket',
+        'quantity' => 1,
+        'unit_price_cents' => 750,
+        'total_price_cents' => 750,
+    ]);
 
-    $invoice = resolve(GenerateInvoiceAction::class)->handle($t);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
     $relativePath = resolve(GenerateInvoicePdfAction::class)->handle($invoice);
 
     Storage::disk('public')->assertExists($relativePath);
+    expect($pdfGenerator->lastInvoice)->not->toBeNull()
+        ->and($pdfGenerator->lastInvoice?->items)->toHaveCount(2)
+        ->and($pdfGenerator->lastInvoice?->items[0]->description)->toBe('Adult ticket')
+        ->and($pdfGenerator->lastInvoice?->items[0]->quantity)->toBe(2)
+        ->and($pdfGenerator->lastInvoice?->items[0]->unitPrice)->toBe(12.5)
+        ->and($pdfGenerator->lastInvoice?->items[0]->getTotal())->toBe(25.0)
+        ->and($pdfGenerator->lastInvoice?->items[1]->description)->toBe('Child ticket')
+        ->and($pdfGenerator->lastInvoice?->items[1]->quantity)->toBe(1)
+        ->and($pdfGenerator->lastInvoice?->items[1]->unitPrice)->toBe(7.5)
+        ->and($pdfGenerator->lastInvoice?->items[1]->getTotal())->toBe(7.5);
 });

--- a/tests/PackageMetadataTest.php
+++ b/tests/PackageMetadataTest.php
@@ -6,5 +6,6 @@ it('marks the node manifest as private tooling metadata', function (): void {
     $package = json_decode(file_get_contents(dirname(__DIR__).'/package.json'), true, flags: JSON_THROW_ON_ERROR);
 
     expect($package['private'] ?? false)->toBeTrue()
+        ->and($package)->not->toHaveKey('main')
         ->and($package['scripts'] ?? [])->not->toHaveKey('release');
 });

--- a/tests/PackageMetadataTest.php
+++ b/tests/PackageMetadataTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+it('marks the node manifest as private tooling metadata', function (): void {
+    $package = json_decode(file_get_contents(dirname(__DIR__).'/package.json'), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($package['private'] ?? false)->toBeTrue()
+        ->and($package['scripts'] ?? [])->not->toHaveKey('release');
+});

--- a/tests/PackageMetadataTest.php
+++ b/tests/PackageMetadataTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 it('marks the node manifest as private tooling metadata', function (): void {
     $package = json_decode(file_get_contents(dirname(__DIR__).'/package.json'), true, flags: JSON_THROW_ON_ERROR);
+    $composer = json_decode(file_get_contents(dirname(__DIR__).'/composer.json'), true, flags: JSON_THROW_ON_ERROR);
 
     expect($package['private'] ?? false)->toBeTrue()
         ->and($package)->not->toHaveKey('main')
+        ->and($package['license'])->toBe($composer['license'])
         ->and($package['scripts'] ?? [])->not->toHaveKey('release');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -48,8 +48,10 @@ function withFileBackups(array $paths, callable $callback): void
 function withPublishedPathBackups(array $paths, callable $callback): void
 {
     $snapshots = [];
+    $fingerprints = [];
     foreach ($paths as $path) {
         $snapshots[$path] = snapshotPublishedPath($path);
+        $fingerprints[$path] = pathSnapshotFingerprint($path);
     }
 
     try {
@@ -57,8 +59,24 @@ function withPublishedPathBackups(array $paths, callable $callback): void
     } finally {
         foreach ($snapshots as $path => $snapshot) {
             restorePublishedPath($path, $snapshot);
+            expect(pathSnapshotFingerprint($path))->toBe($fingerprints[$path]);
         }
     }
+}
+
+function withInstallCommandProjectBackups(callable $callback): void
+{
+    withPublishedPathBackups([
+        base_path('composer.json'),
+        base_path('vite.config.js'),
+        base_path('vite.config.ts'),
+        base_path('config/inertia.php'),
+        config_path('sisp.php'),
+        database_path('migrations'),
+        resource_path('views/vendor/sisp'),
+        resource_path('js/pages/sisp'),
+        public_path('vendor/sisp/css'),
+    ], $callback);
 }
 
 function snapshotPublishedPath(string $path): array
@@ -104,4 +122,38 @@ function restorePublishedPath(string $path, array $snapshot): void
 
     Illuminate\Support\Facades\File::copyDirectory($snapshot['path'], $path);
     Illuminate\Support\Facades\File::deleteDirectory($snapshot['path']);
+}
+
+function pathSnapshotFingerprint(string $path): array
+{
+    if (! file_exists($path)) {
+        return ['type' => 'missing'];
+    }
+
+    if (is_file($path)) {
+        return [
+            'type' => 'file',
+            'hash' => hash_file('sha256', $path),
+        ];
+    }
+
+    $entries = [];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST,
+    );
+
+    foreach ($iterator as $entry) {
+        $relativePath = mb_substr((string) $entry->getPathname(), mb_strlen($path) + 1);
+        $entries[] = $entry->isDir()
+            ? 'dir:'.$relativePath
+            : 'file:'.$relativePath.':'.hash_file('sha256', $entry->getPathname());
+    }
+
+    sort($entries);
+
+    return [
+        'type' => 'directory',
+        'entries' => $entries,
+    ];
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -44,3 +44,64 @@ function withFileBackups(array $paths, callable $callback): void
         }
     }
 }
+
+function withPublishedPathBackups(array $paths, callable $callback): void
+{
+    $snapshots = [];
+    foreach ($paths as $path) {
+        $snapshots[$path] = snapshotPublishedPath($path);
+    }
+
+    try {
+        $callback();
+    } finally {
+        foreach ($snapshots as $path => $snapshot) {
+            restorePublishedPath($path, $snapshot);
+        }
+    }
+}
+
+function snapshotPublishedPath(string $path): array
+{
+    if (! file_exists($path)) {
+        return ['type' => 'missing'];
+    }
+
+    if (is_file($path)) {
+        return [
+            'type' => 'file',
+            'contents' => file_get_contents($path),
+        ];
+    }
+
+    $snapshotPath = sys_get_temp_dir().'/sisp-publish-snapshot-'.bin2hex(random_bytes(8));
+    Illuminate\Support\Facades\File::copyDirectory($path, $snapshotPath);
+
+    return [
+        'type' => 'directory',
+        'path' => $snapshotPath,
+    ];
+}
+
+function restorePublishedPath(string $path, array $snapshot): void
+{
+    if (is_dir($path)) {
+        Illuminate\Support\Facades\File::deleteDirectory($path);
+    } elseif (is_file($path)) {
+        unlink($path);
+    }
+
+    if ($snapshot['type'] === 'missing') {
+        return;
+    }
+
+    if ($snapshot['type'] === 'file') {
+        Illuminate\Support\Facades\File::ensureDirectoryExists(dirname($path));
+        file_put_contents($path, $snapshot['contents']);
+
+        return;
+    }
+
+    Illuminate\Support\Facades\File::copyDirectory($snapshot['path'], $path);
+    Illuminate\Support\Facades\File::deleteDirectory($snapshot['path']);
+}

--- a/tests/Providers/SispServiceProviderTest.php
+++ b/tests/Providers/SispServiceProviderTest.php
@@ -8,24 +8,32 @@ use Akira\Sisp\SispServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 it('registers singletons and factory guesser', function (): void {
-    $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
-    $provider->register();
-    $provider->boot();
+    Factory::guessFactoryNamesUsing(
+        fn (string $modelName): string => 'Original\\Factories\\'.class_basename($modelName).'Factory'
+    );
 
-    expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
-        ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class);
+    withFactoryNameResolverSnapshot(function (): void {
+        $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
+        $provider->register();
+        $provider->boot();
 
-    // Validate factory guesser mapping
-    $guesser = (new class extends Factory
-    {
-        public function definition(): array
-        {
-            return [];
-        }
+        expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
+            ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class)
+            ->and(Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class))->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class)
+            ->and(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Database\\Factories\\UserFactory');
     });
-    $class = Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class);
-    expect($class)->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class);
 
-    $other = Factory::resolveFactoryName('App\\Models\\User');
-    expect($other)->toBe('Database\\Factories\\UserFactory');
+    expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Original\\Factories\\UserFactory');
 });
+
+function withFactoryNameResolverSnapshot(callable $callback): void
+{
+    $property = new ReflectionProperty(Factory::class, 'factoryNameResolver');
+    $previousResolver = $property->getValue();
+
+    try {
+        $callback();
+    } finally {
+        $property->setValue(null, $previousResolver);
+    }
+}

--- a/tests/Providers/SispServiceProviderTest.php
+++ b/tests/Providers/SispServiceProviderTest.php
@@ -8,22 +8,28 @@ use Akira\Sisp\SispServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 it('registers singletons and factory guesser', function (): void {
-    Factory::guessFactoryNamesUsing(
-        fn (string $modelName): string => 'Original\\Factories\\'.class_basename($modelName).'Factory'
-    );
+    $factoryNameBeforeTest = Factory::resolveFactoryName('App\\Models\\User');
 
     withFactoryNameResolverSnapshot(function (): void {
-        $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
-        $provider->register();
-        $provider->boot();
+        Factory::guessFactoryNamesUsing(
+            fn (string $modelName): string => 'Original\\Factories\\'.class_basename($modelName).'Factory'
+        );
 
-        expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
-            ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class)
-            ->and(Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class))->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class)
-            ->and(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Database\\Factories\\UserFactory');
+        withFactoryNameResolverSnapshot(function (): void {
+            $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
+            $provider->register();
+            $provider->boot();
+
+            expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
+                ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class)
+                ->and(Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class))->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class)
+                ->and(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Database\\Factories\\UserFactory');
+        });
+
+        expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Original\\Factories\\UserFactory');
     });
 
-    expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Original\\Factories\\UserFactory');
+    expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe($factoryNameBeforeTest);
 });
 
 function withFactoryNameResolverSnapshot(callable $callback): void

--- a/tests/Traits/EncryptsAttributesTest.php
+++ b/tests/Traits/EncryptsAttributesTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Akira\Sisp\Traits\EncryptsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 final class TmpEncrypted extends Model
@@ -48,7 +50,7 @@ it('encrypts and decrypts string attributes via trait', function (): void {
     });
 
     $m = TmpEncrypted::query()->create(['secret' => 'hello-world']);
-    $raw = Illuminate\Support\Facades\DB::table('tmp_encrypts')->where('id', $m->id)->value('secret');
+    $raw = DB::table('tmp_encrypts')->where('id', $m->id)->value('secret');
     expect($raw)->not->toBe('hello-world');
 
     $found = TmpEncrypted::query()->find($m->id);
@@ -62,8 +64,17 @@ it('encrypts and decrypts array attributes via trait', function (): void {
     });
 
     $m = TmpEncrypted::query()->create(['secret' => ['hello-world', 'goodbye-world', 'secret' => 'secret-value']]);
-    $raw = Illuminate\Support\Facades\DB::table('tmp_encrypts')->where('id', $m->id)->value('secret');
-    expect($raw)->not->toBe('hello-world');
+    $raw = DB::table('tmp_encrypts')->where('id', $m->id)->value('secret');
+
+    expect($raw)->toBeString()
+        ->and($raw)->not->toContain('hello-world')
+        ->and($raw)->not->toContain('goodbye-world')
+        ->and($raw)->not->toContain('secret-value')
+        ->and(json_decode(Crypt::decryptString($raw), true))->toBe([
+            'hello-world',
+            'goodbye-world',
+            'secret' => 'secret-value',
+        ]);
 
     $found = TmpEncrypted::query()->find($m->id);
     expect($found->secret)->toBe(['hello-world', 'goodbye-world', 'secret' => 'secret-value']);
@@ -99,7 +110,7 @@ final class TmpEncryptedAccessor extends Model
 
     protected function getSecretAttribute($value): string
     {
-        return Illuminate\Support\Facades\Crypt::encryptString('accessor-secret');
+        return Crypt::encryptString('accessor-secret');
     }
 }
 
@@ -110,7 +121,7 @@ it('encrypts all attributes when encryptable list is empty', function (): void {
     });
 
     $m = TmpEncryptAll::query()->create(['notes' => 'secret-note']);
-    $raw = Illuminate\Support\Facades\DB::table('tmp_encrypts_all')->where('id', $m->id)->value('notes');
+    $raw = DB::table('tmp_encrypts_all')->where('id', $m->id)->value('notes');
     expect($raw)->not->toBe('secret-note');
 
     $found = TmpEncryptAll::query()->find($m->id);
@@ -150,14 +161,14 @@ it('does not double-encrypt values already encrypted', function (): void {
         $table->text('secret')->nullable();
     });
 
-    $already = Illuminate\Support\Facades\Crypt::encryptString('already');
+    $already = Crypt::encryptString('already');
 
     $m = new TmpEncrypted();
     $m->setTable('tmp_encrypts2');
     $m->secret = $already;
     $m->save();
 
-    $raw = Illuminate\Support\Facades\DB::table('tmp_encrypts2')->where('id', $m->id)->value('secret');
+    $raw = DB::table('tmp_encrypts2')->where('id', $m->id)->value('secret');
     expect($raw)->toBe($already);
 
     $found = new TmpEncrypted()->setTable('tmp_encrypts2')->find($m->id);
@@ -176,7 +187,7 @@ it('does not encrypt attributes not in encryptable list', function (): void {
         'note' => 'plain-note',
     ]);
 
-    $row = Illuminate\Support\Facades\DB::table('tmp_encrypts_selective')->where('id', $m->id)->first();
+    $row = DB::table('tmp_encrypts_selective')->where('id', $m->id)->first();
     expect($row->secret)->not->toBe('top-secret')
         ->and($row->note)->toBe('plain-note');
 
@@ -191,7 +202,7 @@ it('falls back when raw attribute decryption fails and returns original', functi
         $table->text('secret')->nullable();
     });
 
-    $id = Illuminate\Support\Facades\DB::table('tmp_encrypts_fail')->insertGetId(['secret' => 'bogus']);
+    $id = DB::table('tmp_encrypts_fail')->insertGetId(['secret' => 'bogus']);
 
     $model = new TmpEncrypted();
     $model->setTable('tmp_encrypts_fail');

--- a/tests/ValueObjects/CallbackPayloadTest.php
+++ b/tests/ValueObjects/CallbackPayloadTest.php
@@ -56,5 +56,7 @@ it('withoutFingerprint removes fingerprint key from array', function (): void {
     ]);
 
     $arr = $vo->withoutFingerprint();
-    expect($arr)->not->toHaveKey('fingerprint');
+    expect($arr)->not->toHaveKey('resultFingerPrint')
+        ->and($arr['merchantRespMerchantRef'])->toBe('R2')
+        ->and($arr['merchantRespTid'])->toBe('T2');
 });


### PR DESCRIPTION
## Milestone progress

This PR tracks the integration branch for `v0.7.0 — Payment correctness and test reliability hardening`.

Issues stay open until this milestone branch is merged into the release branch. Individual issue PRs should target `milestone/v0.7.0`; after they merge into this branch, update this checklist.

## Checklist

- [x] [#103 Fingerprint test uses the implementation under test as its oracle](https://github.com/akira-io/laravel-sisp/issues/103)
- [x] [#104 Fingerprint tests are self-referential and do not verify known signature output](https://github.com/akira-io/laravel-sisp/issues/104) - [PR #141](https://github.com/akira-io/laravel-sisp/pull/141)
- [x] [#105 Item inclusion test never observes the generated invoice items](https://github.com/akira-io/laravel-sisp/issues/105)
- [x] [#106 NPM package version is stale relative to the documented release line](https://github.com/akira-io/laravel-sisp/issues/106)
- [x] [#107 Publish tests pass without verifying published artifacts](https://github.com/akira-io/laravel-sisp/issues/107) - [PR #142](https://github.com/akira-io/laravel-sisp/pull/142)
- [x] [#108 Published npm entrypoint points to a missing file](https://github.com/akira-io/laravel-sisp/issues/108) - [PR #143](https://github.com/akira-io/laravel-sisp/pull/143)
- [x] [#110 State-changing HTTP tests assert only the response, not the persisted transaction effects](https://github.com/akira-io/laravel-sisp/issues/110) - [PR #144](https://github.com/akira-io/laravel-sisp/pull/144)
- [x] [#111 withoutFingerprint test checks the wrong fingerprint key](https://github.com/akira-io/laravel-sisp/issues/111) - [PR #145](https://github.com/akira-io/laravel-sisp/pull/145)
- [x] [#112 Generated merchant identifiers are only checked for prefixes, not uniqueness](https://github.com/akira-io/laravel-sisp/issues/112) - [PR #146](https://github.com/akira-io/laravel-sisp/pull/146)
- [x] [#114 Array encryption test does not prove the stored value is encrypted](https://github.com/akira-io/laravel-sisp/issues/114) - [PR #147](https://github.com/akira-io/laravel-sisp/pull/147)
- [x] [#115 Exception default code coverage only asserts one exception](https://github.com/akira-io/laravel-sisp/issues/115) - [PR #148](https://github.com/akira-io/laravel-sisp/pull/148)
- [x] [#116 Invoice rendering test does not assert invoice data is included](https://github.com/akira-io/laravel-sisp/issues/116) - [PR #149](https://github.com/akira-io/laravel-sisp/pull/149)
- [x] [#117 Package license metadata contradicts project documentation](https://github.com/akira-io/laravel-sisp/issues/117) - [PR #150](https://github.com/akira-io/laravel-sisp/pull/150)
- [x] [#118 Payment response error tests do not assert the error payload](https://github.com/akira-io/laravel-sisp/issues/118) - [PR #151](https://github.com/akira-io/laravel-sisp/pull/151)
- [x] [#119 Placeholder test provides no application coverage](https://github.com/akira-io/laravel-sisp/issues/119) - [PR #153](https://github.com/akira-io/laravel-sisp/pull/153)
- [x] [#120 Callback test description contradicts its status assertion](https://github.com/akira-io/laravel-sisp/issues/120) - [PR #154](https://github.com/akira-io/laravel-sisp/pull/154)
- [x] [#121 Install command tests write real project files and publish targets](https://github.com/akira-io/laravel-sisp/issues/121) - [PR #152](https://github.com/akira-io/laravel-sisp/pull/152)
- [x] [#122 Optional Inertia fallback branch is not actually exercised](https://github.com/akira-io/laravel-sisp/issues/122) - [PR #155](https://github.com/akira-io/laravel-sisp/pull/155)
- [x] [#123 Provider boot in the test mutates Laravel's global factory-name guesser without restoring it](https://github.com/akira-io/laravel-sisp/issues/123) - [PR #156](https://github.com/akira-io/laravel-sisp/pull/156)
- [x] [#124 Transaction query assertion is tied to SQLite-style SQL quoting](https://github.com/akira-io/laravel-sisp/issues/124) - [PR #157](https://github.com/akira-io/laravel-sisp/pull/157)

## Validation before merge

- [x] All issue PRs merged into `milestone/v0.7.0`
- [x] `composer test` passes on `milestone/v0.7.0`
- [x] Changelog/release notes reviewed if needed





















