### PR TITLE
test(exceptions): assert default status codes

### DIFF
--- a/tests/Exceptions/ExceptionsTest.php
+++ b/tests/Exceptions/ExceptionsTest.php
@@ -6,6 +6,7 @@ use Akira\Sisp\Exceptions\BlacklistedIdentifierException;
 use Akira\Sisp\Exceptions\InvalidPaymentResponseException;
 use Akira\Sisp\Exceptions\RateLimitExceededException;
 use Akira\Sisp\Exceptions\TransactionNotFoundException;
+use Symfony\Component\HttpFoundation\Response;
 
 it('instantiates custom exceptions with default codes', function (): void {
     $e1 = new RateLimitExceededException();
@@ -15,7 +16,10 @@ it('instantiates custom exceptions with default codes', function (): void {
 
     expect($e1->getCode())->toBe(429)
         ->and($e1->getMessage())->not->toBe('')
+        ->and($e2->getCode())->toBe(Response::HTTP_BAD_REQUEST)
         ->and($e2->getMessage())->not->toBe('')
+        ->and($e3->getCode())->toBe(Response::HTTP_UNPROCESSABLE_ENTITY)
         ->and($e3->getMessage())->not->toBe('')
+        ->and($e4->getCode())->toBe(Response::HTTP_FORBIDDEN)
         ->and($e4->getMessage())->toBe('Blocked');
 });


### PR DESCRIPTION
## Summary

- Extends the custom exception default-code test to assert every instantiated exception code.
- Covers `TransactionNotFoundException`, `InvalidPaymentResponseException`, and `BlacklistedIdentifierException` in addition to the existing rate-limit assertion.

Fixes #115

## Validation

- `./vendor/bin/pest tests/Exceptions/ExceptionsTest.php --compact`
- `composer test`
