### PR TITLE
fix(refund): require full-amount reversals

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -7,7 +7,7 @@ extension points.
 
 **Enhanced Transaction Management**
 
-- Partial refunds with itemized selection
+- Full-amount SISP refund compliance helpers
 - Split payments across multiple cards
 - Recurring payment scheduling
 - Payment plan installment tracking

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -181,7 +181,7 @@ The command reconciles only old indeterminate transactions:
 
 ## Refund Transaction
 
-Refund a completed or partially refunded transaction:
+Refund a completed transaction:
 
 ```php
 use Akira\Sisp\Actions\RefundTransactionAction;
@@ -191,7 +191,7 @@ $action = app(RefundTransactionAction::class);
 try {
     $transaction = $action->handle(
         transaction: $transaction,
-        refundAmount: 500.00,      // Amount to refund
+        refundAmount: 500.00,      // Must equal the original transaction amount
         reason: 'customer_request' // Optional reason
     );
     echo "Refunded " . $transaction->formatted_amount;
@@ -203,21 +203,23 @@ try {
 ### Refund Rules
 
 Can be refunded:
-- `completed` - Full or partial refund
-- `partially_refunded` - Additional refunds
+- `completed` - Full refund only
 
 Cannot be refunded:
 - `pending` - Waiting for payment
 - `failed` - Payment failed
 - `cancelled` - Transaction cancelled
-- `refunded` - Already fully refunded
+- `refunded` - Already refunded
 
 ### Refund Amount Rules
 
 - Must be greater than 0
-- Cannot exceed transaction amount
-- Full refund changes status to `refunded`
-- Partial refund changes status to `partially_refunded`
+- Must equal the original transaction amount
+- SISP does not support partial refunds
+- Successful refunds preserve the original transaction amount and change status to `refunded`
+- SISP refund requests use `transactionCode = 4`, and the request amount must be the original transaction amount
+- Refunds are limited to the SISP-supported reversal window, currently no more than 30 days after the original purchase
+- For refunds on a different day, SISP may require enough daily purchase liquidity to cover the refunded amount
 
 ### Refund via Route
 

--- a/docs/08-examples.md
+++ b/docs/08-examples.md
@@ -482,7 +482,7 @@ use Akira\Sisp\Actions\RefundTransactionAction;
 use Akira\Sisp\Models\Transaction;
 
 $transaction = Transaction::find($id);
-$refundAmount = 50.00;
+$refundAmount = $transaction->amount;
 
 $action = app(RefundTransactionAction::class);
 
@@ -495,7 +495,7 @@ try {
 
     return response()->json([
         'success' => true,
-        'message' => "Refunded {$refundAmount} ECV",
+        'message' => "Refunded the full {$refundAmount} ECV transaction amount",
     ]);
 
 } catch (LogicException $e) {

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -128,7 +128,7 @@ you must provide:
 
 ### Can I refund a payment?
 
-Yes, refund completed transactions using `RefundTransactionAction`. Partial and full refunds are supported.
+Yes, refund completed transactions using `RefundTransactionAction`. SISP only supports full-amount refunds, so the refund amount must equal the original transaction amount.
 
 ### Can I cancel a pending payment?
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -419,8 +419,7 @@ TransactionStatus::pending        // Awaiting SISP response
 TransactionStatus::completed      // Payment successful
 TransactionStatus::failed         // Payment rejected
 TransactionStatus::cancelled      // Transaction cancelled
-TransactionStatus::refunded       // Fully refunded
-TransactionStatus::partially_refunded // Partially refunded
+TransactionStatus::refunded       // Fully refunded through SISP full-amount reversal
 ```
 
 ### InvoiceStatus
