### PR TITLE
test(invoice): assert inertia invoice props

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,18 +55,6 @@ parameters:
 			path: src/Actions/RenderPaymentResponseAction.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$invoice_number\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/RenderPaymentResponseAction.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$pdf_url\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/RenderPaymentResponseAction.php
-
-		-
 			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$currency\.$#'
 			identifier: property.notFound
 			count: 1

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Enums\ErrorMessageType;
+use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Contracts\View\View;
 use Inertia\Inertia;
@@ -52,8 +53,11 @@ final readonly class RenderPaymentResponseAction
             'error' => $this->getStructuredError($transaction),
             'translations' => $this->getTranslations->handle(),
             'allowRetry' => $this->canRetryPayment->handle($transaction),
-            'invoice' => $invoice ? [
+            'invoice' => $invoice instanceof Invoice ? [
                 'invoice_number' => $invoice->invoice_number,
+                'invoice_date' => $invoice->invoice_date->toDateString(),
+                'status' => $invoice->status->value,
+                'pdf_path' => $invoice->pdf_path,
                 'pdf_url' => $invoice->pdf_url,
             ] : null,
             'payload' => $payload,

--- a/tests/Actions/RenderPaymentResponseActionInvoiceTest.php
+++ b/tests/Actions/RenderPaymentResponseActionInvoiceTest.php
@@ -5,18 +5,30 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\RenderPaymentResponseAction;
 use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
+use Inertia\Support\Header;
 
 it('renderInertia includes invoice data when present', function (): void {
     $t = Transaction::factory()->create();
 
-    $invoice = Invoice::query()->create([
+    Invoice::query()->create([
         'transaction_id' => $t->id,
         'invoice_number' => 'INV-000001',
-        'invoice_date' => now()->toDateString(),
+        'invoice_date' => '2026-05-23',
         'status' => 'pending',
         'pdf_path' => 'invoices/test.pdf',
     ]);
 
     $resp = resolve(RenderPaymentResponseAction::class)->renderInertia($t, []);
-    expect($resp)->toBeInstanceOf(Inertia\Response::class);
+    $request = request();
+    $request->headers->set(Header::INERTIA, 'true');
+    $data = $resp->toResponse($request)->getData(true);
+
+    expect($resp)->toBeInstanceOf(Inertia\Response::class)
+        ->and($data['props']['invoice'])->toMatchArray([
+            'invoice_number' => 'INV-000001',
+            'invoice_date' => '2026-05-23',
+            'status' => 'pending',
+            'pdf_path' => 'invoices/test.pdf',
+        ])
+        ->and($data['props']['invoice']['pdf_url'])->toContain('invoices/test.pdf');
 });


### PR DESCRIPTION
## Summary

- Expands Inertia invoice props with invoice date, status, and PDF path alongside the existing number and URL.
- Updates the invoice rendering test to inspect the resolved Inertia JSON payload instead of only checking the response type.
- Removes obsolete PHPStan baseline ignores made unnecessary by narrowing the invoice relation to the Invoice model.

Fixes #116

## Validation

- `./vendor/bin/pest tests/Actions/RenderPaymentResponseActionInvoiceTest.php --compact`
- `composer test`
