### PR TITLE
test(post-aut-code): assert cached hash reuse

### DIFF
--- a/tests/Actions/PostAutCodeTest.php
+++ b/tests/Actions/PostAutCodeTest.php
@@ -3,10 +3,34 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Actions\PostAutCode;
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\ValueObjects\SispCredentials;
 
 it('generates base64 sha512 of posAutCode', function (): void {
     $action = resolve(PostAutCode::class);
     $expected = base64_encode(hash('sha512', (string) config('sisp.posAutCode'), true));
 
     expect($action->handle())->toBe($expected);
+});
+
+it('resolves credentials once and reuses the hashed value', function (): void {
+    $resolver = new class implements SispCredentialsResolver
+    {
+        public int $calls = 0;
+
+        public function resolve(): SispCredentials
+        {
+            $this->calls++;
+
+            return SispCredentials::from(['posAutCode' => 'SECRET']);
+        }
+    };
+
+    $action = new PostAutCode($resolver);
+    $expected = base64_encode(hash('sha512', 'SECRET', true));
+
+    expect($action->handle())->toBe($expected)
+        ->and($action->handle())->toBe($expected)
+        ->and($action->handle())->toBe($expected)
+        ->and($resolver->calls)->toBe(1);
 });


### PR DESCRIPTION
Problem: Fixes #80. PostAutCode should not recompute the SHA-512/Base64 authorization hash on every handle() call.

Root cause: The implementation already caches the hash in the action lifecycle, but there was no regression coverage proving the resolver is only called once.

Solution: Add a focused regression test with a counting SispCredentialsResolver. The test calls handle() multiple times and asserts the resolved hash is stable while credentials are resolved once.

Validation:
- vendor/bin/pest tests/Actions/PostAutCodeTest.php --compact
- composer test

Risk/rollback: Very low. Test-only change documenting the expected cached lifecycle behavior.
