### PR TITLE
fix(package): remove missing node entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "laravel-sisp",
   "version": "0.0.0",
   "description": "[![Latest Version on Packagist](https://img.shields.io/packagist/v/akira-io/laravel-sisp.svg?style=flat-square)](https://packagist.org/packages/akira-io/laravel-sisp) [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/akira-io/laravel-sisp/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/akira-io/laravel-sisp/actions?query=workflow%3Arun-tests+branch%3Amain) [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/akira-io/laravel-sisp/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/akira-io/laravel-sisp/actions?query=workflow%3A\"Fix+PHP+code+style+issues\"+branch%3Amain) [![Total Downloads](https://img.shields.io/packagist/dt/akira-io/laravel-sisp.svg?style=flat-square)](https://packagist.org/packages/akira-io/laravel-sisp)",
-  "main": "index.js",
   "directories": {
     "test": "tests"
   },

--- a/tests/PackageMetadataTest.php
+++ b/tests/PackageMetadataTest.php
@@ -6,5 +6,6 @@ it('marks the node manifest as private tooling metadata', function (): void {
     $package = json_decode(file_get_contents(dirname(__DIR__).'/package.json'), true, flags: JSON_THROW_ON_ERROR);
 
     expect($package['private'] ?? false)->toBeTrue()
+        ->and($package)->not->toHaveKey('main')
         ->and($package['scripts'] ?? [])->not->toHaveKey('release');
 });


### PR DESCRIPTION
## Summary

- Removes the stale `main: index.js` entry from the private Node tooling manifest.
- Extends the package metadata test so the private manifest cannot reintroduce a package-root entrypoint without an explicit file.

Fixes #108

## Validation

- `./vendor/bin/pest tests/PackageMetadataTest.php --compact`
- `composer test`
