### PR TITLE
fix(config): publish middleware defaults

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -409,6 +409,8 @@ return [
     |
     */
     'middleware' => [
+        'payment' => [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class],
+        'retry' => [],
         'refund' => ['web', 'auth'],
     ],
 

--- a/tests/Routes/SispRouteMiddlewareTest.php
+++ b/tests/Routes/SispRouteMiddlewareTest.php
@@ -6,6 +6,22 @@ use Akira\Sisp\Http\Middleware\ProtectPaymentRoute;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Route;
 
+it('publishes middleware defaults for configurable state-changing routes', function (): void {
+    expect(config('sisp.middleware.payment'))->toBe([ProtectPaymentRoute::class])
+        ->and(config('sisp.middleware.retry'))->toBe([])
+        ->and(config('sisp.middleware.refund'))->toBe(['web', 'auth']);
+});
+
+it('uses published middleware defaults for payment and retry routes', function (): void {
+    withReloadedSispRoutes(function (): void {
+        $paymentMiddleware = Route::getRoutes()->getByName('sisp.payment')->gatherMiddleware();
+        $retryMiddleware = Route::getRoutes()->getByName('sisp.retry-payment')->gatherMiddleware();
+
+        expect($paymentMiddleware)->toContain(ProtectPaymentRoute::class)
+            ->and($retryMiddleware)->toBe([]);
+    });
+});
+
 it('uses configurable middleware for payment and retry routes', function (): void {
     config()->set('sisp.middleware.payment', ['web', 'auth', ProtectPaymentRoute::class]);
     config()->set('sisp.middleware.retry', ['web', 'auth']);


### PR DESCRIPTION
Problem: Fixes #178. Published config omitted the `payment` and `retry` middleware keys even though routes already read them.

Root cause: `config/sisp.php` only documented and published `middleware.refund`, so users could not discover or override all supported route middleware knobs from the published config.

Solution: add published defaults for `middleware.payment` and `middleware.retry`, preserving `ProtectPaymentRoute::class` for payment and an intentionally empty retry middleware list.

Validation:
- vendor/bin/pest tests/Routes/SispRouteMiddlewareTest.php --compact
- COMPOSER_PROCESS_TIMEOUT=0 composer test
- git diff --check

Risk/rollback: low. Existing apps overriding any `sisp.middleware.*` key keep their configured values; this only fills missing published defaults.
