### PR TITLE
test(install): verify project files are restored

### DIFF
--- a/tests/Commands/LaravelSispInstallCommandHandleTest.php
+++ b/tests/Commands/LaravelSispInstallCommandHandleTest.php
@@ -8,17 +8,14 @@ it('drives handle() through inertia prompts via config toggles', function (): vo
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
-            // Ensure inertia is detected via vite config containing react
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteTs);
             file_put_contents($viteJs, "export default { plugins: ['react'] }");
 
-            // Drive confirmations using config (test mode)
             config()->set('sisp.tests.publish_config', true);
             config()->set('sisp.tests.force_config', false);
             config()->set('sisp.tests.publish_migrations', true);
             config()->set('sisp.tests.force_migrations', false);
-            // Avoid publishing to keep tests fast/stable under parallel
             config()->set('sisp.tests.publish_inertia', false);
             config()->set('sisp.tests.force_inertia', false);
             config()->set('sisp.tests.run_migrations', true);
@@ -35,8 +32,7 @@ it('drives handle() through blade prompts via config toggles', function (): void
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
-            // Ensure blade is detected (no react/inertia indicators)
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteJs);
             @unlink($viteTs);
 

--- a/tests/Commands/LaravelSispInstallCommandTest.php
+++ b/tests/Commands/LaravelSispInstallCommandTest.php
@@ -8,8 +8,7 @@ use Illuminate\Support\Facades\Artisan;
 it('detects inertia stack when composer requires inertia', function (): void {
     withInstallCommandFsLock(function (): void {
         $composerPath = base_path('composer.json');
-        withFileBackups([$composerPath], function () use ($composerPath): void {
-            // Create a composer.json that includes inertia
+        withInstallCommandProjectBackups(function () use ($composerPath): void {
             file_put_contents($composerPath, json_encode([
                 'require' => [
                     'inertiajs/inertia-laravel' => '^2.0',
@@ -33,17 +32,15 @@ it('falls back to blade when no inertia indicators are present', function (): vo
         $inertiaConfig = base_path('config/inertia.php');
         $composerPath = base_path('composer.json');
 
-        withFileBackups([$viteTs, $viteJs, $inertiaConfig, $composerPath], function () use (
+        withInstallCommandProjectBackups(function () use (
             $viteTs,
             $viteJs,
             $inertiaConfig,
             $composerPath
         ): void {
-            // Ensure vite configs do not contain react
             @unlink($viteTs);
             @unlink($viteJs);
             @unlink($inertiaConfig);
-            // Overwrite composer.json without inertia requirement
             file_put_contents($composerPath, json_encode([
                 'require' => [
                     'php' => '^8.4',
@@ -70,7 +67,7 @@ it('detects inertia stack via vite config containing react', function (): void {
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteTs);
             file_put_contents($viteJs, "export default { plugins: ['react'] }");
             $cmd = resolve(LaravelSispInstallCommand::class);
@@ -86,7 +83,7 @@ it('detects inertia stack via vite.config.ts containing react', function (): voi
     withInstallCommandFsLock(function (): void {
         $viteJs = base_path('vite.config.js');
         $viteTs = base_path('vite.config.ts');
-        withFileBackups([$viteJs, $viteTs], function () use ($viteJs, $viteTs): void {
+        withInstallCommandProjectBackups(function () use ($viteJs, $viteTs): void {
             @unlink($viteJs);
             file_put_contents($viteTs, "export default { plugins: ['react'] }");
             $cmd = resolve(LaravelSispInstallCommand::class);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -48,8 +48,10 @@ function withFileBackups(array $paths, callable $callback): void
 function withPublishedPathBackups(array $paths, callable $callback): void
 {
     $snapshots = [];
+    $fingerprints = [];
     foreach ($paths as $path) {
         $snapshots[$path] = snapshotPublishedPath($path);
+        $fingerprints[$path] = pathSnapshotFingerprint($path);
     }
 
     try {
@@ -57,8 +59,24 @@ function withPublishedPathBackups(array $paths, callable $callback): void
     } finally {
         foreach ($snapshots as $path => $snapshot) {
             restorePublishedPath($path, $snapshot);
+            expect(pathSnapshotFingerprint($path))->toBe($fingerprints[$path]);
         }
     }
+}
+
+function withInstallCommandProjectBackups(callable $callback): void
+{
+    withPublishedPathBackups([
+        base_path('composer.json'),
+        base_path('vite.config.js'),
+        base_path('vite.config.ts'),
+        base_path('config/inertia.php'),
+        config_path('sisp.php'),
+        database_path('migrations'),
+        resource_path('views/vendor/sisp'),
+        resource_path('js/pages/sisp'),
+        public_path('vendor/sisp/css'),
+    ], $callback);
 }
 
 function snapshotPublishedPath(string $path): array
@@ -104,4 +122,38 @@ function restorePublishedPath(string $path, array $snapshot): void
 
     Illuminate\Support\Facades\File::copyDirectory($snapshot['path'], $path);
     Illuminate\Support\Facades\File::deleteDirectory($snapshot['path']);
+}
+
+function pathSnapshotFingerprint(string $path): array
+{
+    if (! file_exists($path)) {
+        return ['type' => 'missing'];
+    }
+
+    if (is_file($path)) {
+        return [
+            'type' => 'file',
+            'hash' => hash_file('sha256', $path),
+        ];
+    }
+
+    $entries = [];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST,
+    );
+
+    foreach ($iterator as $entry) {
+        $relativePath = mb_substr((string) $entry->getPathname(), mb_strlen($path) + 1);
+        $entries[] = $entry->isDir()
+            ? 'dir:'.$relativePath
+            : 'file:'.$relativePath.':'.hash_file('sha256', $entry->getPathname());
+    }
+
+    sort($entries);
+
+    return [
+        'type' => 'directory',
+        'entries' => $entries,
+    ];
 }


### PR DESCRIPTION
Problem: Fixes #121. Install command tests mutate workspace-level files and publish targets without proving cleanup restores the original state.

Root cause: The tests only backed up the immediate files they edited, while install flows can touch config, migrations, view assets, JS publish directories, and public assets. The backup helper also restored paths but did not assert that the restored state matched the pre-test snapshot.

Solution: Added a shared install-command project backup helper that snapshots every known install/publish target and verifies a fingerprint after restore. Updated install command tests to use that full workspace snapshot instead of narrower file-only backups.

Validation:
- ./vendor/bin/pest tests/Commands/LaravelSispInstallCommandTest.php tests/Commands/LaravelSispInstallCommandHandleTest.php tests/Commands/LaravelSispInstallCommandMoreTest.php tests/Commands/LaravelSispInstallCommandPublishTest.php tests/Commands/LaravelSispInstallCommandForceTest.php --compact
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: Test-only change. Roll back the helper and affected tests if the fingerprint assertion proves too strict for a future intentionally stateful publish test.
