### PR TITLE
test(http): assert transaction side effects

### DIFF
--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -65,6 +65,15 @@ it('handles POST callback and redirects to GET with ref', function (): void {
 
     $this->post(route('sisp.callback'), $payload->toArray())
         ->assertRedirect(route('sisp.callback', ['ref' => 'MR-G2']));
+
+    $t->refresh();
+
+    expect($t->status->value)->toBe('completed')
+        ->and($t->transaction_id)->toBe($payload->transactionID)
+        ->and($t->message_type)->toBe($payload->messageType)
+        ->and($t->merchant_response)->toBe($payload->merchantResponse)
+        ->and($t->response_code)->toBe($payload->merchantRespCp)
+        ->and($t->fingerprint)->toBe($payload->fingerprint);
 });
 
 it('rejects invalid callback payload before transaction lookups', function (): void {

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Akira\Sisp\Models\Transaction;
+
 it('creates transaction and renders payment form', function (): void {
     config()->set('sisp.rate_limiting.enabled', false);
 
@@ -22,11 +24,24 @@ it('creates transaction and renders payment form', function (): void {
     $response->assertOk();
     $response->assertSee('sisp-payment-form');
     $response->assertSee(trans('sisp::payment.manual_redirect_button'));
+
+    $transaction = Transaction::query()->sole();
+
+    expect($transaction->amount)->toBe(100.0)
+        ->and($transaction->currency)->toBe('132')
+        ->and($transaction->status->value)->toBe('pending')
+        ->and($transaction->customer_name)->toBe('John')
+        ->and($transaction->customer_email)->toBe('john@example.test')
+        ->and($transaction->merchant_ref)->not->toBe('')
+        ->and($transaction->merchant_session)->not->toBe('')
+        ->and($transaction->items)->toHaveCount(1)
+        ->and($transaction->items->first()->product_name)->toBe('Test')
+        ->and($transaction->items->first()->quantity)->toBe(1)
+        ->and((float) $transaction->items->first()->total_price)->toBe(100.0);
 });
 
 it('blocks duplicate transactions via middleware', function (): void {
-    // Existing processed transaction
-    Akira\Sisp\Models\Transaction::factory()->create([
+    Transaction::factory()->create([
         'merchant_ref' => 'MR-DUP',
         'merchant_session' => 'MS-DUP',
         'status' => 'completed',

--- a/tests/Http/RetryPaymentControllerTest.php
+++ b/tests/Http/RetryPaymentControllerTest.php
@@ -9,9 +9,19 @@ it('retries payment for an existing transaction', function (): void {
         'amount' => 123.0,
         'currency' => '132',
         'status' => 'failed',
+        'merchant_session' => 'old-session',
+        'transaction_code' => '1',
     ]);
 
     $this->post(route('sisp.retry-payment'), [
         'transaction_id' => $t->id,
     ])->assertOk();
+
+    $t->refresh();
+
+    expect($t->merchant_session)->not->toBe('old-session')
+        ->and($t->merchant_session)->not->toBe('')
+        ->and($t->amount)->toBe(123.0)
+        ->and($t->currency)->toBe('132')
+        ->and($t->status->value)->toBe('failed');
 });


### PR DESCRIPTION
## Summary

- Adds persisted transaction assertions to the payment HTTP flow.
- Verifies signed callbacks store gateway result fields and complete the transaction.
- Verifies retry requests update the merchant session while preserving transaction amount, currency, and status.

Fixes #110

## Validation

- `./vendor/bin/pest tests/Http/PaymentControllerTest.php tests/Http/CallbackControllerTest.php tests/Http/RetryPaymentControllerTest.php --compact`
- `composer test`
