### PR TITLE
ci(tests): bound aspell install time

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,7 @@ jobs:
           tools: composer:v2
 
       - name: Install Aspell
+        timeout-minutes: 5
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Install dependencies


### PR DESCRIPTION
Problem: The `Install Aspell` step can hang for a long time when the GitHub Actions runner has slow or stuck APT mirrors, blocking the full PHP/Laravel matrix.

Root cause: The step runs `apt-get update` across all runner repositories without a step-level timeout, so a transient network or mirror issue can keep the matrix pending far longer than useful.

Solution: Add `timeout-minutes: 5` to the `Install Aspell` step. This keeps the existing spellcheck dependency but fails fast when the runner environment is unhealthy.

Validation:
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

Risk/rollback: CI-only change. If a healthy runner consistently needs more than 5 minutes for APT, increase the timeout or move spellcheck to a separate non-matrix job.
