### PR TITLE
fix(retry): require signed retry requests

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -26,6 +26,14 @@ The locale for each transaction is automatically stored in the `locale` field of
 
 ## Optional Configuration
 
+### Retry Payments
+
+```env
+SISP_ALLOW_RETRY=true
+```
+
+Retry links are temporary signed URLs. The retry endpoint rejects unsigned, expired, or tampered requests before resolving the transaction.
+
 ### 3D Secure
 
 ```env

--- a/resources/js/react/pages/payment-response-data.ts
+++ b/resources/js/react/pages/payment-response-data.ts
@@ -1,0 +1,90 @@
+export interface TransactionData {
+    id: number;
+    status: 'completed' | 'failed' | 'pending';
+    amount: number;
+    formatted_amount: string;
+    currency: string;
+    merchant_ref: string;
+    merchant_session: string;
+    message_type?: string;
+}
+
+export interface ErrorData {
+    code: string;
+    label: string;
+    category: string;
+    categoryLabel: string;
+    action: string;
+    actionLabel: string;
+}
+
+export interface InvoiceData {
+    invoice_number: string;
+    pdf_url: string;
+}
+
+export interface Translations {
+    payment: {
+        success_title: string;
+        success_message: string;
+        success_status: string;
+        failed_title: string;
+        failed_message: string;
+        failed_status: string;
+        pending_title: string;
+        pending_message: string;
+        pending_status: string;
+        pending_note: string;
+        reference: string;
+        amount: string;
+        status: string;
+        category: string;
+        reason: string;
+        action: string;
+        invoice_download: string;
+        back_home: string;
+        declined: string;
+        retry_payment: string;
+        cancel_payment: string;
+        copy_reference: string;
+        download_invoice_alert_title: string;
+        download_invoice_alert_message: string;
+        leave_confirmation_title: string;
+        leave_confirmation_message: string;
+        leave_page: string;
+        stay_on_page: string;
+    };
+}
+
+export const DEFAULT_TRANSLATIONS: Translations = {
+    payment: {
+        success_title: 'Pagamento Concluído com Sucesso!',
+        success_message: 'A sua transação foi processada com sucesso.',
+        success_status: 'Concluído',
+        failed_title: 'Pagamento Recusado',
+        failed_message: 'Desculpe, o seu pagamento não foi processado.',
+        failed_status: 'Falhou',
+        pending_title: 'Pagamento Pendente',
+        pending_message: 'O seu pagamento está a ser processado.',
+        pending_status: 'Pendente',
+        pending_note: 'Receberá uma confirmação em breve. Por favor, não feche esta página.',
+        reference: 'Referência',
+        amount: 'Montante',
+        status: 'Estado',
+        category: 'Categoria',
+        reason: 'Motivo',
+        action: 'Ação',
+        invoice_download: 'Baixar Fatura',
+        back_home: 'Voltar ao Início',
+        declined: 'Recusado',
+        retry_payment: 'Tentar Novamente',
+        cancel_payment: 'Cancelar',
+        copy_reference: 'Copiar referência',
+        download_invoice_alert_title: 'Faça o download da sua fatura',
+        download_invoice_alert_message: 'Guarde uma cópia da sua fatura para os seus registos.',
+        leave_confirmation_title: 'Tem a certeza que quer sair?',
+        leave_confirmation_message: 'Se sair agora, poderá perder informações sobre o seu pagamento.',
+        leave_page: 'Sair da página',
+        stay_on_page: 'Ficar na página',
+    },
+};

--- a/resources/js/react/pages/payment-response.tsx
+++ b/resources/js/react/pages/payment-response.tsx
@@ -4,112 +4,23 @@ import { useForm } from '@inertiajs/react';
 import { motion } from 'framer-motion';
 import { AlertCircle, Check, CheckCircle2, ChevronRight, Clock, Copy, Download, FileDown, Home, RefreshCw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-
-interface TransactionData {
-    id: number;
-    status: 'completed' | 'failed' | 'pending';
-    amount: number;
-    formatted_amount: string;
-    currency: string;
-    merchant_ref: string;
-    merchant_session: string;
-    message_type?: string;
-}
-
-interface ErrorData {
-    code: string;
-    label: string;
-    category: string;
-    categoryLabel: string;
-    action: string;
-    actionLabel: string;
-}
-
-interface InvoiceData {
-    invoice_number: string;
-    pdf_url: string;
-}
-
-interface Translations {
-    payment: {
-        success_title: string;
-        success_message: string;
-        success_status: string;
-        failed_title: string;
-        failed_message: string;
-        failed_status: string;
-        pending_title: string;
-        pending_message: string;
-        pending_status: string;
-        pending_note: string;
-        reference: string;
-        amount: string;
-        status: string;
-        category: string;
-        reason: string;
-        action: string;
-        invoice_download: string;
-        back_home: string;
-        declined: string;
-        retry_payment: string;
-        cancel_payment: string;
-        copy_reference: string;
-        download_invoice_alert_title: string;
-        download_invoice_alert_message: string;
-        leave_confirmation_title: string;
-        leave_confirmation_message: string;
-        leave_page: string;
-        stay_on_page: string;
-    };
-}
-
+import { DEFAULT_TRANSLATIONS, type ErrorData, type InvoiceData, type TransactionData, type Translations } from './payment-response-data';
 interface PaymentResponseProps {
     transaction: TransactionData;
     error?: ErrorData | null;
     translations?: Translations;
     allowRetry?: boolean;
+    retryUrl?: string | null;
     invoice?: InvoiceData | null;
     payload: Record<string, unknown>;
 }
-
-const DEFAULT_TRANSLATIONS: Translations = {
-    payment: {
-        success_title: 'Pagamento Concluído com Sucesso!',
-        success_message: 'A sua transação foi processada com sucesso.',
-        success_status: 'Concluído',
-        failed_title: 'Pagamento Recusado',
-        failed_message: 'Desculpe, o seu pagamento não foi processado.',
-        failed_status: 'Falhou',
-        pending_title: 'Pagamento Pendente',
-        pending_message: 'O seu pagamento está a ser processado.',
-        pending_status: 'Pendente',
-        pending_note: 'Receberá uma confirmação em breve. Por favor, não feche esta página.',
-        reference: 'Referência',
-        amount: 'Montante',
-        status: 'Estado',
-        category: 'Categoria',
-        reason: 'Motivo',
-        action: 'Ação',
-        invoice_download: 'Baixar Fatura',
-        back_home: 'Voltar ao Início',
-        declined: 'Recusado',
-        retry_payment: 'Tentar Novamente',
-        cancel_payment: 'Cancelar',
-        copy_reference: 'Copiar referência',
-        download_invoice_alert_title: 'Faça o download da sua fatura',
-        download_invoice_alert_message: 'Guarde uma cópia da sua fatura para os seus registos.',
-        leave_confirmation_title: 'Tem a certeza que quer sair?',
-        leave_confirmation_message: 'Se sair agora, poderá perder informações sobre o seu pagamento.',
-        leave_page: 'Sair da página',
-        stay_on_page: 'Ficar na página',
-    },
-};
 
 export default function PaymentResponse({
     transaction,
     error,
     translations = DEFAULT_TRANSLATIONS,
     allowRetry = true,
+    retryUrl = null,
     invoice,
 }: PaymentResponseProps) {
     const isSuccess = transaction.status === 'completed';
@@ -117,9 +28,7 @@ export default function PaymentResponse({
     const isPending = transaction.status === 'pending';
     const t = translations.payment;
 
-    const { post, processing } = useForm({
-        transaction_id: transaction.id,
-    });
+    const { post, processing } = useForm({});
 
     const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
     const [copiedReference, setCopiedReference] = useState(false);
@@ -127,7 +36,9 @@ export default function PaymentResponse({
     const beforeUnloadHandlerRef = useRef<((e: BeforeUnloadEvent) => void) | null>(null);
 
     const handleRetryPayment = () => {
-        post('/sisp/retry-payment');
+        if (retryUrl) {
+            post(retryUrl);
+        }
     };
 
     const handleCopyReference = async () => {
@@ -137,9 +48,7 @@ export default function PaymentResponse({
             await navigator.clipboard.writeText(transaction.merchant_ref);
             setCopiedReference(true);
             setTimeout(() => setCopiedReference(false), 2000);
-        } catch {
-            // silently fail
-        }
+        } catch {}
     };
 
     const handleLeaveConfirm = () => {
@@ -156,7 +65,6 @@ export default function PaymentResponse({
         }
     };
 
-    // Only show beforeunload confirmation for success and pending states
     useEffect(() => {
         if (isFailed) return;
 
@@ -175,7 +83,6 @@ export default function PaymentResponse({
         };
     }, [isFailed]);
 
-    // Intercept browser back button
     useEffect(() => {
         if (isFailed) return;
 
@@ -392,7 +299,7 @@ export default function PaymentResponse({
 
                     {/* Action Buttons */}
                     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.4 }} className="space-y-3">
-                        {isFailed && allowRetry && (
+                        {isFailed && allowRetry && retryUrl && (
                             <button
                                 onClick={handleRetryPayment}
                                 disabled={processing}

--- a/resources/js/vue/pages/PaymentResponse.vue
+++ b/resources/js/vue/pages/PaymentResponse.vue
@@ -106,7 +106,7 @@
                 <!-- Action Buttons -->
                 <div class="space-y-3 fade-in-up" style="animation-delay: 0.4s">
                     <button
-                        v-if="isFailed && allowRetry"
+                        v-if="isFailed && allowRetry && retryUrl"
                         @click="retryPayment"
                         :disabled="processing"
                         class="flex h-14 w-full items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-purple-600 to-purple-500 text-lg font-bold text-white shadow-xl shadow-purple-500/20 transition-all hover:scale-[1.02] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
@@ -192,76 +192,21 @@ import SmoothScroll from '@/components/landing/SmoothScroll.vue';
 import { useForm } from '@inertiajs/vue3';
 import { AlertCircle, Check, CheckCircle2, ChevronRight, Clock, Copy, Download, FileDown, Home, RefreshCw } from 'lucide-vue-next';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
-
-interface TransactionData {
-    id: number;
-    status: 'completed' | 'failed' | 'pending';
-    amount: number;
-    formatted_amount: string;
-    currency: string;
-    merchant_ref: string;
-    merchant_session: string;
-    message_type?: string;
-}
-
-interface ErrorData {
-    code: string;
-    label: string;
-    category: string;
-    categoryLabel: string;
-    action: string;
-    actionLabel: string;
-}
-
-interface InvoiceData {
-    invoice_number: string;
-    pdf_url: string;
-}
-
-interface Translations {
-    payment: {
-        success_title: string;
-        success_message: string;
-        success_status: string;
-        failed_title: string;
-        failed_message: string;
-        failed_status: string;
-        pending_title: string;
-        pending_message: string;
-        pending_status: string;
-        pending_note: string;
-        reference: string;
-        amount: string;
-        status: string;
-        category: string;
-        reason: string;
-        action: string;
-        invoice_download: string;
-        back_home: string;
-        declined: string;
-        retry_payment: string;
-        cancel_payment: string;
-        copy_reference: string;
-        download_invoice_alert_title: string;
-        download_invoice_alert_message: string;
-        leave_confirmation_title: string;
-        leave_confirmation_message: string;
-        leave_page: string;
-        stay_on_page: string;
-    };
-}
+import { DEFAULT_TRANSLATIONS, type ErrorData, type InvoiceData, type TransactionData, type Translations } from './payment-response-data';
 
 interface PaymentResponseProps {
     transaction: TransactionData;
     error?: ErrorData | null;
     translations?: Translations;
     allowRetry?: boolean;
+    retryUrl?: string | null;
     invoice?: InvoiceData | null;
     payload: Record<string, unknown>;
 }
 
 const props = withDefaults(defineProps<PaymentResponseProps>(), {
     allowRetry: true,
+    retryUrl: null,
     error: null,
     invoice: null,
 });
@@ -270,36 +215,7 @@ const isSuccess = computed(() => props.transaction.status === 'completed');
 const isFailed = computed(() => props.transaction.status === 'failed');
 const isPending = computed(() => props.transaction.status === 'pending');
 
-const t = computed(() => props.translations?.payment ?? {
-    success_title: 'Pagamento Concluído com Sucesso!',
-    success_message: 'A sua transação foi processada com sucesso.',
-    success_status: 'Concluído',
-    failed_title: 'Pagamento Recusado',
-    failed_message: 'Desculpe, o seu pagamento não foi processado.',
-    failed_status: 'Falhou',
-    pending_title: 'Pagamento Pendente',
-    pending_message: 'O seu pagamento está a ser processado.',
-    pending_status: 'Pendente',
-    pending_note: 'Receberá uma confirmação em breve. Por favor, não feche esta página.',
-    reference: 'Referência',
-    amount: 'Montante',
-    status: 'Estado',
-    category: 'Categoria',
-    reason: 'Motivo',
-    action: 'Ação',
-    invoice_download: 'Baixar Fatura',
-    back_home: 'Voltar ao Início',
-    declined: 'Recusado',
-    retry_payment: 'Tentar Novamente',
-    cancel_payment: 'Cancelar',
-    copy_reference: 'Copiar referência',
-    download_invoice_alert_title: 'Faça o download da sua fatura',
-    download_invoice_alert_message: 'Guarde uma cópia da sua fatura para os seus registos.',
-    leave_confirmation_title: 'Tem a certeza que quer sair?',
-    leave_confirmation_message: 'Se sair agora, poderá perder informações sobre o seu pagamento.',
-    leave_page: 'Sair da página',
-    stay_on_page: 'Ficar na página',
-});
+const t = computed(() => props.translations?.payment ?? DEFAULT_TRANSLATIONS.payment);
 
 const statusConfig = computed(() => {
     if (isSuccess.value) {
@@ -350,14 +266,18 @@ const statusText = computed(() => {
     return t.value.pending_status;
 });
 
-const { post, processing } = useForm({ transaction_id: props.transaction.id });
+const { post, processing } = useForm({});
 
 const showLeaveConfirm = ref(false);
 const copiedReference = ref(false);
 const isBackButton = ref(false);
 let beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | null = null;
 
-const retryPayment = () => post('/sisp/retry-payment');
+const retryPayment = () => {
+    if (props.retryUrl) {
+        post(props.retryUrl);
+    }
+};
 
 const copyReference = async () => {
     if (!props.transaction.merchant_ref) return;

--- a/resources/js/vue/pages/payment-response-data.ts
+++ b/resources/js/vue/pages/payment-response-data.ts
@@ -1,0 +1,90 @@
+export interface TransactionData {
+    id: number;
+    status: 'completed' | 'failed' | 'pending';
+    amount: number;
+    formatted_amount: string;
+    currency: string;
+    merchant_ref: string;
+    merchant_session: string;
+    message_type?: string;
+}
+
+export interface ErrorData {
+    code: string;
+    label: string;
+    category: string;
+    categoryLabel: string;
+    action: string;
+    actionLabel: string;
+}
+
+export interface InvoiceData {
+    invoice_number: string;
+    pdf_url: string;
+}
+
+export interface Translations {
+    payment: {
+        success_title: string;
+        success_message: string;
+        success_status: string;
+        failed_title: string;
+        failed_message: string;
+        failed_status: string;
+        pending_title: string;
+        pending_message: string;
+        pending_status: string;
+        pending_note: string;
+        reference: string;
+        amount: string;
+        status: string;
+        category: string;
+        reason: string;
+        action: string;
+        invoice_download: string;
+        back_home: string;
+        declined: string;
+        retry_payment: string;
+        cancel_payment: string;
+        copy_reference: string;
+        download_invoice_alert_title: string;
+        download_invoice_alert_message: string;
+        leave_confirmation_title: string;
+        leave_confirmation_message: string;
+        leave_page: string;
+        stay_on_page: string;
+    };
+}
+
+export const DEFAULT_TRANSLATIONS: Translations = {
+    payment: {
+        success_title: 'Pagamento Concluído com Sucesso!',
+        success_message: 'A sua transação foi processada com sucesso.',
+        success_status: 'Concluído',
+        failed_title: 'Pagamento Recusado',
+        failed_message: 'Desculpe, o seu pagamento não foi processado.',
+        failed_status: 'Falhou',
+        pending_title: 'Pagamento Pendente',
+        pending_message: 'O seu pagamento está a ser processado.',
+        pending_status: 'Pendente',
+        pending_note: 'Receberá uma confirmação em breve. Por favor, não feche esta página.',
+        reference: 'Referência',
+        amount: 'Montante',
+        status: 'Estado',
+        category: 'Categoria',
+        reason: 'Motivo',
+        action: 'Ação',
+        invoice_download: 'Baixar Fatura',
+        back_home: 'Voltar ao Início',
+        declined: 'Recusado',
+        retry_payment: 'Tentar Novamente',
+        cancel_payment: 'Cancelar',
+        copy_reference: 'Copiar referência',
+        download_invoice_alert_title: 'Faça o download da sua fatura',
+        download_invoice_alert_message: 'Guarde uma cópia da sua fatura para os seus registos.',
+        leave_confirmation_title: 'Tem a certeza que quer sair?',
+        leave_confirmation_message: 'Se sair agora, poderá perder informações sobre o seu pagamento.',
+        leave_page: 'Sair da página',
+        stay_on_page: 'Ficar na página',
+    },
+};

--- a/resources/views/payment-response.blade.php
+++ b/resources/views/payment-response.blade.php
@@ -151,10 +151,9 @@
 
         {{-- Action Buttons --}}
         <div class="space-y-3 fade-in-up" style="animation-delay:.4s">
-            @if($transaction->status === 'failed' && $allowRetry)
-                <form method="POST" action="{{ route('sisp.retry-payment') }}">
+            @if($transaction->status === 'failed' && $allowRetry && $retryUrl)
+                <form method="POST" action="{{ $retryUrl }}">
                     @csrf
-                    <input type="hidden" name="transaction_id" value="{{ $transaction->id }}">
                     <button type="submit" class="flex h-14 w-full items-center justify-center gap-2 rounded-2xl bg-purple-600 hover:bg-purple-700 text-lg font-bold text-white shadow-xl shadow-purple-500/20 transition-all hover:scale-[1.02] active:scale-[0.98]">
                         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -25,7 +25,7 @@ final readonly class RenderPaymentResponseAction
     {
         $allowRetry = $this->canRetryPayment->handle($transaction);
 
-        return view('sisp::payment-response', [
+        return view()->make('sisp::payment-response', [
             'transaction' => $transaction,
             'payload' => $payload,
             'error' => $this->getStructuredError($transaction),

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -9,6 +9,7 @@ use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\InertiaAvailability;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 
 final readonly class RenderPaymentResponseAction
@@ -22,14 +23,14 @@ final readonly class RenderPaymentResponseAction
 
     public function renderBlade(Transaction $transaction, array $payload): View
     {
-        /** @var view-string $viewName */
-        $viewName = 'sisp::payment-response';
+        $allowRetry = $this->canRetryPayment->handle($transaction);
 
-        return view($viewName, [
+        return view('sisp::payment-response', [
             'transaction' => $transaction,
             'payload' => $payload,
             'error' => $this->getStructuredError($transaction),
-            'allowRetry' => $this->canRetryPayment->handle($transaction),
+            'allowRetry' => $allowRetry,
+            'retryUrl' => $allowRetry ? $this->retryUrl($transaction) : null,
         ]);
     }
 
@@ -40,6 +41,7 @@ final readonly class RenderPaymentResponseAction
         }
 
         $invoice = $transaction->invoice;
+        $allowRetry = $this->canRetryPayment->handle($transaction);
 
         return Inertia::render($component, [
             'transaction' => [
@@ -54,7 +56,8 @@ final readonly class RenderPaymentResponseAction
             ],
             'error' => $this->getStructuredError($transaction),
             'translations' => $this->getTranslations->handle(),
-            'allowRetry' => $this->canRetryPayment->handle($transaction),
+            'allowRetry' => $allowRetry,
+            'retryUrl' => $allowRetry ? $this->retryUrl($transaction) : null,
             'invoice' => $invoice instanceof Invoice ? [
                 'invoice_number' => $invoice->invoice_number,
                 'invoice_date' => $invoice->invoice_date->toDateString(),
@@ -79,5 +82,14 @@ final readonly class RenderPaymentResponseAction
         }
 
         return $this->getErrorResponse->handle($errorType)->toArray();
+    }
+
+    private function retryUrl(Transaction $transaction): string
+    {
+        return URL::temporarySignedRoute(
+            'sisp.retry-payment',
+            now()->addMinutes(30),
+            ['transaction' => $transaction->id],
+        );
     }
 }

--- a/src/Http/Controllers/RetryPaymentController.php
+++ b/src/Http/Controllers/RetryPaymentController.php
@@ -18,7 +18,7 @@ final readonly class RetryPaymentController
 
     public function __invoke(RetryPaymentRequest $request): mixed
     {
-        $transaction = Transaction::query()->findOrFail($request->integer('transaction_id'));
+        $transaction = Transaction::query()->findOrFail($request->integer('transaction'));
 
         $paymentRequest = $this->retryPayment->handle($transaction);
 

--- a/src/Http/Requests/RetryPaymentRequest.php
+++ b/src/Http/Requests/RetryPaymentRequest.php
@@ -7,34 +7,35 @@ namespace Akira\Sisp\Http\Requests;
 use Akira\Sisp\Actions\CanRetryPaymentAction;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\Validator;
 
 final class RetryPaymentRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return true;
+        return URL::hasValidSignature($this);
     }
 
     public function rules(): array
     {
         return [
-            'transaction_id' => ['required', 'integer', 'exists:sisp_transactions,id'],
+            'transaction' => ['required', 'integer', 'exists:sisp_transactions,id'],
         ];
     }
 
     public function withValidator(Validator $validator): void
     {
         $validator->after(function (Validator $validator): void {
-            if ($validator->errors()->has('transaction_id')) {
+            if ($validator->errors()->has('transaction')) {
                 return;
             }
 
-            $transaction = Transaction::query()->find($this->integer('transaction_id'));
+            $transaction = Transaction::query()->find($this->integer('transaction'));
 
             if (! $transaction || ! resolve(CanRetryPaymentAction::class)->handle($transaction)) {
                 $validator->errors()->add(
-                    'transaction_id',
+                    'transaction',
                     __('sisp::messages.payment.response.retry_not_available')
                 );
             }

--- a/tests/Actions/RenderPaymentResponseActionTest.php
+++ b/tests/Actions/RenderPaymentResponseActionTest.php
@@ -65,3 +65,16 @@ it('sets allowRetry to false when 3DS is enabled and transaction is missing requ
 
     expect($view->getData()['allowRetry'])->toBeFalse();
 });
+
+it('provides a signed retry URL when retry is allowed', function (): void {
+    $t = Transaction::factory()->failed()->create();
+
+    $view = resolve(RenderPaymentResponseAction::class)->renderBlade($t, []);
+    $retryUrl = $view->getData()['retryUrl'];
+
+    expect($view->getData()['allowRetry'])->toBeTrue()
+        ->and($retryUrl)->toBeString()
+        ->and($retryUrl)->toContain('/sisp/retry-payment')
+        ->and($retryUrl)->toContain('signature=')
+        ->and($retryUrl)->toContain('transaction='.$t->id);
+});

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\URL;
 
 it('retries payment and renders form', function (): void {
     $t = Transaction::factory()->create([
@@ -13,7 +14,7 @@ it('retries payment and renders form', function (): void {
         'currency' => '132',
     ]);
 
-    $response = $this->post(route('sisp.retry-payment'), ['transaction_id' => $t->id]);
+    $response = $this->post(signedRetryUrl($t));
     $response->assertStatus(200);
 });
 
@@ -26,7 +27,7 @@ it('updates merchant_session on transaction so callback can find it', function (
         'currency' => '132',
     ]);
 
-    $this->post(route('sisp.retry-payment'), ['transaction_id' => $t->id])
+    $this->post(signedRetryUrl($t))
         ->assertStatus(200);
 
     $t->refresh();
@@ -37,8 +38,22 @@ it('updates merchant_session on transaction so callback can find it', function (
 });
 
 it('returns validation error without triggering after callback when transaction does not exist', function (): void {
-    $this->post(route('sisp.retry-payment'), ['transaction_id' => 999999])
-        ->assertSessionHasErrors(['transaction_id']);
+    $this->postJson(signedRetryUrl(999999))
+        ->assertJsonValidationErrors(['transaction']);
+});
+
+it('rejects unsigned retry requests before resolving transactions', function (): void {
+    $t = Transaction::factory()->failed()->create();
+
+    $this->post(route('sisp.retry-payment', ['transaction' => $t->id]))
+        ->assertForbidden();
+});
+
+it('rejects expired retry links before resolving transactions', function (): void {
+    $t = Transaction::factory()->failed()->create();
+
+    $this->post(URL::temporarySignedRoute('sisp.retry-payment', now()->subMinute(), ['transaction' => $t->id]))
+        ->assertForbidden();
 });
 
 it('rejects retry when 3DS is enabled and required customer data is missing', function (): void {
@@ -56,6 +71,15 @@ it('rejects retry when 3DS is enabled and required customer data is missing', fu
     ]);
 
     $this->from('/sisp/callback?ref='.$t->merchant_ref)
-        ->post(route('sisp.retry-payment'), ['transaction_id' => $t->id])
-        ->assertSessionHasErrors(['transaction_id']);
+        ->postJson(signedRetryUrl($t))
+        ->assertJsonValidationErrors(['transaction']);
 });
+
+function signedRetryUrl(Transaction|int $transaction): string
+{
+    return URL::temporarySignedRoute(
+        'sisp.retry-payment',
+        now()->addMinutes(30),
+        ['transaction' => $transaction instanceof Transaction ? $transaction->id : $transaction],
+    );
+}

--- a/tests/Http/RetryPaymentControllerTest.php
+++ b/tests/Http/RetryPaymentControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\URL;
 
 it('retries payment for an existing transaction', function (): void {
     $t = Transaction::factory()->create([
@@ -13,9 +14,8 @@ it('retries payment for an existing transaction', function (): void {
         'transaction_code' => '1',
     ]);
 
-    $this->post(route('sisp.retry-payment'), [
-        'transaction_id' => $t->id,
-    ])->assertOk();
+    $this->post(URL::temporarySignedRoute('sisp.retry-payment', now()->addMinutes(30), ['transaction' => $t->id]))
+        ->assertOk();
 
     $t->refresh();
 


### PR DESCRIPTION
Problem: Fixes #169. The retry-payment endpoint accepted a raw local transaction ID, leaving the retry flow exposed to transaction ID reuse.

Root cause: Built-in Blade, React, and Vue retry forms posted `transaction_id` directly to `/sisp/retry-payment`, and `RetryPaymentRequest::authorize()` allowed every request.

Solution:
- Generate a temporary signed retry URL when rendering failed payment responses.
- Require a valid signed URL in `RetryPaymentRequest::authorize()` before validation or transaction lookup.
- Resolve retries from the signed `transaction` query parameter instead of a body `transaction_id`.
- Update Blade, React, and Vue retry flows to post to the signed URL.
- Extract React/Vue response data into small published files to keep touched source files within commit-guard limits.
- Add regression tests for signed retry, unsigned retry, expired retry, invalid transaction, and 3DS retry rejection.

Validation:
- `./vendor/bin/pest tests/Controllers/RetryPaymentControllerTest.php tests/Http/RetryPaymentControllerTest.php tests/Actions/RenderPaymentResponseActionTest.php --compact`
- `npm run build`
- `composer test`

Risk/rollback: Direct posts with `transaction_id` are now rejected unless generated through the signed retry URL. This is intentional because secure defaults must not depend on host-app middleware.
