### PR TITLE
feat(payments): reconcile pending transaction status

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -239,6 +239,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Transaction Status Reconciliation
+    |--------------------------------------------------------------------------
+    |
+    | SISP exposes a status endpoint for reconciling transactions that remain
+    | pending after the customer leaves the payment gateway or when callbacks
+    | are delayed/lost. Portal credentials are used for HTTP Basic Auth.
+    |
+    */
+    'transaction_status' => [
+        'enabled' => env('SISP_TRANSACTION_STATUS_ENABLED', true),
+        'test_url' => env('SISP_TRANSACTION_STATUS_TEST_URL', 'https://comerciante.teste.sisp.cv/pos/transaction-status'),
+        'production_url' => env('SISP_TRANSACTION_STATUS_PRODUCTION_URL', 'https://comerciante.vinti4.cv/pos/transaction-status'),
+        'portal_id' => env('SISP_PORTAL_ID', ''),
+        'portal_password' => env('SISP_PORTAL_PASSWORD', ''),
+        'timeout_seconds' => env('SISP_TRANSACTION_STATUS_TIMEOUT', 10),
+        'indeterminate_after_minutes' => env('SISP_TRANSACTION_STATUS_INDETERMINATE_AFTER', 5),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Invoice Configuration
     |--------------------------------------------------------------------------
     |

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -106,6 +106,26 @@ npm install @inertiajs/react    # For React
 npm install @inertiajs/vue3     # For Vue 3
 ```
 
+## Transaction Status Reconciliation
+
+Use the SISP transaction status API to reconcile payments that remain pending after the customer leaves the gateway or when a callback is delayed/lost.
+
+```env
+SISP_TRANSACTION_STATUS_ENABLED=true
+SISP_TRANSACTION_STATUS_TEST_URL=https://comerciante.teste.sisp.cv/pos/transaction-status
+SISP_TRANSACTION_STATUS_PRODUCTION_URL=https://comerciante.vinti4.cv/pos/transaction-status
+SISP_PORTAL_ID=your_portal_id
+SISP_PORTAL_PASSWORD=your_portal_password
+SISP_TRANSACTION_STATUS_INDETERMINATE_AFTER=5
+SISP_TRANSACTION_STATUS_TIMEOUT=10
+```
+
+The package automatically checks an indeterminate pending transaction when the callback response page is opened after the configured threshold. For batch reconciliation, schedule:
+
+```php
+$schedule->command('sisp:reconcile-pending')->everyFiveMinutes();
+```
+
 ## Rate Limiting Configuration
 
 ```env

--- a/src/Actions/QueryTransactionStatusAction.php
+++ b/src/Actions/QueryTransactionStatusAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions;
+
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\SispTransactionStatusResponse;
+use Illuminate\Support\Facades\Http;
+use LogicException;
+
+final readonly class QueryTransactionStatusAction
+{
+    public function __construct(
+        private LoadConfig $config,
+        private SispCredentialsResolver $resolver,
+    ) {}
+
+    public function handle(Transaction|string $transaction): SispTransactionStatusResponse
+    {
+        $merchantRef = $transaction instanceof Transaction
+            ? (string) $transaction->getAttribute('merchant_ref')
+            : $transaction;
+
+        $portalId = $this->config->getTransactionStatusPortalId();
+        $portalPassword = $this->config->getTransactionStatusPortalPassword();
+
+        throw_if($portalId === '' || $portalPassword === '', LogicException::class, 'SISP transaction status portal credentials are not configured.');
+
+        $credentials = $this->resolver->resolve();
+
+        $response = Http::acceptJson()
+            ->asJson()
+            ->timeout($this->config->getTransactionStatusTimeoutSeconds())
+            ->withBasicAuth($portalId, $portalPassword)
+            ->post($this->config->getTransactionStatusUrl(), [
+                'posID' => $credentials->posId,
+                'posAuthCode' => $credentials->posAutCode,
+                'merchantRef' => $merchantRef,
+            ]);
+
+        if (! $response->successful()) {
+            return SispTransactionStatusResponse::from([
+                'result' => false,
+                'transactionSuccess' => false,
+                'transactionStatusDescription' => '',
+                'msg' => "SISP transaction status request failed with HTTP {$response->status()}.",
+            ]);
+        }
+
+        return SispTransactionStatusResponse::from($response->json() ?? []);
+    }
+}

--- a/src/Actions/ReconcileTransactionStatusAction.php
+++ b/src/Actions/ReconcileTransactionStatusAction.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions;
+
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final readonly class ReconcileTransactionStatusAction
+{
+    public function __construct(
+        private QueryTransactionStatusAction $queryTransactionStatus,
+        private UpdateInvoiceStatusAction $updateInvoiceStatus,
+    ) {}
+
+    public function handle(Transaction $transaction): Transaction
+    {
+        if ($transaction->status !== TransactionStatus::pending) {
+            return $transaction;
+        }
+
+        try {
+            $response = $this->queryTransactionStatus->handle($transaction);
+        } catch (Throwable $exception) {
+            Log::warning('SISP transaction status reconciliation failed.', [
+                'transaction_id' => $transaction->getKey(),
+                'merchant_ref' => $transaction->getAttribute('merchant_ref'),
+                'error' => $exception->getMessage(),
+            ]);
+
+            return $transaction;
+        }
+
+        if (! $response->result) {
+            Log::warning('SISP transaction status reconciliation returned an unsuccessful result.', [
+                'transaction_id' => $transaction->getKey(),
+                'merchant_ref' => $transaction->getAttribute('merchant_ref'),
+                'message' => $response->msg,
+            ]);
+
+            return $transaction;
+        }
+
+        $status = $response->transactionStatus();
+        $payload = $transaction->getAttribute('payload');
+        $payload = is_array($payload) ? $payload : [];
+        $payload['transaction_status_response'] = $response->raw;
+
+        $transaction->update([
+            'status' => $status->value,
+            'message_type' => $response->transactionSuccess ? 'transaction_status_success' : 'transaction_status_failed',
+            'merchant_response' => $response->transactionStatusDescription ?: $response->msg,
+            'payload' => $payload,
+        ]);
+
+        $this->updateInvoiceStatus->handle($transaction, $status);
+
+        return $transaction->refresh();
+    }
+}

--- a/src/Commands/ReconcilePendingTransactionsCommand.php
+++ b/src/Commands/ReconcilePendingTransactionsCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Commands;
+
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Console\Command;
+
+final class ReconcilePendingTransactionsCommand extends Command
+{
+    protected $signature = 'sisp:reconcile-pending
+                            {--older-than= : Minimum pending age in minutes}
+                            {--limit= : Maximum transactions to reconcile}';
+
+    protected $description = 'Reconcile pending SISP transactions using the transaction status API';
+
+    public function handle(LoadConfig $config, ReconcileTransactionStatusAction $reconcile): int
+    {
+        if (! $config->isTransactionStatusReconciliationEnabled()) {
+            $this->warn('SISP transaction status reconciliation is disabled.');
+
+            return self::SUCCESS;
+        }
+
+        $olderThan = (int) ($this->option('older-than') ?: $config->getTransactionStatusIndeterminateAfterMinutes());
+
+        $query = Transaction::query()
+            ->where('status', TransactionStatus::pending->value)
+            ->whereNull('message_type')
+            ->where('created_at', '<=', now()->subMinutes($olderThan))
+            ->oldest();
+
+        if ($limit = $this->option('limit')) {
+            $query->limit((int) $limit);
+        }
+
+        $transactions = $query->get();
+
+        if ($transactions->isEmpty()) {
+            $this->info('No pending SISP transactions require reconciliation.');
+
+            return self::SUCCESS;
+        }
+
+        $reconciled = 0;
+
+        foreach ($transactions as $transaction) {
+            $before = $transaction->status;
+            $updated = $reconcile->handle($transaction);
+
+            if ($updated->status !== $before) {
+                $reconciled++;
+            }
+        }
+
+        $this->info("Reconciled {$reconciled} of {$transactions->count()} pending SISP transactions.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -118,6 +118,40 @@ final readonly class LoadConfig
         return $this->config->get('sisp.url', '');
     }
 
+    public function isTransactionStatusReconciliationEnabled(): bool
+    {
+        return (bool) $this->config->get('sisp.transaction_status.enabled', true);
+    }
+
+    public function getTransactionStatusUrl(): string
+    {
+        if ($this->isSandboxEnabled()) {
+            return $this->config->get('sisp.transaction_status.test_url', 'https://comerciante.teste.sisp.cv/pos/transaction-status');
+        }
+
+        return $this->config->get('sisp.transaction_status.production_url', 'https://comerciante.vinti4.cv/pos/transaction-status');
+    }
+
+    public function getTransactionStatusPortalId(): string
+    {
+        return $this->config->get('sisp.transaction_status.portal_id', '');
+    }
+
+    public function getTransactionStatusPortalPassword(): string
+    {
+        return $this->config->get('sisp.transaction_status.portal_password', '');
+    }
+
+    public function getTransactionStatusTimeoutSeconds(): int
+    {
+        return (int) $this->config->get('sisp.transaction_status.timeout_seconds', 10);
+    }
+
+    public function getTransactionStatusIndeterminateAfterMinutes(): int
+    {
+        return (int) $this->config->get('sisp.transaction_status.indeterminate_after_minutes', 5);
+    }
+
     public function getInvoiceNumberFormat(): string
     {
         return $this->config->get('sisp.invoice.number_format', 'date-based');

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Http\Controllers;
 
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
 use Akira\Sisp\Actions\RenderPaymentResponseBasedOnConfigAction;
 use Akira\Sisp\Actions\StoreRequestMetadataAction;
 use Akira\Sisp\Actions\UpdateInvoiceStatusAction;
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\CallbackPayload;
+use Carbon\CarbonInterface;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -19,6 +23,8 @@ final readonly class CallbackController
         private RenderPaymentResponseBasedOnConfigAction $renderResponse,
         private StoreRequestMetadataAction $storeMetadata,
         private UpdateInvoiceStatusAction $updateInvoiceStatus,
+        private ReconcileTransactionStatusAction $reconcileTransactionStatus,
+        private LoadConfig $config,
     ) {}
 
     public function __invoke(Request $request): mixed
@@ -54,7 +60,29 @@ final readonly class CallbackController
             app()->setLocale($transaction->locale);
         }
 
+        $transaction = $this->reconcileIfIndeterminate($transaction);
+
         return $this->renderResponse->handle($transaction, []);
+    }
+
+    private function reconcileIfIndeterminate(Transaction $transaction): Transaction
+    {
+        if (! $this->config->isTransactionStatusReconciliationEnabled()) {
+            return $transaction;
+        }
+
+        $createdAt = $transaction->getAttribute('created_at');
+
+        if (
+            $transaction->status === TransactionStatus::pending
+            && blank($transaction->getAttribute('message_type'))
+            && $createdAt instanceof CarbonInterface
+            && $createdAt->lte(now()->subMinutes($this->config->getTransactionStatusIndeterminateAfterMinutes()))
+        ) {
+            return $this->reconcileTransactionStatus->handle($transaction);
+        }
+
+        return $transaction;
     }
 
     private function handlePostRequest(Request $request): RedirectResponse

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -11,6 +11,7 @@ use Akira\Sisp\Actions\HandleCallbackAction;
 use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
 use Akira\Sisp\Commands\DoctorCommand;
 use Akira\Sisp\Commands\LaravelSispInstallCommand;
+use Akira\Sisp\Commands\ReconcilePendingTransactionsCommand;
 use Akira\Sisp\Commands\RegenerateMissingInvoicePdfsCommand;
 use Akira\Sisp\Configuration\EnvSispCredentialsResolver;
 use Akira\Sisp\Configuration\LoadConfig;
@@ -34,6 +35,7 @@ final class SispServiceProvider extends PackageServiceProvider
             ->hasCommands([
                 LaravelSispInstallCommand::class,
                 RegenerateMissingInvoicePdfsCommand::class,
+                ReconcilePendingTransactionsCommand::class,
                 DoctorCommand::class,
             ]);
     }

