### PR TITLE
test(response): assert payment error payload

### DIFF
--- a/tests/Actions/RenderPaymentResponseActionNullErrorTest.php
+++ b/tests/Actions/RenderPaymentResponseActionNullErrorTest.php
@@ -11,5 +11,6 @@ it('getStructuredError returns null for unknown message type', function (): void
     ]);
 
     $view = resolve(RenderPaymentResponseAction::class)->renderBlade($t, []);
-    expect($view->name())->toBe('sisp::payment-response');
+    expect($view->name())->toBe('sisp::payment-response')
+        ->and($view->getData()['error'])->toBeNull();
 });

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -12,7 +12,15 @@ it('renders blade view with structured error when message type is error', functi
     ]);
 
     $view = resolve(RenderPaymentResponseAction::class)->renderBlade($t, ['foo' => 'bar']);
-    expect($view->name())->toBe('sisp::payment-response');
+    $error = $view->getData()['error'];
+
+    expect($view->name())->toBe('sisp::payment-response')
+        ->and($error)->toMatchArray([
+            'code' => ErrorMessageType::invalidAmount->value,
+            'label' => 'Invalid amount',
+            'category' => 'validation',
+            'action' => 'check-payment-details',
+        ]);
 });
 
 it('renderInertia falls back to blade when Inertia is absent', function (): void {
@@ -21,7 +29,6 @@ it('renderInertia falls back to blade when Inertia is absent', function (): void
     ]);
 
     $result = resolve(RenderPaymentResponseAction::class)->renderInertia($t, ['a' => 1]);
-    // Inertia is available in this testbench; expect Inertia response
     expect($result)->toBeInstanceOf(Inertia\Response::class);
 });
 

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -17,7 +17,7 @@ it('renders blade view with structured error when message type is error', functi
     expect($view->name())->toBe('sisp::payment-response')
         ->and($error)->toMatchArray([
             'code' => ErrorMessageType::invalidAmount->value,
-            'label' => 'Invalid amount',
+            'label' => ErrorMessageType::invalidAmount->label(),
             'category' => 'validation',
             'action' => 'check-payment-details',
         ]);


### PR DESCRIPTION
## Summary

- Adds explicit Blade view data assertions for known payment error message types.
- Verifies unknown message types produce a null structured error payload.
- Removes an obsolete narrative comment from the touched response test.

Fixes #118

## Validation

- `./vendor/bin/pest tests/Actions/RenderPaymentResponseActionTest.php tests/Actions/RenderPaymentResponseActionNullErrorTest.php --compact`
- `composer test`
