### PR TITLE
test(callback): clarify invalid fingerprint status

### DIFF
--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\HandleCallbackAction;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Enums\SuccessMessageType;
+use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
 use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
@@ -37,7 +38,7 @@ beforeEach(function (): void {
     Facade::clearResolvedInstances();
 });
 
-it('dispatches PaymentFailed and skips status update when fingerprint is invalid', function (): void {
+it('dispatches PaymentFailed and marks the transaction failed when fingerprint is invalid', function (): void {
     app()->instance(Akira\Sisp\Sisp::class, new class
     {
         public function validateCallback(CallbackPayload $payload): bool
@@ -53,6 +54,7 @@ it('dispatches PaymentFailed and skips status update when fingerprint is invalid
         'amount' => 10,
         'currency' => '132',
         'transaction_code' => '8',
+        'status' => TransactionStatus::pending,
     ]);
 
     resolve(HandleCallbackAction::class)->handle(cb_payload(ErrorMessageType::invalidAmount->value));


### PR DESCRIPTION
Problem: Fixes #120. The invalid-fingerprint callback test title said the action skipped the status update, but the assertion expected the transaction to become failed.

Root cause: The test description was stale relative to the current callback contract, making the expected invalid-fingerprint behavior ambiguous.

Solution: Renamed the test to state that invalid fingerprints dispatch PaymentFailed and mark the transaction failed. The setup now also gives the transaction an explicit pending initial status so the status transition is clear.

Validation:
- ./vendor/bin/pest tests/Actions/HandleCallbackActionTest.php --compact
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: Test-only clarification. If the intended contract changes to preserve the original status on invalid fingerprints, this test should be updated with the production behavior in the same PR.
