### PR TITLE
fix(package): align node license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "vite-plugin-laravel": "^0.3.1"
   },

--- a/tests/PackageMetadataTest.php
+++ b/tests/PackageMetadataTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 it('marks the node manifest as private tooling metadata', function (): void {
     $package = json_decode(file_get_contents(dirname(__DIR__).'/package.json'), true, flags: JSON_THROW_ON_ERROR);
+    $composer = json_decode(file_get_contents(dirname(__DIR__).'/composer.json'), true, flags: JSON_THROW_ON_ERROR);
 
     expect($package['private'] ?? false)->toBeTrue()
         ->and($package)->not->toHaveKey('main')
+        ->and($package['license'])->toBe($composer['license'])
         ->and($package['scripts'] ?? [])->not->toHaveKey('release');
 });


### PR DESCRIPTION
## Summary

- Aligns `package.json` license metadata with the Composer package and README license.
- Extends the package metadata test to enforce license consistency between `package.json` and `composer.json`.

Fixes #117

## Validation

- `./vendor/bin/pest tests/PackageMetadataTest.php --compact`
- `composer test`
