### PR TITLE
fix(security): clarify unsupported controls

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -352,28 +352,30 @@ return [
     |--------------------------------------------------------------------------
     |
     | Advanced security settings for payment transaction protection.
-    | Configure fraud detection, VPN/proxy blocking, and transaction limits.
+    | The package enforces blacklist and rate-limit controls. VPN detection,
+    | proxy detection, risk scoring, country blocking, and whitelist checks are
+    | reserved for application-level integrations or future package features.
     |
     | - 'collect_metadata': Collect device and browser metadata for fraud detection
-    | - 'detect_vpn': Detect and flag transactions from VPN services
-    | - 'detect_proxy': Detect and flag transactions from proxy services
-    | - 'calculate_risk_score': Calculate risk score for each transaction
+    | - 'detect_vpn': Planned flag for external VPN detection integrations
+    | - 'detect_proxy': Planned flag for external proxy detection integrations
+    | - 'calculate_risk_score': Planned flag for external risk scoring
     | - 'max_amount_per_day': Maximum transaction amount allowed per day (null = unlimited)
     | - 'max_amount_per_month': Maximum transaction amount allowed per month (null = unlimited)
-    | - 'block_new_country_payments': Block payments from countries where user hasn't transacted before
-    | - 'block_vpn_proxy': Block transactions from detected VPN/proxy services
-    | - 'require_whitelist': Require IP addresses to be whitelisted before payment
+    | - 'block_new_country_payments': Planned country-blocking control
+    | - 'block_vpn_proxy': Planned VPN and proxy blocking control
+    | - 'require_whitelist': Planned IP whitelist control
     |
     */
     'security' => [
         'collect_metadata' => env('SISP_COLLECT_METADATA', true),
-        'detect_vpn' => env('SISP_DETECT_VPN', true),
-        'detect_proxy' => env('SISP_DETECT_PROXY', true),
-        'calculate_risk_score' => env('SISP_CALCULATE_RISK_SCORE', true),
+        'detect_vpn' => env('SISP_DETECT_VPN', false),
+        'detect_proxy' => env('SISP_DETECT_PROXY', false),
+        'calculate_risk_score' => env('SISP_CALCULATE_RISK_SCORE', false),
         'max_amount_per_day' => env('SISP_MAX_AMOUNT_PER_DAY'),
         'max_amount_per_month' => env('SISP_MAX_AMOUNT_PER_MONTH'),
         'block_new_country_payments' => env('SISP_BLOCK_NEW_COUNTRY_PAYMENTS', false),
-        'block_vpn_proxy' => env('SISP_BLOCK_VPN_PROXY', true),
+        'block_vpn_proxy' => env('SISP_BLOCK_VPN_PROXY', false),
         'require_whitelist' => env('SISP_REQUIRE_WHITELIST', false),
     ],
 

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -233,12 +233,17 @@ Use this to add CSRF, authentication, tenancy, or custom authorization checks to
 
 ```env
 SISP_COLLECT_METADATA=true         # Collect IP, device, geolocation
-SISP_DETECT_VPN=true               # Detect VPN usage
-SISP_DETECT_PROXY=true             # Detect proxy usage
-SISP_CALCULATE_RISK_SCORE=true     # Calculate fraud risk score
-SISP_BLOCK_VPN_PROXY=true          # Block VPN/proxy requests
-SISP_REQUIRE_WHITELIST=false       # Require IP whitelist
+SISP_DETECT_VPN=false              # Reserved for external VPN detection
+SISP_DETECT_PROXY=false            # Reserved for external proxy detection
+SISP_CALCULATE_RISK_SCORE=false    # Reserved for external risk scoring
+SISP_BLOCK_VPN_PROXY=false         # Reserved for external VPN and proxy blocking
+SISP_REQUIRE_WHITELIST=false       # Reserved for external IP whitelist enforcement
 ```
+
+The package currently enforces blacklist and rate-limit checks. VPN detection,
+proxy detection, risk scoring, country blocking, and whitelist enforcement are
+not built in. Add custom middleware or application services if your project
+requires those controls.
 
 ### Amount Limits
 
@@ -432,10 +437,10 @@ SISP_RATE_LIMIT_PER_USER_WINDOW=3600
 
 # Security
 SISP_COLLECT_METADATA=true
-SISP_DETECT_VPN=true
-SISP_DETECT_PROXY=true
-SISP_CALCULATE_RISK_SCORE=true
-SISP_BLOCK_VPN_PROXY=true
+SISP_DETECT_VPN=false
+SISP_DETECT_PROXY=false
+SISP_CALCULATE_RISK_SCORE=false
+SISP_BLOCK_VPN_PROXY=false
 SISP_REQUIRE_WHITELIST=false
 SISP_MAX_AMOUNT_PER_DAY=
 SISP_MAX_AMOUNT_PER_MONTH=

--- a/docs/04-payment-flow.md
+++ b/docs/04-payment-flow.md
@@ -86,7 +86,11 @@ Before creating transaction:
 - Captures IP address
 - Device information
 - Geolocation data (if enabled)
-- Risk score calculation
+- Risk score fields for application-level integrations
+
+The package does not perform VPN detection, proxy detection, risk scoring, or
+whitelist enforcement by itself. Use custom middleware or blacklist entries for
+those controls.
 
 ## Step 4: Transaction Creation
 

--- a/docs/07-security.md
+++ b/docs/07-security.md
@@ -167,24 +167,27 @@ echo $metadata->city;               // Geolocation city
 echo $metadata->latitude;           // Geolocation latitude
 echo $metadata->longitude;          // Geolocation longitude
 echo $metadata->isp;                // Internet service provider
-echo $metadata->is_vpn;             // VPN detected (boolean)
-echo $metadata->is_proxy;           // Proxy detected (boolean)
+echo $metadata->is_vpn;             // Reserved for external VPN detection
+echo $metadata->is_proxy;           // Reserved for external proxy detection
 echo $metadata->is_mobile;          // Mobile device (boolean)
-echo $metadata->risk_score;         // Risk score 0-100
-echo $metadata->risk_reason;        // Why risk score was assigned
+echo $metadata->risk_score;         // Reserved risk score, defaults to 0
+echo $metadata->risk_reason;        // Reserved risk explanation
 ```
 
-### Enable/Disable Collection
+### Configure Collection
 
 ```env
 SISP_COLLECT_METADATA=true
-SISP_DETECT_VPN=true
-SISP_DETECT_PROXY=true
-SISP_CALCULATE_RISK_SCORE=true
-SISP_BLOCK_VPN_PROXY=true
+SISP_DETECT_VPN=false
+SISP_DETECT_PROXY=false
+SISP_CALCULATE_RISK_SCORE=false
+SISP_BLOCK_VPN_PROXY=false
 ```
 
-When `SISP_BLOCK_VPN_PROXY=true`, requests from VPN/proxy will be rejected with 403.
+The package does not perform VPN detection, proxy detection, risk scoring, or
+whitelist enforcement by itself. These flags are reserved for application-level
+integrations. Use blacklist entries, rate limits, or custom middleware to block
+requests before creating payment transactions.
 
 ## Geolocation
 
@@ -213,10 +216,10 @@ use Akira\Sisp\Models\RequestMetadata;
 // Get metadata for transaction
 $metadata = RequestMetadata::where('transaction_id', $transactionId)->first();
 
-// High risk transactions
+// Application-assigned risk values
 $risky = RequestMetadata::where('risk_score', '>=', 70)->get();
 
-// VPN/Proxy users
+// Application-assigned VPN and proxy flags
 $suspicious = RequestMetadata::where(function ($q) {
     $q->where('is_vpn', true)
         ->orWhere('is_proxy', true);

--- a/docs/08-examples.md
+++ b/docs/08-examples.md
@@ -328,7 +328,7 @@ $englishTransactions = Transaction::where('locale', 'en')
     ->where('status', TransactionStatus::completed)
     ->count();
 
-// Transactions with high risk score
+// Transactions with application-assigned risk score
 $risky = Transaction::with('metadata')
     ->whereHas('metadata', fn ($q) => $q->where('risk_score', '>=', 70))
     ->get();
@@ -426,7 +426,7 @@ if ($failedCount >= 3) {
     );
 }
 
-// Monitor high-risk IPs
+// Monitor application-assigned high-risk IPs
 $riskMetadata = RequestMetadata::where('risk_score', '>=', 80)
     ->where('created_at', '>=', now()->subHour())
     ->get();
@@ -436,7 +436,7 @@ foreach ($riskMetadata as $metadata) {
         type: 'ip',
         value: $metadata->ip_address,
         severity: 'medium',
-        reason: 'High fraud risk score',
+        reason: 'Application-assigned fraud risk score',
         expiresInMinutes: 1440  // 24 hours
     );
 }
@@ -513,7 +513,7 @@ Analyze payment risk and security metrics.
 ```php
 use Akira\Sisp\Models\RequestMetadata;
 
-// VPN/Proxy detection
+// Application-assigned VPN and proxy flags
 $vpnUsers = RequestMetadata::where(function ($q) {
     $q->where('is_vpn', true)
         ->orWhere('is_proxy', true);
@@ -522,7 +522,7 @@ $vpnUsers = RequestMetadata::where(function ($q) {
 // Mobile payments
 $mobilePayments = RequestMetadata::where('is_mobile', true)->count();
 
-// High-risk transactions
+// Application-assigned high-risk transactions
 $highRisk = RequestMetadata::where('risk_score', '>=', 70)
     ->orderByDesc('risk_score')
     ->get();

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -208,11 +208,10 @@ Your `APP_KEY` is used for encryption. Never change it after storing data, or en
 
 The package provides several tools:
 
-1. **Rate limiting** - Limit requests per IP/merchant/user
-2. **Blacklist** - Block suspicious IPs/emails
-3. **VPN/Proxy detection** - Identify risky connections
-4. **Risk scoring** - Calculate fraud likelihood
-5. **Metadata collection** - Analyze device fingerprints, geolocation
+1. **Rate limiting** - Limit requests per IP, merchant, or user.
+2. **Blacklist** - Block suspicious IPs and emails.
+3. **Metadata collection** - Store device fingerprints and geolocation data.
+4. **Application extensions** - Add custom middleware for VPN detection, proxy detection, whitelist checks, or risk scoring.
 
 ### What data is collected?
 
@@ -221,8 +220,8 @@ Request metadata includes:
 - IP address, user agent, browser, OS
 - Device type and fingerprint
 - Geolocation (country, city, coordinates)
-- VPN/Proxy detection
-- Risk score calculation
+- Reserved VPN and proxy flags for application integrations
+- Reserved risk score fields for application integrations
 
 Disable collection if not needed:
 
@@ -230,16 +229,17 @@ Disable collection if not needed:
 SISP_COLLECT_METADATA=false
 ```
 
-### Can I block VPN/Proxy users?
+### Can I block VPN and proxy users?
 
-Yes:
+Not with package defaults. The package does not perform VPN or proxy detection
+by itself. Use custom middleware or an application service to detect those
+requests, then add the IP to the blacklist or block the request before payment
+creation.
 
 ```env
-SISP_DETECT_VPN=true
-SISP_BLOCK_VPN_PROXY=true
+SISP_DETECT_VPN=false
+SISP_BLOCK_VPN_PROXY=false
 ```
-
-When enabled, VPN/proxy requests return HTTP 403.
 
 ### How are callbacks verified?
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -205,11 +205,11 @@ $metadata->os                     // Windows/macOS/Linux/iOS/Android
 $metadata->device_fingerprint     // SHA256 hash of device
 $metadata->response_time_ms       // API response time in milliseconds
 $metadata->api_version            // API version used
-$metadata->is_vpn                 // VPN detected (boolean)
-$metadata->is_proxy               // Proxy detected (boolean)
+$metadata->is_vpn                 // Reserved for external VPN detection
+$metadata->is_proxy               // Reserved for external proxy detection
 $metadata->is_mobile              // Mobile device (boolean)
-$metadata->risk_score             // Fraud risk score 0-100
-$metadata->risk_reason            // Why risk was assigned
+$metadata->risk_score             // Reserved risk score, defaults to 0
+$metadata->risk_reason            // Reserved risk explanation
 $metadata->custom_metadata        // Custom metadata (array)
 $metadata->created_at             // Created timestamp
 $metadata->updated_at             // Updated timestamp

--- a/src/Actions/StoreRequestMetadataAction.php
+++ b/src/Actions/StoreRequestMetadataAction.php
@@ -38,6 +38,8 @@ final readonly class StoreRequestMetadataAction
                 'is_vpn' => $ipInfo['is_vpn'] ?? false,
                 'is_proxy' => $ipInfo['is_proxy'] ?? false,
                 'is_mobile' => $this->isMobileDevice($request),
+                'risk_score' => 0,
+                'risk_reason' => null,
             ]);
     }
 

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -205,7 +205,7 @@ final readonly class LoadConfig
 
     public function shouldBlockVpnProxy(): bool
     {
-        return $this->config->get('sisp.security.block_vpn_proxy', true);
+        return $this->config->get('sisp.security.block_vpn_proxy', false);
     }
 
     public function shouldBlockNewCountryPayments(): bool
@@ -215,17 +215,17 @@ final readonly class LoadConfig
 
     public function isVpnDetectionEnabled(): bool
     {
-        return $this->config->get('sisp.security.detect_vpn', true);
+        return $this->config->get('sisp.security.detect_vpn', false);
     }
 
     public function isProxyDetectionEnabled(): bool
     {
-        return $this->config->get('sisp.security.detect_proxy', true);
+        return $this->config->get('sisp.security.detect_proxy', false);
     }
 
     public function isRiskScoringEnabled(): bool
     {
-        return $this->config->get('sisp.security.calculate_risk_score', true);
+        return $this->config->get('sisp.security.calculate_risk_score', false);
     }
 
     public function getRateLimitPerIp(): int

--- a/tests/Actions/StoreRequestMetadataActionTest.php
+++ b/tests/Actions/StoreRequestMetadataActionTest.php
@@ -57,7 +57,6 @@ it('detects browser/OS/device/mobile flags from user-agent variants', function (
 });
 
 it('handles public ip when location driver is missing', function (): void {
-    // No location.driver configured; ensure action catches and returns [] geo
     config()->set('location.driver');
 
     $action = resolve(StoreRequestMetadataAction::class);
@@ -74,6 +73,28 @@ it('handles public ip when location driver is missing', function (): void {
 
     expect($meta->country_code)->toBeNull()
         ->and($meta->country_name)->toBeNull();
+});
+
+it('stores neutral advanced security metadata without external detection support', function (): void {
+    config()->set('sisp.security.detect_vpn', true);
+    config()->set('sisp.security.detect_proxy', true);
+    config()->set('sisp.security.calculate_risk_score', true);
+    config()->set('sisp.security.block_vpn_proxy', true);
+
+    $action = resolve(StoreRequestMetadataAction::class);
+    $transaction = Transaction::factory()->create();
+
+    $request = Request::create('/test', 'GET', server: [
+        'REMOTE_ADDR' => '127.0.0.1',
+        'HTTP_USER_AGENT' => 'Mozilla/5.0',
+    ]);
+
+    $meta = $action->handle($request, $transaction);
+
+    expect($meta->is_vpn)->toBeFalse()
+        ->and($meta->is_proxy)->toBeFalse()
+        ->and($meta->risk_score)->toBe(0)
+        ->and($meta->risk_reason)->toBeNull();
 });
 
 it('detects tablet (iPad) and marks mobile true', function (): void {

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -82,6 +82,15 @@ it('reads boolean flags for features and security', function (): void {
         ->and($this->cfg->getGeolocationProvider())->toBe('ip2location');
 });
 
+it('defaults unsupported advanced security controls to disabled', function (): void {
+    expect($this->cfg->isMetadataCollectionEnabled())->toBeTrue()
+        ->and($this->cfg->isVpnDetectionEnabled())->toBeFalse()
+        ->and($this->cfg->isProxyDetectionEnabled())->toBeFalse()
+        ->and($this->cfg->isRiskScoringEnabled())->toBeFalse()
+        ->and($this->cfg->shouldBlockVpnProxy())->toBeFalse()
+        ->and($this->cfg->shouldBlockNewCountryPayments())->toBeFalse();
+});
+
 it('uses configured merchant identifier generators', function (): void {
     app()->singleton('sisp.test.merchantReference', fn (): object => new class
     {


### PR DESCRIPTION
Problem: Fixes #180. The package advertised VPN/proxy blocking, risk scoring, country blocking, and whitelist enforcement as if they were runtime controls.

Root cause: the runtime only enforced blacklist and rate limits. Advanced security fields were metadata placeholders and defaulted to enabled in config/docs, creating a false security guarantee.

Solution: mark unsupported advanced controls as planned/application-level integrations, default those flags to disabled, keep request metadata neutral, and update docs to describe actual runtime behavior.

Validation:
- vendor/bin/pest tests/Configuration/LoadConfigMoreTest.php tests/Actions/StoreRequestMetadataActionTest.php --compact
- COMPOSER_PROCESS_TIMEOUT=0 composer test
- git diff --check

Risk/rollback: low runtime risk. Existing apps that explicitly enable these flags still keep metadata neutral; they must add custom middleware/services for enforcement until the package ships first-class support.
