### PR TITLE
fix(routes): configure state-changing middleware

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -213,12 +213,13 @@ Customize middleware assigned to package routes in `config/sisp.php`:
 
 ```php
 'middleware' => [
-    // Applied to POST /sisp/refund/{transaction}
+    'payment' => [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class],
+    'retry' => [],
     'refund' => ['web', 'auth'],
 ],
 ```
 
-Use this to enforce authentication/authorization for refunds.
+Use this to add CSRF, authentication, tenancy, or custom authorization checks to browser-originated routes. The payment route keeps duplicate-payment protection by default. The callback route is intentionally not part of this configuration because SISP must be able to post callbacks without browser CSRF middleware.
 
 ## Security Configuration
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -993,7 +993,7 @@ POST   /sisp/sandbox           -> SandboxController
 GET    /sisp/countries         -> CountriesController
 ```
 
-Refund route middleware is configurable via `config('sisp.middleware.refund')`.
+State-changing route middleware is configurable via `config('sisp.middleware.payment')`, `config('sisp.middleware.retry')`, and `config('sisp.middleware.refund')`. The callback route remains outside this configuration so SISP callbacks are not blocked by browser-only middleware.
 
 Route names:
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,10 +12,11 @@ use Akira\Sisp\Http\Controllers\SandboxController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('sisp/payment', PaymentController::class)
-    ->middleware(Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class)
+    ->middleware(config()->array('sisp.middleware.payment', [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class]))
     ->name('sisp.payment');
 
 Route::post('sisp/retry-payment', RetryPaymentController::class)
+    ->middleware(config()->array('sisp.middleware.retry', []))
     ->name('sisp.retry-payment');
 
 Route::match(['get', 'post'], 'sisp/callback', CallbackController::class)

--- a/tests/Routes/SispRouteMiddlewareTest.php
+++ b/tests/Routes/SispRouteMiddlewareTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Http\Middleware\ProtectPaymentRoute;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+it('uses configurable middleware for payment and retry routes', function (): void {
+    config()->set('sisp.middleware.payment', ['web', 'auth', ProtectPaymentRoute::class]);
+    config()->set('sisp.middleware.retry', ['web', 'auth']);
+
+    withReloadedSispRoutes(function (): void {
+        $paymentMiddleware = Route::getRoutes()->getByName('sisp.payment')->gatherMiddleware();
+        $retryMiddleware = Route::getRoutes()->getByName('sisp.retry-payment')->gatherMiddleware();
+
+        expect($paymentMiddleware)->toContain('web', 'auth', ProtectPaymentRoute::class)
+            ->and($retryMiddleware)->toContain('web', 'auth');
+    });
+});
+
+it('keeps callback route outside configurable browser middleware', function (): void {
+    config()->set('sisp.middleware.payment', ['web', 'auth', ProtectPaymentRoute::class]);
+    config()->set('sisp.middleware.retry', ['web', 'auth']);
+    config()->set('sisp.middleware.refund', ['web', 'auth']);
+
+    withReloadedSispRoutes(function (): void {
+        $callbackRoute = Route::getRoutes()->getByName('sisp.callback');
+
+        expect($callbackRoute->gatherMiddleware())->not->toContain('auth')
+            ->and($callbackRoute->excludedMiddleware())->toContain('web');
+    });
+});
+
+function withReloadedSispRoutes(callable $callback): void
+{
+    $router = Route::getFacadeRoot();
+    $originalRoutes = $router->getRoutes();
+
+    try {
+        $router->setRoutes(new RouteCollection());
+        require __DIR__.'/../../routes/web.php';
+        Route::getRoutes()->refreshNameLookups();
+
+        $callback();
+    } finally {
+        $router->setRoutes($originalRoutes);
+    }
+}


### PR DESCRIPTION
Problem: Fixes #171. State-changing package routes could not be configured consistently through `config('sisp.middleware.*')`.

Root cause: `POST /sisp/payment` had a fixed duplicate-protection middleware, `POST /sisp/retry-payment` had no configurable middleware, and only the refund route read from package config.

Solution:
- Route `POST /sisp/payment` through `config('sisp.middleware.payment')`, with `ProtectPaymentRoute` as the fallback default.
- Route `POST /sisp/retry-payment` through `config('sisp.middleware.retry')`, defaulting to no extra middleware for compatibility.
- Keep callback behavior unchanged and outside browser middleware configuration.
- Document payment, retry, and refund middleware configuration.
- Add route tests that reload package routes with custom middleware and assert callback remains outside browser middleware.

Validation:
- `./vendor/bin/pest tests/Routes/SispRouteMiddlewareTest.php --compact`
- `composer test`

Risk/rollback: Applications can now add `web`, `auth`, tenancy, or custom authorization middleware through config. Existing defaults remain compatible.
