### PR TITLE
test(provider): isolate factory guesser

### DIFF
--- a/tests/Providers/SispServiceProviderTest.php
+++ b/tests/Providers/SispServiceProviderTest.php
@@ -8,24 +8,32 @@ use Akira\Sisp\SispServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 it('registers singletons and factory guesser', function (): void {
-    $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
-    $provider->register();
-    $provider->boot();
+    Factory::guessFactoryNamesUsing(
+        fn (string $modelName): string => 'Original\\Factories\\'.class_basename($modelName).'Factory'
+    );
 
-    expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
-        ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class);
+    withFactoryNameResolverSnapshot(function (): void {
+        $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
+        $provider->register();
+        $provider->boot();
 
-    // Validate factory guesser mapping
-    $guesser = (new class extends Factory
-    {
-        public function definition(): array
-        {
-            return [];
-        }
+        expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
+            ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class)
+            ->and(Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class))->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class)
+            ->and(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Database\\Factories\\UserFactory');
     });
-    $class = Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class);
-    expect($class)->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class);
 
-    $other = Factory::resolveFactoryName('App\\Models\\User');
-    expect($other)->toBe('Database\\Factories\\UserFactory');
+    expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Original\\Factories\\UserFactory');
 });
+
+function withFactoryNameResolverSnapshot(callable $callback): void
+{
+    $property = new ReflectionProperty(Factory::class, 'factoryNameResolver');
+    $previousResolver = $property->getValue();
+
+    try {
+        $callback();
+    } finally {
+        $property->setValue(null, $previousResolver);
+    }
+}

--- a/tests/Providers/SispServiceProviderTest.php
+++ b/tests/Providers/SispServiceProviderTest.php
@@ -8,22 +8,28 @@ use Akira\Sisp\SispServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 it('registers singletons and factory guesser', function (): void {
-    Factory::guessFactoryNamesUsing(
-        fn (string $modelName): string => 'Original\\Factories\\'.class_basename($modelName).'Factory'
-    );
+    $factoryNameBeforeTest = Factory::resolveFactoryName('App\\Models\\User');
 
     withFactoryNameResolverSnapshot(function (): void {
-        $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
-        $provider->register();
-        $provider->boot();
+        Factory::guessFactoryNamesUsing(
+            fn (string $modelName): string => 'Original\\Factories\\'.class_basename($modelName).'Factory'
+        );
 
-        expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
-            ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class)
-            ->and(Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class))->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class)
-            ->and(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Database\\Factories\\UserFactory');
+        withFactoryNameResolverSnapshot(function (): void {
+            $provider = app()->getProvider(SispServiceProvider::class) ?? new SispServiceProvider(app());
+            $provider->register();
+            $provider->boot();
+
+            expect(app()->make(LoadConfig::class))->toBeInstanceOf(LoadConfig::class)
+                ->and(app()->make(Sisp::class))->toBeInstanceOf(Sisp::class)
+                ->and(Factory::resolveFactoryName(Akira\Sisp\Models\Transaction::class))->toBe(Akira\Sisp\Database\Factories\TransactionFactory::class)
+                ->and(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Database\\Factories\\UserFactory');
+        });
+
+        expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Original\\Factories\\UserFactory');
     });
 
-    expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe('Original\\Factories\\UserFactory');
+    expect(Factory::resolveFactoryName('App\\Models\\User'))->toBe($factoryNameBeforeTest);
 });
 
 function withFactoryNameResolverSnapshot(callable $callback): void


### PR DESCRIPTION
Problem: Fixes #123. The provider test booted `SispServiceProvider` directly, which mutates Laravel's global factory name resolver without restoring the previous static state.

Root cause: `Factory::guessFactoryNamesUsing()` stores a static callback. The test asserted the provider-installed resolver but did not isolate the mutation for tests that run afterward.

Solution: Added a scoped test helper that snapshots `Factory::$factoryNameResolver` via reflection and restores it in `finally`. The test now installs a sentinel resolver before booting the provider, verifies the provider mapping inside the scope, and verifies the sentinel resolver is restored afterward.

Validation:
- ./vendor/bin/pest tests/Providers/SispServiceProviderTest.php --compact
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: Test-only isolation. If Laravel exposes a public getter/resetter for this state in a future version, this reflection helper can be replaced with that API.
