### PR TITLE
fix(blade): use package scoped layout

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -89,6 +89,8 @@ SISP_USE_INERTIA=false
 
 Renders payment forms using Blade templates.
 
+Package Blade views use the package-scoped `<x-sisp::layouts.app>` layout by default, so they do not require the host application to provide a `layouts.app` view. If you publish the views for customization, keep the package layout component or replace it with your own explicit application layout.
+
 ### Inertia.js
 
 ```env

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -6,7 +6,9 @@
 	<meta name="csrf-token" content="{{ csrf_token() }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{{ config('app.name') }}</title>
-	@vite('resources/css/app.css')
+	@if (file_exists(public_path('build/manifest.json')))
+		@vite('resources/css/app.css')
+	@endif
 	<script>
       if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
           document.documentElement.classList.add('dark');

--- a/resources/views/payment-form.blade.php
+++ b/resources/views/payment-form.blade.php
@@ -1,6 +1,4 @@
-@extends('layouts.app')
-
-@section('content')
+<x-sisp::layouts.app>
 <div class="relative flex min-h-screen flex-col items-center justify-center px-4 py-12">
     <div class="w-full max-w-md">
 
@@ -148,4 +146,4 @@
     }, 1000);
 })();
 </script>
-@endsection
+</x-sisp::layouts.app>

--- a/resources/views/payment-response.blade.php
+++ b/resources/views/payment-response.blade.php
@@ -1,6 +1,4 @@
-@extends('layouts.app')
-
-@section('content')
+<x-sisp::layouts.app>
 <div class="relative flex min-h-screen flex-col items-center justify-center px-4 py-12">
     <div class="w-full max-w-md">
 
@@ -249,4 +247,4 @@
     @endif
 })();
 </script>
-@endsection
+</x-sisp::layouts.app>

--- a/tests/Actions/RenderPaymentFormActionBladeTest.php
+++ b/tests/Actions/RenderPaymentFormActionBladeTest.php
@@ -19,5 +19,6 @@ it('renders blade payment form view', function (): void {
     $req = Sisp::buildRequestPayload($data);
 
     $view = resolve(RenderPaymentFormAction::class)->renderBlade($req);
-    expect($view->name())->toBe('sisp::payment-form');
+    expect($view->name())->toBe('sisp::payment-form')
+        ->and($view->render())->toContain(trans('sisp::payment.manual_redirect_button'));
 });

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -17,6 +17,7 @@ it('renders blade view with structured error when message type is error', functi
     $error = $view->getData()['error'];
 
     expect($view->name())->toBe('sisp::payment-response')
+        ->and($view->render())->toContain('<!DOCTYPE html>')
         ->and($error)->toMatchArray([
             'code' => ErrorMessageType::invalidAmount->value,
             'label' => ErrorMessageType::invalidAmount->label(),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,14 +48,6 @@ abstract class TestCase extends Orchestra
 
         // Set application namespace for Blade component compilation
         $app->singleton('namespace', fn (): string => 'App\\');
-
-        // Ensure a base layout exists for package Blade views extending 'layouts.app'
-        $paths = $app->make(Repository::class)->get('view.paths', []);
-        $testViews = __DIR__.'/resources/views';
-        if (! in_array($testViews, $paths, true)) {
-            $paths[] = $testViews;
-            $app->make(Repository::class)->set('view.paths', $paths);
-        }
     }
 
     protected function defineDatabaseMigrations()

--- a/tests/resources/views/layouts/app.blade.php
+++ b/tests/resources/views/layouts/app.blade.php
@@ -1,1 +1,0 @@
-@yield('content')


### PR DESCRIPTION
Problem: Fixes #78. Package Blade views depended on a host application `layouts.app` view, causing render failures in apps that do not use that convention.

Root cause: `payment-form` and `payment-response` extended `layouts.app`, while tests provided a fake host layout that hid the integration problem. The package layout also required a host Vite manifest.

Solution: Move the payment views to the package-scoped `<x-sisp::layouts.app>` component, make Vite asset loading optional when a manifest exists, remove the fake test host layout, and document the package layout expectation for published/customized views.

Validation:
- vendor/bin/pest tests/Actions/RenderPaymentFormActionBladeTest.php tests/Actions/RenderPaymentResponseActionTest.php --compact
- composer test

Risk/rollback: Low. Blade rendering now uses the package layout by default. Consumers with already-published old views may need to republish or update their customized copies.
