### PR TITLE
fix(invoice): honor configured pdf path

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -273,6 +273,7 @@ return [
     | - 'number_format': Format for invoice numbers (date-based, sequential, etc.)
     | - 'prefix': Prefix to add to invoice numbers (e.g., 'INV-')
     | - 'disk': Laravel filesystem disk for storing invoices
+    | - 'path': Directory inside the configured disk for generated PDFs
     | - 'template': Template style for invoice generation (branded, minimal, etc.)
     | - 'temporary_url_expiration_hours': Hours for S3 temporary URL expiration (default: 24)
     | - 'company_*': Company information displayed on invoices
@@ -282,6 +283,7 @@ return [
         'number_format' => env('SISP_INVOICE_NUMBER_FORMAT', 'date-based'),
         'prefix' => env('SISP_INVOICE_NUMBER_PREFIX', 'INV'),
         'disk' => env('SISP_INVOICE_DISK', 'public'),
+        'path' => env('SISP_INVOICE_PATH', 'invoices'),
         'template' => env('SISP_INVOICE_TEMPLATE', 'branded'),
         'temporary_url_expiration_hours' => env('SISP_INVOICE_TEMPORARY_URL_EXPIRATION_HOURS', 24),
         'company_name' => env('SISP_COMPANY_NAME', ''),

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -84,7 +84,10 @@ SISP_INVOICE_TEMPLATE=modern       # modern, minimal, or branded
 SISP_INVOICE_NUMBER_FORMAT=date-based
 SISP_INVOICE_NUMBER_PREFIX=INV
 SISP_INVOICE_DISK=public           # Storage disk for PDFs
+SISP_INVOICE_PATH=invoices         # Directory inside the disk for PDFs
 ```
+
+`SISP_INVOICE_PATH` is relative to the configured filesystem disk. With the default `public` disk it resolves under `storage/app/public`. With S3 it is used as the object key prefix.
 
 ## Rendering Engine Configuration
 

--- a/docs/06-invoice-generation.md
+++ b/docs/06-invoice-generation.md
@@ -92,7 +92,7 @@ Result: `INV-20250101-001`, `INV-20250101-002`, etc.
 
 ## PDF Storage
 
-PDFs are stored in `storage/app/public/invoices/` with UUID filenames:
+By default, PDFs are stored on the `public` disk under the `invoices` directory with UUID filenames:
 
 ```php
 echo $invoice->pdf_path;  // 'invoices/550e8400-e29b-41d4-a716-446655440000.pdf'
@@ -176,10 +176,14 @@ Configure where invoices are stored:
 ```env
 # Local storage (default)
 SISP_INVOICE_DISK=public
+SISP_INVOICE_PATH=invoices
 
 # Or S3 storage
 SISP_INVOICE_DISK=s3
+SISP_INVOICE_PATH=invoices
 ```
+
+`SISP_INVOICE_DISK` selects the Laravel filesystem disk. `SISP_INVOICE_PATH` selects the directory inside that disk. With the default local `public` disk, the path resolves to `storage/app/public/invoices`. With S3, the same value is used as the object key prefix, for example `invoices/uuid.pdf`.
 
 ### S3 Temporary URL Expiration
 

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -174,7 +174,7 @@ SISP_INVOICE_TEMPLATE=modern
 
 ### Where are PDF files stored?
 
-PDFs are stored in `storage/app/public/invoices/`. Make sure this directory is writable.
+By default, PDFs are stored in `storage/app/public/invoices/`. Configure `SISP_INVOICE_DISK` and `SISP_INVOICE_PATH` to store them on another Laravel filesystem disk or directory.
 
 ### Can I attach invoices to emails?
 

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
+    ->withParallel(timeoutSeconds: 300)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/config',

--- a/src/Actions/GenerateInvoicePdfAction.php
+++ b/src/Actions/GenerateInvoicePdfAction.php
@@ -74,7 +74,8 @@ final readonly class GenerateInvoicePdfAction
 
         $filename = Str::uuid().'.pdf';
         $storageDisk = $this->config->getInvoiceStorageDisk();
-        $relativePath = "invoices/$filename";
+        $storagePath = mb_trim((string) config('sisp.invoice.path', 'invoices'), '/') ?: 'invoices';
+        $relativePath = "{$storagePath}/{$filename}";
 
         Storage::disk($storageDisk)->put($relativePath, $pdfContent);
 

--- a/src/Commands/DoctorCommand.php
+++ b/src/Commands/DoctorCommand.php
@@ -18,18 +18,15 @@ final class DoctorCommand extends Command
 
     public function handle(): int
     {
-        $this->info('🔍 Diagnosing Invoice PDF Issues...');
+        $this->info('Diagnosing Invoice PDF Issues...');
         $this->newLine();
 
-        // Check configuration
         $this->checkConfiguration();
         $this->newLine();
 
-        // Check storage
         $this->checkStorage();
         $this->newLine();
 
-        // Check invoices
         $this->checkInvoices();
         $this->newLine();
 
@@ -38,12 +35,12 @@ final class DoctorCommand extends Command
 
     private function checkConfiguration(): void
     {
-        $this->info('📋 Configuration Check:');
+        $this->info('Configuration Check:');
 
         $disk = config('sisp.invoice.disk', 'public');
         $this->line("  Disk: <info>{$disk}</info>");
 
-        $path = config('sisp.invoice.path', 'invoices');
+        $path = $this->invoiceStoragePath();
         $this->line("  Path: <info>{$path}</info>");
 
         $driver = config("filesystems.disks.{$disk}.driver");
@@ -62,43 +59,41 @@ final class DoctorCommand extends Command
 
     private function checkStorage(): void
     {
-        $this->info('💾 Storage Check:');
+        $this->info('Storage Check:');
 
         $disk = config('sisp.invoice.disk', 'public');
 
         try {
             $exists = Storage::disk($disk)->exists('');
             $this->line($exists
-                ? '  ✅ Storage disk is accessible'
-                : '  ❌ Storage disk is not accessible');
+                ? '  Storage disk is accessible'
+                : '  Storage disk is not accessible');
         } catch (Throwable $e) {
-            $this->error("  ❌ Error accessing storage: {$e->getMessage()}");
+            $this->error("  Error accessing storage: {$e->getMessage()}");
         }
 
-        // Check if directory is writable
-        $path = config('sisp.invoice.path', 'invoices');
+        $path = $this->invoiceStoragePath();
 
         try {
             Storage::disk($disk)->makeDirectory($path);
-            $this->line('  ✅ Invoice directory exists or was created');
+            $this->line('  Invoice directory exists or was created');
         } catch (Throwable $e) {
-            $this->error("  ❌ Cannot create invoice directory: {$e->getMessage()}");
+            $this->error("  Cannot create invoice directory: {$e->getMessage()}");
         }
 
-        // Try to write a test file
         try {
             $testFile = $path.'/test.txt';
             Storage::disk($disk)->put($testFile, 'test');
             Storage::disk($disk)->delete($testFile);
-            $this->line('  ✅ Can write to invoice directory');
+            $this->line('  Can write to invoice directory');
         } catch (Throwable $e) {
-            $this->error("  ❌ Cannot write to invoice directory: {$e->getMessage()}");
+            $this->error("  Cannot write to invoice directory: {$e->getMessage()}");
         }
     }
 
     private function checkInvoices(): void
     {
-        $this->info('📄 Invoice Status:');
+        $this->info('Invoice Status:');
 
         $totalInvoices = Invoice::query()->count();
         $this->line("  Total invoices: <info>{$totalInvoices}</info>");
@@ -114,9 +109,8 @@ final class DoctorCommand extends Command
             ->count();
 
         if ($paidWithoutPdf > 0) {
-            $this->warn("  ⚠️  {$paidWithoutPdf} paid invoices are missing PDFs");
+            $this->warn("  {$paidWithoutPdf} paid invoices are missing PDFs");
 
-            // Show sample
             $sample = Invoice::with('transaction')
                 ->where('status', InvoiceStatus::paid->value)
                 ->whereNull('pdf_path')
@@ -133,9 +127,14 @@ final class DoctorCommand extends Command
             }
 
             $this->newLine();
-            $this->line('  💡 Run <info>php artisan sisp:regenerate-pdfs</info> to generate missing PDFs');
+            $this->line('  Run <info>php artisan sisp:regenerate-pdfs</info> to generate missing PDFs');
         } else {
-            $this->line('  ✅ All paid invoices have PDFs');
+            $this->line('  All paid invoices have PDFs');
         }
+    }
+
+    private function invoiceStoragePath(): string
+    {
+        return mb_trim((string) config('sisp.invoice.path', 'invoices'), '/') ?: 'invoices';
     }
 }

--- a/tests/Commands/DoctorCommandTest.php
+++ b/tests/Commands/DoctorCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Storage;
 it('reports healthy storage and invoices on public disk', function (): void {
     Storage::fake('public');
     config()->set('sisp.invoice.disk', 'public');
-    config()->set('sisp.invoice.path', 'invoices');
+    config()->set('sisp.invoice.path', 'billing/pdfs');
     config()->set('filesystems.disks.public.driver', 'local');
     config()->set('filesystems.disks.public.root', storage_path('app/public'));
 
@@ -35,6 +35,8 @@ it('reports healthy storage and invoices on public disk', function (): void {
     expect($code)->toBe(0)
         ->and($output)->toContain('Configuration Check:')
         ->and($output)->toContain('Disk: ')
+        ->and($output)->toContain('Path: ')
+        ->and($output)->toContain('billing/pdfs')
         ->and($output)->toContain('Driver: ')
         ->and($output)->toContain('Root: ')
         ->and($output)->toContain('Storage disk is accessible')

--- a/tests/Invoices/GenerateInvoicePdfDueDateTest.php
+++ b/tests/Invoices/GenerateInvoicePdfDueDateTest.php
@@ -55,3 +55,19 @@ it('passes due date to invoice builder when due date is present', function (): v
     expect($pdfGenerator->lastInvoice)->not->toBeNull()
         ->and($pdfGenerator->lastInvoice?->dueAt?->toDateString())->toBe($invoice->due_date?->toDateString());
 });
+
+it('stores generated invoice pdfs in the configured path', function (): void {
+    $pdfGenerator = new CapturingPdfGenerator();
+    app()->instance(PdfGeneratorContract::class, $pdfGenerator);
+    Storage::fake('public');
+    config()->set('sisp.invoice.path', 'billing/pdfs');
+
+    $transaction = Transaction::factory()->create();
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+
+    $relativePath = resolve(GenerateInvoicePdfAction::class)->handle($invoice);
+
+    Storage::disk('public')->assertExists($relativePath);
+    expect(str_starts_with($relativePath, 'billing/pdfs/'))->toBeTrue()
+        ->and($invoice->refresh()->pdf_path)->toBe($relativePath);
+});


### PR DESCRIPTION
## Summary
- Adds the published `SISP_INVOICE_PATH` setting and uses it for generated invoice PDF paths.
- Makes `sisp:doctor` report and validate the same configured invoice directory.
- Documents local and S3 invoice disk/path behavior.
- Increases the Rector parallel timeout so `composer test` completes reliably on the full project.

## Validation
- `vendor/bin/pest tests/Invoices/GenerateInvoicePdfDueDateTest.php tests/Commands/DoctorCommandTest.php --compact`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Fixes #185