### PR TITLE
fix(rate-limit): serialize hit updates

### DIFF
--- a/src/Actions/CheckRateLimitAction.php
+++ b/src/Actions/CheckRateLimitAction.php
@@ -6,7 +6,9 @@ namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Exceptions\RateLimitExceededException;
 use Akira\Sisp\Models\RateLimit;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 final readonly class CheckRateLimitAction
 {
@@ -27,14 +29,46 @@ final readonly class CheckRateLimitAction
         $limit ??= $this->getDefaultLimit($limitType);
         $windowSeconds ??= $this->getDefaultWindow($limitType);
         $blockedKey = "rate_limit_blocked:{$limitType}:{$identifier}:{$context}";
+        $lockKey = "rate_limit_lock:{$limitType}:{$identifier}:{$context}";
 
         throw_if(Cache::has($blockedKey), RateLimitExceededException::class, "Rate limit exceeded for {$limitType}: {$identifier}");
 
-        $rateLimit = RateLimit::query()->firstOrCreate([
+        $exceeded = false;
+
+        try {
+            Cache::lock($lockKey, 10)->block(5, function () use (&$exceeded, $limitType, $identifier, $context, $limit, $windowSeconds, $blockedKey): void {
+                $exceeded = DB::transaction(
+                    fn (): bool => $this->recordHit($limitType, $identifier, $context, $limit, $windowSeconds, $blockedKey)
+                );
+            });
+        } catch (LockTimeoutException) {
+            throw new RateLimitExceededException("Rate limit lock timeout for {$limitType}: {$identifier}");
+        }
+
+        throw_if($exceeded, RateLimitExceededException::class, "Rate limit exceeded for {$limitType}: {$identifier}. Limit: {$limit} requests per {$windowSeconds} seconds");
+    }
+
+    private function recordHit(
+        string $limitType,
+        string $identifier,
+        ?string $context,
+        int $limit,
+        int $windowSeconds,
+        string $blockedKey,
+    ): bool {
+        $rateLimit = RateLimit::query()
+            ->where([
+                'identifier' => $identifier,
+                'limit_type' => $limitType,
+                'context' => $context,
+            ])
+            ->lockForUpdate()
+            ->first();
+
+        $rateLimit ??= RateLimit::query()->create([
             'identifier' => $identifier,
             'limit_type' => $limitType,
             'context' => $context,
-        ], [
             'hits' => 0,
             'limit' => $limit,
             'window_seconds' => $windowSeconds,
@@ -51,10 +85,10 @@ final readonly class CheckRateLimitAction
             $rateLimit->block($windowSeconds);
             Cache::put($blockedKey, true, $windowSeconds);
 
-            throw new RateLimitExceededException(
-                "Rate limit exceeded for {$limitType}: {$identifier}. Limit: {$limit} requests per {$windowSeconds} seconds"
-            );
+            return true;
         }
+
+        return false;
     }
 
     private function getDefaultLimit(string $limitType): int

--- a/tests/Actions/CheckRateLimitActionTest.php
+++ b/tests/Actions/CheckRateLimitActionTest.php
@@ -62,3 +62,30 @@ it('resets when window elapsed then counts again', function (): void {
     expect($fresh->hits)->toBe(1)
         ->and($fresh->reset_at->isFuture())->toBeTrue();
 });
+
+it('increments an existing active window without creating duplicate records', function (): void {
+    $action = resolve(CheckRateLimitAction::class);
+    $identifier = '3.3.3.3';
+
+    RateLimit::query()->create([
+        'identifier' => $identifier,
+        'limit_type' => 'ip',
+        'context' => 'checkout',
+        'hits' => 1,
+        'limit' => 5,
+        'window_seconds' => 60,
+        'reset_at' => now()->addMinute(),
+        'is_blocked' => false,
+    ]);
+
+    $action->handle('ip', $identifier, 'checkout', 5, 60);
+
+    $rows = RateLimit::query()
+        ->where('identifier', $identifier)
+        ->where('limit_type', 'ip')
+        ->where('context', 'checkout')
+        ->get();
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows->first()->hits)->toBe(2);
+});

--- a/tests/Actions/CheckRateLimitDefaultsTest.php
+++ b/tests/Actions/CheckRateLimitDefaultsTest.php
@@ -17,11 +17,10 @@ it('uses configured defaults for different limit types', function (): void {
 
     $action = resolve(CheckRateLimitAction::class);
 
-    // Should not throw on first hit for any type when using defaults
     $action->handle('ip', '9.9.9.9');
     $action->handle('user', 'user-1', 'ctx');
     $action->handle('merchant', 'merchant-1');
-    $action->handle('unknown', 'x'); // exercise default branch
+    $action->handle('unknown', 'x');
 
     expect(true)->toBeTrue();
 });


### PR DESCRIPTION
Problem: Fixes #170. Rate-limit hit recording used separate read/create/increment operations, leaving burst traffic exposed to race conditions.

Root cause: `CheckRateLimitAction` resolved or created a `RateLimit` row, reset expired windows, incremented hits, and blocked the row as independent operations without a per-window critical section.

Solution:
- Serialize each rate-limit window with a cache lock keyed by limit type, identifier, and context.
- Run row lookup, reset, increment, and block inside a database transaction with `lockForUpdate()`.
- Persist the limit-exceeded hit and block state before throwing the domain exception.
- Add regression coverage that existing active windows are incremented without duplicate rows.
- Keep the existing threshold semantics: the request that pushes hits above the limit is recorded and rejected.

Validation:
- `./vendor/bin/pest tests/Actions/CheckRateLimitActionTest.php tests/Actions/CheckRateLimitDefaultsTest.php tests/Models/RateLimitTest.php --compact`
- `composer test`

Risk/rollback: The implementation depends on Laravel cache locks. Supported Redis, database, file, and array stores expose lock semantics; applications should avoid cache stores without lock support for payment rate limiting.
