### PR TITLE
test(install): assert published artifacts

### DIFF
--- a/tests/Commands/LaravelSispInstallCommandForceTest.php
+++ b/tests/Commands/LaravelSispInstallCommandForceTest.php
@@ -10,23 +10,27 @@ it('publishes inertia/vue/assets/blade with force', function (): void {
         'sisp-inertia-components' => [
             'source' => __DIR__.'/../../resources/js/react/pages/payment-response.tsx',
             'target' => resource_path('js/pages/sisp/payment-response.tsx'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-vue-components' => [
             'source' => __DIR__.'/../../resources/js/vue/pages/PaymentResponse.vue',
             'target' => resource_path('js/pages/sisp/PaymentResponse.vue'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-assets' => [
             'source' => __DIR__.'/../../resources/css/sisp.css',
             'target' => public_path('vendor/sisp/css/sisp.css'),
+            'targetDirectory' => public_path('vendor/sisp/css'),
         ],
         'sisp-views' => [
             'source' => __DIR__.'/../../resources/views/payment-response.blade.php',
             'target' => resource_path('views/vendor/sisp/payment-response.blade.php'),
+            'targetDirectory' => resource_path('views/vendor/sisp'),
         ],
     ];
 
     withInstallCommandFsLock(function () use ($targets): void {
-        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+        withPublishedPathBackups(array_unique(array_column($targets, 'targetDirectory')), function () use ($targets): void {
             foreach ($targets as $tag => $paths) {
                 File::ensureDirectoryExists(dirname($paths['target']));
                 file_put_contents($paths['target'], 'stale');

--- a/tests/Commands/LaravelSispInstallCommandForceTest.php
+++ b/tests/Commands/LaravelSispInstallCommandForceTest.php
@@ -2,16 +2,40 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 
 it('publishes inertia/vue/assets/blade with force', function (): void {
-    $cmd = resolve(LaravelSispInstallCommand::class);
-    $ref = new ReflectionClass($cmd);
+    $targets = [
+        'sisp-inertia-components' => [
+            'source' => __DIR__.'/../../resources/js/react/pages/payment-response.tsx',
+            'target' => resource_path('js/pages/sisp/payment-response.tsx'),
+        ],
+        'sisp-vue-components' => [
+            'source' => __DIR__.'/../../resources/js/vue/pages/PaymentResponse.vue',
+            'target' => resource_path('js/pages/sisp/PaymentResponse.vue'),
+        ],
+        'sisp-assets' => [
+            'source' => __DIR__.'/../../resources/css/sisp.css',
+            'target' => public_path('vendor/sisp/css/sisp.css'),
+        ],
+        'sisp-views' => [
+            'source' => __DIR__.'/../../resources/views/payment-response.blade.php',
+            'target' => resource_path('views/vendor/sisp/payment-response.blade.php'),
+        ],
+    ];
 
-    foreach (['publishInertiaComponents', 'publishVueComponents', 'publishAssets', 'publishBladeViews'] as $method) {
-        $m = $ref->getMethod($method);
-        $m->invoke($cmd, true);
-    }
+    withInstallCommandFsLock(function () use ($targets): void {
+        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+            foreach ($targets as $tag => $paths) {
+                File::ensureDirectoryExists(dirname($paths['target']));
+                file_put_contents($paths['target'], 'stale');
 
-    expect(true)->toBeTrue();
+                expect(Artisan::call('vendor:publish', ['--tag' => $tag]))->toBe(0)
+                    ->and(file_get_contents($paths['target']))->toBe('stale')
+                    ->and(Artisan::call('vendor:publish', ['--tag' => $tag, '--force' => true]))->toBe(0)
+                    ->and(file_get_contents($paths['target']))->toBe(file_get_contents($paths['source']));
+            }
+        });
+    });
 });

--- a/tests/Commands/LaravelSispInstallCommandMoreTest.php
+++ b/tests/Commands/LaravelSispInstallCommandMoreTest.php
@@ -2,18 +2,48 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Illuminate\Support\Facades\Artisan;
 
 it('publishes config and migrations with and without force', function (): void {
-    $cmd = resolve(LaravelSispInstallCommand::class);
-    $ref = new ReflectionClass($cmd);
+    $configPath = config_path('sisp.php');
+    $migrationDirectory = database_path('migrations');
 
-    foreach ([false, true] as $force) {
-        foreach (['publishConfig', 'publishMigrations'] as $method) {
-            $m = $ref->getMethod($method);
-            $m->invoke($cmd, $force);
-        }
-    }
+    withInstallCommandFsLock(function () use ($configPath, $migrationDirectory): void {
+        withPublishedPathBackups([$configPath, $migrationDirectory], function () use ($configPath): void {
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-config', '--force' => true]))->toBe(0)
+                ->and($configPath)->toBeFile()
+                ->and(file_get_contents($configPath))->toBe(file_get_contents(__DIR__.'/../../config/sisp.php'));
 
-    expect(true)->toBeTrue();
+            file_put_contents($configPath, 'stale');
+
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-config']))->toBe(0)
+                ->and(file_get_contents($configPath))->toBe('stale')
+                ->and(Artisan::call('vendor:publish', ['--tag' => 'sisp-config', '--force' => true]))->toBe(0)
+                ->and(file_get_contents($configPath))->toBe(file_get_contents(__DIR__.'/../../config/sisp.php'));
+
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-migrations', '--force' => true]))->toBe(0);
+
+            $migrationPath = publishedSispMigrationPath();
+            expect($migrationPath)->toBeString()
+                ->and($migrationPath)->toBeFile()
+                ->and(file_get_contents($migrationPath))->toBe(file_get_contents(__DIR__.'/../../database/migrations/create_laravel_sisp_table.php'));
+
+            file_put_contents($migrationPath, 'stale');
+
+            expect(Artisan::call('vendor:publish', ['--tag' => 'sisp-migrations']))->toBe(0)
+                ->and(file_get_contents($migrationPath))->toBe('stale')
+                ->and(Artisan::call('vendor:publish', ['--tag' => 'sisp-migrations', '--force' => true]))->toBe(0)
+                ->and(file_get_contents($migrationPath))->toBe(file_get_contents(__DIR__.'/../../database/migrations/create_laravel_sisp_table.php'));
+        });
+    });
 });
+
+function publishedSispMigrationPath(): string
+{
+    $matches = glob(database_path('migrations/*create_laravel_sisp_table.php'));
+
+    expect($matches)->not->toBeFalse()
+        ->and($matches)->not->toBeEmpty();
+
+    return reset($matches);
+}

--- a/tests/Commands/LaravelSispInstallCommandPublishTest.php
+++ b/tests/Commands/LaravelSispInstallCommandPublishTest.php
@@ -10,23 +10,27 @@ it('publishes blade views, inertia components, vue components and assets', funct
         'sisp-views' => [
             'source' => __DIR__.'/../../resources/views/payment-form.blade.php',
             'target' => resource_path('views/vendor/sisp/payment-form.blade.php'),
+            'targetDirectory' => resource_path('views/vendor/sisp'),
         ],
         'sisp-inertia-components' => [
             'source' => __DIR__.'/../../resources/js/react/pages/payment-form.tsx',
             'target' => resource_path('js/pages/sisp/payment-form.tsx'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-vue-components' => [
             'source' => __DIR__.'/../../resources/js/vue/pages/PaymentForm.vue',
             'target' => resource_path('js/pages/sisp/PaymentForm.vue'),
+            'targetDirectory' => resource_path('js/pages/sisp'),
         ],
         'sisp-assets' => [
             'source' => __DIR__.'/../../resources/css/sisp.css',
             'target' => public_path('vendor/sisp/css/sisp.css'),
+            'targetDirectory' => public_path('vendor/sisp/css'),
         ],
     ];
 
     withInstallCommandFsLock(function () use ($targets): void {
-        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+        withPublishedPathBackups(array_unique(array_column($targets, 'targetDirectory')), function () use ($targets): void {
             foreach ($targets as $tag => $paths) {
                 File::delete($paths['target']);
 

--- a/tests/Commands/LaravelSispInstallCommandPublishTest.php
+++ b/tests/Commands/LaravelSispInstallCommandPublishTest.php
@@ -2,15 +2,38 @@
 
 declare(strict_types=1);
 
-use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 
 it('publishes blade views, inertia components, vue components and assets', function (): void {
-    $cmd = resolve(LaravelSispInstallCommand::class);
-    $ref = new ReflectionClass($cmd);
+    $targets = [
+        'sisp-views' => [
+            'source' => __DIR__.'/../../resources/views/payment-form.blade.php',
+            'target' => resource_path('views/vendor/sisp/payment-form.blade.php'),
+        ],
+        'sisp-inertia-components' => [
+            'source' => __DIR__.'/../../resources/js/react/pages/payment-form.tsx',
+            'target' => resource_path('js/pages/sisp/payment-form.tsx'),
+        ],
+        'sisp-vue-components' => [
+            'source' => __DIR__.'/../../resources/js/vue/pages/PaymentForm.vue',
+            'target' => resource_path('js/pages/sisp/PaymentForm.vue'),
+        ],
+        'sisp-assets' => [
+            'source' => __DIR__.'/../../resources/css/sisp.css',
+            'target' => public_path('vendor/sisp/css/sisp.css'),
+        ],
+    ];
 
-    foreach (['publishBladeViews', 'publishInertiaComponents', 'publishVueComponents', 'publishAssets'] as $method) {
-        $m = $ref->getMethod($method);
-        $m->invoke($cmd, false);
-        expect(true)->toBeTrue();
-    }
+    withInstallCommandFsLock(function () use ($targets): void {
+        withPublishedPathBackups(array_column($targets, 'target'), function () use ($targets): void {
+            foreach ($targets as $tag => $paths) {
+                File::delete($paths['target']);
+
+                expect(Artisan::call('vendor:publish', ['--tag' => $tag]))->toBe(0)
+                    ->and($paths['target'])->toBeFile()
+                    ->and(file_get_contents($paths['target']))->toBe(file_get_contents($paths['source']));
+            }
+        });
+    });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -44,3 +44,64 @@ function withFileBackups(array $paths, callable $callback): void
         }
     }
 }
+
+function withPublishedPathBackups(array $paths, callable $callback): void
+{
+    $snapshots = [];
+    foreach ($paths as $path) {
+        $snapshots[$path] = snapshotPublishedPath($path);
+    }
+
+    try {
+        $callback();
+    } finally {
+        foreach ($snapshots as $path => $snapshot) {
+            restorePublishedPath($path, $snapshot);
+        }
+    }
+}
+
+function snapshotPublishedPath(string $path): array
+{
+    if (! file_exists($path)) {
+        return ['type' => 'missing'];
+    }
+
+    if (is_file($path)) {
+        return [
+            'type' => 'file',
+            'contents' => file_get_contents($path),
+        ];
+    }
+
+    $snapshotPath = sys_get_temp_dir().'/sisp-publish-snapshot-'.bin2hex(random_bytes(8));
+    Illuminate\Support\Facades\File::copyDirectory($path, $snapshotPath);
+
+    return [
+        'type' => 'directory',
+        'path' => $snapshotPath,
+    ];
+}
+
+function restorePublishedPath(string $path, array $snapshot): void
+{
+    if (is_dir($path)) {
+        Illuminate\Support\Facades\File::deleteDirectory($path);
+    } elseif (is_file($path)) {
+        unlink($path);
+    }
+
+    if ($snapshot['type'] === 'missing') {
+        return;
+    }
+
+    if ($snapshot['type'] === 'file') {
+        Illuminate\Support\Facades\File::ensureDirectoryExists(dirname($path));
+        file_put_contents($path, $snapshot['contents']);
+
+        return;
+    }
+
+    Illuminate\Support\Facades\File::copyDirectory($snapshot['path'], $path);
+    Illuminate\Support\Facades\File::deleteDirectory($snapshot['path']);
+}


### PR DESCRIPTION
## Summary

- Replaces unconditional publish test assertions with filesystem assertions for the published files.
- Verifies non-force publish preserves existing destination content.
- Verifies force publish overwrites stale destination content for config, migrations, views, React/Vue components, and assets.
- Adds backup/restore helpers so publish tests do not leave generated artifacts in the workspace.

Fixes #107

## Validation

- `./vendor/bin/pest tests/Commands/LaravelSispInstallCommandPublishTest.php tests/Commands/LaravelSispInstallCommandForceTest.php tests/Commands/LaravelSispInstallCommandMoreTest.php --compact`
- `composer test`