@@ -518,7 +517,7 @@ app(CancelTransactionAction::class)->handle(
 
 ### RefundTransactionAction
 
-Refund a completed transaction.
+Refund a completed transaction. SISP only supports full-amount refunds, so `refundAmount` must equal the original transaction amount.
 
 ```php
 app(RefundTransactionAction::class)->handle(

--- a/src/Actions/RefundTransactionAction.php
+++ b/src/Actions/RefundTransactionAction.php
@@ -22,19 +22,16 @@ final readonly class RefundTransactionAction
             );
         }
 
-        if ($refundAmount > $transaction->amount) {
+        throw_if($refundAmount <= 0, LogicException::class, 'Refund amount must be greater than 0.');
+
+        if ($this->amountInMinorUnits($refundAmount) !== $this->amountInMinorUnits($transaction->amount)) {
             throw new LogicException(
-                "Refund amount ({$refundAmount}) cannot exceed transaction amount ({$transaction->amount})."
+                "SISP only supports full-amount refunds. Refund amount ({$refundAmount}) must equal transaction amount ({$transaction->amount})."
             );
         }
 
-        throw_if($refundAmount <= 0, LogicException::class, 'Refund amount must be greater than 0.');
-
-        $newAmount = $transaction->amount - $refundAmount;
-
         $transaction->update([
             'status' => TransactionStatus::refunded->value,
-            'amount' => $newAmount,
             'merchant_response' => "{$reason}::{$refundAmount}",
             'refunded_at' => now(),
         ]);
@@ -47,5 +44,10 @@ final readonly class RefundTransactionAction
     private function canBeRefunded(Transaction $transaction): bool
     {
         return $transaction->status->value === 'completed';
+    }
+
+    private function amountInMinorUnits(float $amount): int
+    {
+        return (int) round($amount * 100);
     }
 }

--- a/tests/Actions/RefundTransactionActionTest.php
+++ b/tests/Actions/RefundTransactionActionTest.php
@@ -6,27 +6,39 @@ use Akira\Sisp\Actions\RefundTransactionAction;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Transaction;
 
-it('refunds a completed transaction and updates amount/status', function (): void {
+it('refunds a completed transaction for the full original amount', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
     ]);
 
-    $updated = resolve(RefundTransactionAction::class)->handle($t, 25.5, 'partial_refund');
+    $updated = resolve(RefundTransactionAction::class)->handle($t, 100.0, 'customer_request');
 
     expect($updated->status->value)->toBe('refunded')
-        ->and($updated->amount)->toBe(74.5)
-        ->and($updated->merchant_response)->toBe('partial_refund::25.5');
+        ->and($updated->amount)->toBe(100.0)
+        ->and($updated->merchant_response)->toBe('customer_request::100');
 });
 
-it('does not allow refund exceeding amount', function (): void {
+it('does not allow partial refund amounts', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+    ]);
+
+    expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 50.0))
+        ->toThrow(LogicException::class, 'SISP only supports full-amount refunds')
+        ->and($t->refresh()->status)->toBe(TransactionStatus::completed)
+        ->and($t->amount)->toBe(100.0);
+});
+
+it('does not allow refund amounts above the transaction amount', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 10.0,
     ]);
 
     expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 15.0))
-        ->toThrow(LogicException::class);
+        ->toThrow(LogicException::class, 'SISP only supports full-amount refunds');
 });
 
 it('does not allow refund for non-completed status', function (): void {

--- a/tests/Controllers/RefundTransactionControllerTest.php
+++ b/tests/Controllers/RefundTransactionControllerTest.php
@@ -15,7 +15,7 @@ it('refunds a completed transaction and returns json', function (): void {
     ]);
 
     $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 50.0, 'reason' => 'test']);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 100.0, 'reason' => 'test']);
     $request->setUserResolver(fn (): object => new class
     {
         public string $email = 'buyer@example.com';
@@ -54,6 +54,29 @@ it('returns 400 when refund amount exceeds transaction', function (): void {
 
     $response = $controller($t, $request);
     expect($response->getStatusCode())->toBe(400);
+});
+
+it('returns 400 when refund amount is below transaction total', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'completed',
+        'amount' => 100.0,
+        'customer_email' => 'buyer@example.com',
+    ]);
+
+    $controller = resolve(RefundTransactionController::class);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 50.0]);
+    $request->setUserResolver(fn (): object => new class
+    {
+        public function can(string $ability, mixed $subject): bool
+        {
+            return $ability === 'refund' && $subject instanceof Transaction;
+        }
+    });
+
+    $response = $controller($t, $request);
+    expect($response->getStatusCode())->toBe(400)
+        ->and($response->getData(true)['message'])->toContain('SISP only supports full-amount refunds')
+        ->and($t->refresh()->amount)->toBe(100.0);
 });
 
 it('returns 403 when user is not authorized for the transaction', function (): void {
@@ -157,7 +180,7 @@ it('allows authorized users through can refund ability', function (): void {
     ]);
 
     $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0, 'reason' => 'policy_allowed']);
+    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 100.0, 'reason' => 'policy_allowed']);
     $request->setUserResolver(fn (): object => new class
     {
         public string $email = 'intruder@example.com';


### PR DESCRIPTION
Problem: Fixes #166. SISP only supports full-amount reversals, but the package allowed partial refund amounts and reduced the original transaction amount.

Root cause: `RefundTransactionAction` only rejected amounts above the transaction total, then subtracted accepted refund amounts from `transaction.amount`. Documentation also advertised partial refund support that does not exist in the SISP specification.

Solution:
- Require the refund amount to equal the original transaction amount.
- Preserve the original transaction amount on successful refund.
- Keep the transaction status update to `refunded` and retain the `TransactionRefunded` event.
- Update action/controller tests for full, partial, above-total, and unauthorized refund cases.
- Correct documentation and examples to state SISP full-amount refund behavior, the 30-day limit, and the liquidity caveat.

Validation:
- `./vendor/bin/pest tests/Actions/RefundTransactionActionTest.php tests/Controllers/RefundTransactionControllerTest.php --compact`
- `composer test`

Risk/rollback: This intentionally rejects partial refund calls that were previously accepted by the package but are unsupported by SISP. Consumers must pass the original transaction amount when refunding.
