### PR TITLE
test(smoke): replace placeholder coverage

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-it('can test', function (): void {
-    expect(true)->toBeTrue();
+it('boots package routes and serves countries data', function (): void {
+    $response = $this->get(route('sisp.countries'));
+
+    $response->assertOk()
+        ->assertJsonPath('cv.numeric', '132')
+        ->assertJsonPath('cv.name', 'Cabo Verde');
 });


### PR DESCRIPTION
Problem: Fixes #119. The placeholder test asserted `true`, so it did not exercise package behavior or catch application regressions.

Root cause: `tests/ExampleTest.php` contained only a tautological assertion and did not boot routes, resolve package services, or execute framework wiring.

Solution: Replaced the placeholder with a smoke test that calls the package `sisp.countries` route and asserts real JSON data from the package response.

Validation:
- ./vendor/bin/pest tests/ExampleTest.php --compact
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: Test-only change. If this smoke test becomes redundant with more specific endpoint coverage, it can be moved or renamed without affecting production code.
