### PR TITLE
test(callback): normalize transaction query assertions

### DIFF
--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -25,6 +25,22 @@ function callback_controller_payload(Transaction $transaction, array $overrides 
     ], $overrides)))->toArray();
 }
 
+function callback_query_reads_transactions_table(string $query): bool
+{
+    $normalizedQuery = str_replace(['`', '"', '[', ']'], '', mb_strtolower($query));
+
+    return preg_match('/\bfrom\s+(?:[a-z0-9_]+\.)?transactions\b/', $normalizedQuery) === 1;
+}
+
+it('detects transaction table lookups across database grammars', function (string $query): void {
+    expect(callback_query_reads_transactions_table($query))->toBeTrue();
+})->with([
+    'sqlite quoted table' => ['select * from "transactions" where "merchant_ref" = ?'],
+    'mysql quoted table' => ['select * from `transactions` where `merchant_ref` = ?'],
+    'unquoted table' => ['select * from transactions where merchant_ref = ?'],
+    'qualified quoted table' => ['select * from `main`.`transactions` where `merchant_ref` = ?'],
+]);
+
 it('redirects when user cancelled flag present', function (): void {
     config()->set('sisp.redirect_url', '/home');
     $this->post(route('sisp.callback'), ['UserCancelled' => true])
@@ -103,7 +119,7 @@ it('rejects invalid callback payload before transaction lookups', function (): v
     $queries = collect(DB::getQueryLog())->pluck('query');
 
     expect($queries->filter(
-        fn (string $query): bool => str_contains(mb_strtolower($query), 'from "transactions"')
+        fn (string $query): bool => callback_query_reads_transactions_table($query)
     ))->toHaveCount(0);
 });
 
@@ -117,9 +133,10 @@ it('skips duplicate lookup when callback payload has no transaction keys', funct
         'timeStamp' => '2024-01-01 00:00:00',
         'currency' => '132',
         'transactionCode' => '1',
-    ]));
+    ]))->toArray();
+    unset($payload['merchantRespMerchantRef'], $payload['merchantRespMerchantSession']);
 
-    $this->post(route('sisp.callback'), $payload->toArray())
+    $this->post(route('sisp.callback'), $payload)
         ->assertRedirect('/home');
 });
 


### PR DESCRIPTION
Problem: Fixes #124. The invalid callback test detected transaction lookups by searching for the exact SQLite-style SQL fragment `from "transactions"`.

Root cause: The assertion was tied to one database grammar. Equivalent MySQL/backtick or unquoted SQL would not be detected.

Solution: Added a grammar-neutral helper that normalizes identifier quotes and detects `from transactions` with optional schema qualification. Added coverage for SQLite-style quotes, MySQL backticks, unquoted names, and qualified table names. While validating the file, also made the no-transaction-keys test actually remove the callback transaction keys before posting.

Validation:
- ./vendor/bin/pest tests/Http/CallbackControllerTest.php --compact
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: Test-only change. If a future query style uses aliases or joins for this lookup, extend the helper with an additional fixture before changing the assertion.