--- a/src/ValueObjects/SispTransactionStatusResponse.php
+++ b/src/ValueObjects/SispTransactionStatusResponse.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\ValueObjects;
+
+use Akira\Sisp\Enums\TransactionStatus;
+
+final readonly class SispTransactionStatusResponse
+{
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public bool $result,
+        public bool $transactionSuccess,
+        public string $transactionStatusDescription,
+        public string $msg,
+        public array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function from(array $data): self
+    {
+        return new self(
+            result: (bool) ($data['result'] ?? false),
+            transactionSuccess: (bool) ($data['transactionSuccess'] ?? false),
+            transactionStatusDescription: (string) ($data['transactionStatusDescription'] ?? ''),
+            msg: (string) ($data['msg'] ?? ''),
+            raw: $data,
+        );
+    }
+
+    public function transactionStatus(): TransactionStatus
+    {
+        if (! $this->result) {
+            return TransactionStatus::pending;
+        }
+
+        return $this->transactionSuccess
+            ? TransactionStatus::completed
+            : TransactionStatus::failed;
+    }
+}

--- a/tests/Actions/QueryTransactionStatusActionTest.php
+++ b/tests/Actions/QueryTransactionStatusActionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\QueryTransactionStatusAction;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+it('queries the sandbox transaction status endpoint with basic authentication', function (): void {
+    config()->set('sisp.sandbox', true);
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        'https://comerciante.teste.sisp.cv/pos/transaction-status' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-STATUS-1',
+    ]);
+
+    $response = resolve(QueryTransactionStatusAction::class)->handle($transaction);
+
+    expect($response->result)->toBeTrue()
+        ->and($response->transactionSuccess)->toBeTrue()
+        ->and($response->transactionStatusDescription)->toBe('C-SUCESSO');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://comerciante.teste.sisp.cv/pos/transaction-status'
+        && $request->hasHeader('Authorization', 'Basic '.base64_encode('portal:secret'))
+        && $request['posID'] === 'TEST_POS_001'
+        && $request['posAuthCode'] === 'TEST_POS_AUT_CODE'
+        && $request['merchantRef'] === 'MR-STATUS-1');
+});
+
+it('returns an unsuccessful response when SISP returns a non-success HTTP status', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        '*' => Http::response(['msg' => 'Forbidden'], 403),
+    ]);
+
+    $response = resolve(QueryTransactionStatusAction::class)->handle('MR-STATUS-2');
+
+    expect($response->result)->toBeFalse()
+        ->and($response->transactionSuccess)->toBeFalse()
+        ->and($response->msg)->toContain('HTTP 403');
+});

