### PR TITLE
test(inertia): cover response fallback

### DIFF
--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Actions;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\InertiaAvailability;
 use Illuminate\Contracts\View\View;
 use Inertia\Inertia;
 
@@ -16,6 +17,7 @@ final readonly class RenderPaymentResponseAction
         private GetPaymentErrorResponseAction $getErrorResponse,
         private GetPaymentResponseTranslationsAction $getTranslations,
         private CanRetryPaymentAction $canRetryPayment,
+        private InertiaAvailability $inertiaAvailability,
     ) {}
 
     public function renderBlade(Transaction $transaction, array $payload): View
@@ -33,8 +35,8 @@ final readonly class RenderPaymentResponseAction
 
     public function renderInertia(Transaction $transaction, array $payload, string $component = 'Sisp/PaymentResponse'): mixed
     {
-        if (! class_exists(Inertia::class)) {
-            return $this->renderBlade($transaction, $payload); // @codeCoverageIgnore
+        if (! $this->inertiaAvailability->available()) {
+            return $this->renderBlade($transaction, $payload);
         }
 
         $invoice = $transaction->invoice;

--- a/src/Support/InertiaAvailability.php
+++ b/src/Support/InertiaAvailability.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Support;
+
+use Inertia\Inertia;
+
+final readonly class InertiaAvailability
+{
+    public function __construct(private bool $available = true) {}
+
+    public function available(): bool
+    {
+        return $this->available && class_exists(Inertia::class);
+    }
+}

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Akira\Sisp\Actions\RenderPaymentResponseAction;
 use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\InertiaAvailability;
+use Illuminate\Contracts\View\View;
 
 it('renders blade view with structured error when message type is error', function (): void {
     $t = Transaction::factory()->create([
@@ -23,13 +25,26 @@ it('renders blade view with structured error when message type is error', functi
         ]);
 });
 
-it('renderInertia falls back to blade when Inertia is absent', function (): void {
+it('renderInertia returns an inertia response when Inertia is available', function (): void {
     $t = Transaction::factory()->create([
         'message_type' => null,
     ]);
 
     $result = resolve(RenderPaymentResponseAction::class)->renderInertia($t, ['a' => 1]);
     expect($result)->toBeInstanceOf(Inertia\Response::class);
+});
+
+it('renderInertia falls back to blade when Inertia is absent', function (): void {
+    app()->instance(InertiaAvailability::class, new InertiaAvailability(false));
+
+    $t = Transaction::factory()->create([
+        'message_type' => null,
+    ]);
+
+    $result = resolve(RenderPaymentResponseAction::class)->renderInertia($t, ['a' => 1]);
+
+    expect($result)->toBeInstanceOf(View::class)
+        ->and($result->name())->toBe('sisp::payment-response');
 });
 
 it('sets allowRetry to false when 3DS is enabled and transaction is missing required customer data', function (): void {


### PR DESCRIPTION
Problem: Fixes #122. The existing `renderInertia` test claimed to cover the Blade fallback when Inertia is absent, but it actually asserted an Inertia response because Inertia is installed in the testbench.

Root cause: `RenderPaymentResponseAction` checked `class_exists(Inertia::class)` directly, so tests could not force the optional dependency absence path.

Solution: Added a small `InertiaAvailability` seam and injected it into `RenderPaymentResponseAction`. The existing test now documents the available-Inertia path, and a new test binds `InertiaAvailability(false)` to assert the Blade fallback view.

Validation:
- ./vendor/bin/pest tests/Actions/RenderPaymentResponseActionTest.php tests/Actions/RenderPaymentResponseActionNullErrorTest.php --compact
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: Low. The production default still uses `class_exists(Inertia::class)`, and the injected seam only makes the optional dependency branch testable.
