### PR TITLE
fix(payment): validate item totals

### DIFF
--- a/src/Http/Requests/StorePaymentRequest.php
+++ b/src/Http/Requests/StorePaymentRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
 
 final class StorePaymentRequest extends FormRequest
 {
@@ -34,5 +35,44 @@ final class StorePaymentRequest extends FormRequest
             'customer_postal_code' => ['sometimes', 'string', 'max:20'],
             'locale' => ['sometimes', 'string', 'max:10'],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if ($validator->errors()->has('amount') || $validator->errors()->has('items')) {
+                return;
+            }
+
+            $items = $this->input('items', []);
+            if (! is_array($items)) {
+                return;
+            }
+
+            $submittedTotal = 0;
+
+            foreach ($items as $index => $item) {
+                if (! is_array($item)) {
+                    return;
+                }
+
+                $lineTotal = $this->amountInMinorUnits($item['total_price'] ?? 0);
+                $expectedLineTotal = ((int) ($item['quantity'] ?? 0)) * $this->amountInMinorUnits($item['unit_price'] ?? 0);
+                $submittedTotal += $lineTotal;
+
+                if ($lineTotal !== $expectedLineTotal) {
+                    $validator->errors()->add("items.{$index}.total_price", 'Item total must equal quantity multiplied by unit price.');
+                }
+            }
+
+            if ($this->amountInMinorUnits($this->input('amount')) !== $submittedTotal) {
+                $validator->errors()->add('amount', 'Payment amount must equal the sum of item totals.');
+            }
+        });
+    }
+
+    private function amountInMinorUnits(mixed $amount): int
+    {
+        return (int) round((float) $amount * 100);
     }
 }

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -63,3 +63,35 @@ it('blocks duplicate transactions via middleware', function (): void {
 
     $response->assertRedirect('/');
 });
+
+it('rejects item totals that do not match quantity multiplied by unit price', function (): void {
+    config()->set('sisp.rate_limiting.enabled', false);
+
+    $this->postJson(route('sisp.payment'), [
+        'amount' => 100.0,
+        'items' => [[
+            'product_name' => 'Test',
+            'quantity' => 2,
+            'unit_price' => 50.0,
+            'total_price' => 90.0,
+        ]],
+    ])->assertJsonValidationErrors(['items.0.total_price', 'amount']);
+
+    expect(Transaction::query()->count())->toBe(0);
+});
+
+it('rejects payment amount that does not match item totals', function (): void {
+    config()->set('sisp.rate_limiting.enabled', false);
+
+    $this->postJson(route('sisp.payment'), [
+        'amount' => 120.0,
+        'items' => [[
+            'product_name' => 'Test',
+            'quantity' => 2,
+            'unit_price' => 50.0,
+            'total_price' => 100.0,
+        ]],
+    ])->assertJsonValidationErrors(['amount']);
+
+    expect(Transaction::query()->count())->toBe(0);
+});


### PR DESCRIPTION
Problem: Fixes #167. Payment creation accepted `amount` independently from item totals, allowing the charged amount and item breakdown to diverge.

Root cause: `StorePaymentRequest` validated only field shape and numeric bounds. It did not reconcile each line total or the aggregate payment amount.

Solution:
- Add post-validation checks in `StorePaymentRequest`.
- Compare each `items.*.total_price` against `quantity * unit_price` in minor units.
- Compare `amount` against the sum of submitted item totals.
- Reject invalid requests before any transaction is created.
- Add regression tests for mismatched line totals and mismatched payment amount.

Validation:
- `./vendor/bin/pest tests/Http/PaymentControllerTest.php --compact`
- `composer test`

Risk/rollback: Existing callers that submitted inconsistent totals will now receive validation errors and must correct their payloads before creating a SISP transaction.