--- a/tests/Actions/ReconcileTransactionStatusActionTest.php
+++ b/tests/Actions/ReconcileTransactionStatusActionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+});
+
+it('marks pending transactions completed when SISP reports success', function (): void {
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'merchant_response' => null,
+    ]);
+
+    $updated = resolve(ReconcileTransactionStatusAction::class)->handle($transaction);
+
+    expect($updated->status->value)->toBe('completed')
+        ->and($updated->message_type)->toBe('transaction_status_success')
+        ->and($updated->merchant_response)->toBe('C-SUCESSO')
+        ->and($updated->payload['transaction_status_response']['transactionSuccess'])->toBeTrue();
+});
+
+it('marks pending transactions failed when SISP reports a completed status check with failed payment', function (): void {
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => false,
+            'transactionStatusDescription' => 'E-ERRO',
+            'msg' => 'Declined',
+        ]),
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'merchant_response' => null,
+    ]);
+
+    $updated = resolve(ReconcileTransactionStatusAction::class)->handle($transaction);
+
+    expect($updated->status->value)->toBe('failed')
+        ->and($updated->message_type)->toBe('transaction_status_failed')
+        ->and($updated->merchant_response)->toBe('E-ERRO');
+});
+
+it('keeps pending transactions unchanged when the status API call is unsuccessful', function (): void {
+    Http::fake([
+        '*' => Http::response([
+            'result' => false,
+            'transactionSuccess' => false,
+            'transactionStatusDescription' => '',
+            'msg' => 'Invalid credentials',
+        ]),
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'merchant_response' => null,
+    ]);
+
+    $updated = resolve(ReconcileTransactionStatusAction::class)->handle($transaction);
+
+    expect($updated->status->value)->toBe('pending')
+        ->and($updated->message_type)->toBeNull()
+        ->and($updated->merchant_response)->toBeNull();
+});

