### PR TITLE
fix(callback): strip serialized fingerprint key

### DIFF
--- a/src/ValueObjects/CallbackPayload.php
+++ b/src/ValueObjects/CallbackPayload.php
@@ -86,7 +86,7 @@ final readonly class CallbackPayload
     public function withoutFingerprint(): array
     {
         $data = $this->toArray();
-        unset($data['fingerprint']);
+        unset($data['resultFingerPrint']);
 
         return $data;
     }

--- a/tests/ValueObjects/CallbackPayloadTest.php
+++ b/tests/ValueObjects/CallbackPayloadTest.php
@@ -56,5 +56,7 @@ it('withoutFingerprint removes fingerprint key from array', function (): void {
     ]);
 
     $arr = $vo->withoutFingerprint();
-    expect($arr)->not->toHaveKey('fingerprint');
+    expect($arr)->not->toHaveKey('resultFingerPrint')
+        ->and($arr['merchantRespMerchantRef'])->toBe('R2')
+        ->and($arr['merchantRespTid'])->toBe('T2');
 });


### PR DESCRIPTION
## Summary

- Fixes `CallbackPayload::withoutFingerprint()` to remove the serialized gateway key `resultFingerPrint`.
- Updates the regression test to assert the contract key is removed while other callback fields remain present.

Fixes #111

## Validation

- `./vendor/bin/pest tests/ValueObjects/CallbackPayloadTest.php --compact`
- `composer test`
