### PR TITLE
fix(fingerprint): normalize SISP amounts safely

### DIFF
--- a/src/Actions/FingerPrint/PaymentResponseFingerPrintAction.php
+++ b/src/Actions/FingerPrint/PaymentResponseFingerPrintAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions\FingerPrint;
 
 use Akira\Sisp\Actions\PostAutCode;
+use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 
 final readonly class PaymentResponseFingerPrintAction
@@ -15,7 +16,7 @@ final readonly class PaymentResponseFingerPrintAction
     {
         $posAutCode = $this->postAutCode->handle();
 
-        $amountThousandths = (int) ((float) $payload->amount * 1000);
+        $amountThousandths = SispAmount::toThousandths($payload->amount);
 
         $fields = [
             $posAutCode,

--- a/src/Actions/GenerateFingerprintAction.php
+++ b/src/Actions/GenerateFingerprintAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
+use Akira\Sisp\Support\SispAmount;
+
 final readonly class GenerateFingerprintAction
 {
     public function __construct(private PostAutCode $postAutCode) {}
@@ -17,7 +19,7 @@ final readonly class GenerateFingerprintAction
 
     private function buildFingerprintContent(array $data): string
     {
-        $parsedAmount = (int) ((float) $data['amount'] * 1000);
+        $parsedAmount = SispAmount::toThousandths($data['amount']);
 
         return $this->postAutCode->handle()
             .($data['timeStamp'] ?? '')

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -14,6 +14,7 @@ use Akira\Sisp\Events\PaymentFailed;
 use Akira\Sisp\Events\PaymentPending;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 
 final readonly class HandleCallbackAction
@@ -75,7 +76,7 @@ final readonly class HandleCallbackAction
 
     private function amountMatches(float|int|string $expected, float|int|string $actual): bool
     {
-        return (int) round((float) $expected * 1000) === (int) round((float) $actual * 1000);
+        return SispAmount::toThousandths($expected) === SispAmount::toThousandths($actual);
     }
 
     private function failTransaction(Transaction $transaction, CallbackPayload $payload): void

--- a/src/Support/SispAmount.php
+++ b/src/Support/SispAmount.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Support;
+
+final readonly class SispAmount
+{
+    public static function toThousandths(float|int|string $amount): int
+    {
+        $decimal = self::decimalString($amount);
+
+        if ($decimal === null) {
+            return (int) round((float) $amount * 1000);
+        }
+
+        return self::decimalStringToThousandths($decimal);
+    }
+
+    private static function decimalString(float|int|string $amount): ?string
+    {
+        if (is_float($amount)) {
+            return number_format($amount, 10, '.', '');
+        }
+
+        $decimal = mb_trim((string) $amount);
+
+        if ($decimal === '') {
+            return null;
+        }
+
+        return preg_match('/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/', $decimal) === 1
+            ? $decimal
+            : null;
+    }
+
+    private static function decimalStringToThousandths(string $decimal): int
+    {
+        $sign = 1;
+
+        if (str_starts_with($decimal, '-')) {
+            $sign = -1;
+            $decimal = mb_substr($decimal, 1);
+        } elseif (str_starts_with($decimal, '+')) {
+            $decimal = mb_substr($decimal, 1);
+        }
+
+        [$units, $fraction] = array_pad(explode('.', $decimal, 2), 2, '');
+
+        $units = $units === '' ? '0' : $units;
+        $fraction = mb_str_pad($fraction, 4, '0');
+
+        $thousandths = ((int) $units * 1000) + (int) mb_substr($fraction, 0, 3);
+
+        if ((int) $fraction[3] >= 5) {
+            $thousandths++;
+        }
+
+        return $sign * $thousandths;
+    }
+}

--- a/tests/Actions/GenerateFingerprintActionTest.php
+++ b/tests/Actions/GenerateFingerprintActionTest.php
@@ -24,7 +24,7 @@ it('generates the known SISP request fingerprint vector', function (): void {
     expect($fingerprint)->toBe('xoYJjgMu1BZN/pZHxIj2GL9gyulZjByJ/moOMc6iDd/N962z6GYHGqZfnIQKoxfxpUiM79NvA6WrasgecGAqJg==');
 });
 
-it('amount is converted to integer milliseconds', function (): void {
+it('amount is converted to integer thousandths', function (): void {
     $data1 = [
         'timeStamp' => '2024-01-15 14:30:00',
         'amount' => 100.50,
@@ -49,6 +49,22 @@ it('amount is converted to integer milliseconds', function (): void {
     $fingerprint2 = $this->action->handle($data2);
 
     expect($fingerprint1)->toBe($fingerprint2);
+});
+
+it('normalizes decimal amounts to SISP thousandths before fingerprinting', function (): void {
+    $fingerprintData = [
+        'timeStamp' => '2024-01-15 14:30:00',
+        'amount' => 8.03,
+        'merchantRef' => 'test-ref-803',
+        'merchantSession' => 'test-session-803',
+        'posID' => 'POS-001',
+        'currency' => 'AOA',
+        'transactionCode' => 'PURCHASE',
+    ];
+
+    $fingerprint = $this->action->handle($fingerprintData);
+
+    expect($fingerprint)->toBe('Yr0dM+VllFj8HUK9HdwOkS5Cwd2iPdJ5FSweuVnYttxnuYXP88c0ijnxy5iKQp3eF32NKCVJF7lovl4Xug3YnA==');
 });
 
 it('different amounts generate different fingerprints', function (): void {

--- a/tests/Actions/ValidateFingerprintActionTest.php
+++ b/tests/Actions/ValidateFingerprintActionTest.php
@@ -65,6 +65,31 @@ it('fingerprint rejects altered amount', function (): void {
     expect($this->action->handle($alteredPayload))->toBeFalse();
 });
 
+it('accepts response fingerprint when decimal amount would otherwise truncate', function (): void {
+    $payloadData = [
+        'messageType' => 'S',
+        'merchantRespCP' => '01',
+        'merchantRespTid' => '987654321',
+        'merchantRespMerchantRef' => 'R20251112123456',
+        'merchantRespMerchantSession' => 'S20251112123456',
+        'merchantRespPurchaseAmount' => '8.03',
+        'merchantRespMessageID' => 'ABCDEF12345',
+        'merchantRespPan' => '504150XXXXXX1234',
+        'merchantResp' => '00',
+        'merchantRespTimeStamp' => '2025-11-12 14:34:56',
+        'merchantRespReferenceNumber' => '123456789',
+        'merchantRespEntityCode' => '10010',
+        'merchantRespClientReceipt' => '**********',
+        'merchantRespAdditionalErrorMessage' => '',
+        'reloadCode' => '',
+        'resultFingerPrint' => 'mnY+ewvtKlfO1HR4TOq3lwOha5Wff6Wc6SLu8t6KsbBJnWJ+5yE8Mf+HyzVu2BNCaF2bENVRI8hO1vJHNhMlRQ==',
+    ];
+
+    $payload = CallbackPayload::from($payloadData);
+
+    expect($this->action->handle($payload))->toBeTrue();
+});
+
 it('fingerprint rejects altered message type', function (): void {
     $payloadData = [
         'messageType' => 'S',

--- a/tests/Support/SispAmountTest.php
+++ b/tests/Support/SispAmountTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Support\SispAmount;
+
+it('converts amounts to SISP thousandths without float truncation', function (float|int|string $amount, int $expected): void {
+    expect(SispAmount::toThousandths($amount))->toBe($expected);
+})->with([
+    'decimal string' => ['8.03', 8030],
+    'decimal float' => [8.03, 8030],
+    'already whole amount' => [1000, 1000000],
+    'two decimals' => ['100.50', 100500],
+    'three decimals' => ['0.001', 1],
+    'rounds fourth decimal up' => ['8.0295', 8030],
+    'keeps fourth decimal below half down' => ['8.0294', 8029],
+]);


### PR DESCRIPTION
Problem: Fixes #188. Fingerprint amount normalization used direct float multiplication and integer casts, which can truncate decimal amounts such as 8.03 to 8029 thousandths.

Root cause: Request and callback fingerprint generation converted amounts independently with `(int) ((float) $amount * 1000)`, making the conversion sensitive to floating-point precision.

Solution: Added a shared SISP amount normalizer that converts integers, floats, and decimal strings to thousandths with deterministic rounding. Request fingerprints, callback response fingerprints, and callback amount reconciliation now use the same conversion path.

Validation:
- vendor/bin/pest tests/Support/SispAmountTest.php tests/Actions/GenerateFingerprintActionTest.php tests/Actions/ValidateFingerprintActionTest.php --compact
- COMPOSER_PROCESS_TIMEOUT=0 composer test

Risk/rollback: Low. The change is scoped to amount normalization before fingerprint and reconciliation comparisons. Roll back this PR to restore the previous cast-based behavior.
