### PR TITLE
ci(release): authenticate git-cliff notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
           tool: git-cliff
 
       - name: Generate CHANGELOG
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: git-cliff --config cliff.toml --tag "${{ github.ref_name }}" --output CHANGELOG.md
 
       - name: Commit CHANGELOG
@@ -35,11 +37,14 @@ jobs:
 
       - name: Extract release notes
         id: notes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
+          git-cliff --config cliff.toml --latest --strip all > /tmp/release-notes.md
           {
-            echo 'body<<EOF'
-            git-cliff --config cliff.toml --latest --strip all
-            echo 'EOF'
+            echo 'body<<RELEASE_NOTES_EOF'
+            cat /tmp/release-notes.md
+            echo 'RELEASE_NOTES_EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release


### PR DESCRIPTION
Problem: The `v0.7.0` release workflow failed while extracting release notes because `git-cliff --latest --strip all` tried to call the GitHub API without an authenticated token and received HTTP 403. The failed command also prevented the multiline `$GITHUB_OUTPUT` delimiter from being written.

Root cause: The release workflow uses `git-cliff` with GitHub remote metadata configured in `cliff.toml`, but the `git-cliff` steps did not receive the built-in GitHub Actions token.

Solution: Pass the built-in `${{ github.token }}` as `GITHUB_TOKEN` to both `git-cliff` steps. Also write release notes to a temp file before appending to `$GITHUB_OUTPUT`, so the output block is only emitted after `git-cliff` succeeds.

Validation:
- composer test
- commit-guard scans: comments, chained-if, git diff --check, staged secrets/AI scan

After merge: recreate/push the `v0.7.0` tag on the new `1.x` HEAD so the tag uses this fixed workflow.