--- a/tests/Commands/ReconcilePendingTransactionsCommandTest.php
+++ b/tests/Commands/ReconcilePendingTransactionsCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Http;
+
+it('reconciles pending transactions older than the configured threshold', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+    config()->set('sisp.transaction_status.indeterminate_after_minutes', 5);
+
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => false,
+            'transactionStatusDescription' => 'E-ERRO',
+            'msg' => 'Declined',
+        ]),
+    ]);
+
+    $oldPending = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'created_at' => now()->subMinutes(6),
+    ]);
+    $freshPending = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'created_at' => now()->subMinutes(2),
+    ]);
+
+    $this->artisan('sisp:reconcile-pending')
+        ->expectsOutput('Reconciled 1 of 1 pending SISP transactions.')
+        ->assertSuccessful();
+
+    expect($oldPending->refresh()->status->value)->toBe('failed')
+        ->and($freshPending->refresh()->status->value)->toBe('pending');
+});

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -8,6 +8,7 @@ use Akira\Sisp\Sisp as SispManager;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 
 beforeEach(function (): void {
     config()->set('sisp.sandbox', true);
@@ -59,6 +60,37 @@ it('renders response for existing transaction via GET', function (): void {
 
     $this->get(route('sisp.callback', ['ref' => 'MR-G1']))
         ->assertOk();
+});
+
+it('reconciles indeterminate pending transactions via GET callback', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+    config()->set('sisp.transaction_status.indeterminate_after_minutes', 5);
+
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-RECONCILE',
+        'merchant_session' => 'MS-RECONCILE',
+        'amount' => 10,
+        'currency' => '132',
+        'status' => 'pending',
+        'message_type' => null,
+        'created_at' => now()->subMinutes(6),
+    ]);
+
+    $this->get(route('sisp.callback', ['ref' => 'MR-RECONCILE']))
+        ->assertOk();
+
+    expect($transaction->refresh()->status->value)->toBe('completed')
+        ->and($transaction->message_type)->toBe('transaction_status_success');
 });
 
 it('handles POST callback and redirects to GET with ref', function (): void {


### PR DESCRIPTION
Problem: Fixes #47. Pending transactions can remain indeterminate when SISP callbacks are delayed or lost, leaving merchant records inconsistent with SISP.

Root cause: The package had no integration with SISP's transaction status endpoint, so pending transactions could only be resolved by receiving a callback.

Solution: Add a transaction status query action using SISP's Basic Auth API, a reconciliation action that updates transaction and invoice state from definitive SISP responses, automatic reconciliation when an old pending transaction is viewed through the callback GET route, and a `sisp:reconcile-pending` command for scheduled batch reconciliation. Configuration and docs now include portal credentials, endpoint URLs, timeout, and pending-age threshold.

Validation:
- vendor/bin/pest tests/Actions/QueryTransactionStatusActionTest.php tests/Actions/ReconcileTransactionStatusActionTest.php tests/Commands/ReconcilePendingTransactionsCommandTest.php tests/Http/CallbackControllerTest.php --compact
- composer test

Risk/rollback: Medium. This adds outbound HTTP calls only for pending transactions older than the configured threshold or when the command is run. Disable with `SISP_TRANSACTION_STATUS_ENABLED=false` or roll back this PR.
