### PR TITLE
fix(retry): honor configured transaction table

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -269,6 +269,8 @@ SISP_TABLE_RATE_LIMITS=sisp_rate_limits
 SISP_TABLE_BLACKLIST=sisp_blacklist
 ```
 
+The transaction model and retry request validation read `SISP_TABLE_TRANSACTIONS`, so retry links continue to validate correctly when the transaction table is renamed.
+
 ## Configuration via Code
 
 You can also configure programmatically in a service provider:

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -343,6 +343,8 @@ SISP_TABLE_TRANSACTIONS=my_transactions
 SISP_TABLE_INVOICES=my_invoices
 ```
 
+The package models and retry validation use the configured transaction table name.
+
 ### How do I backup transaction data?
 
 Use Laravel's backup tools or database backups. Include these tables:

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
+    ->withParallel(timeoutSeconds: 300)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/config',

--- a/src/Http/Requests/RetryPaymentRequest.php
+++ b/src/Http/Requests/RetryPaymentRequest.php
@@ -8,6 +8,7 @@ use Akira\Sisp\Actions\CanRetryPaymentAction;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
 final class RetryPaymentRequest extends FormRequest
@@ -20,7 +21,7 @@ final class RetryPaymentRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'transaction' => ['required', 'integer', 'exists:sisp_transactions,id'],
+            'transaction' => ['required', 'integer', Rule::exists(new Transaction()->getTable(), 'id')],
         ];
     }
 

--- a/tests/Http/RetryPaymentRequestTest.php
+++ b/tests/Http/RetryPaymentRequestTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Http\Requests\RetryPaymentRequest;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Validator;
+
+it('validates retry transactions against the configured transaction table', function (): void {
+    config()->set('sisp.tables.transactions', 'custom_sisp_transactions');
+
+    Schema::create('custom_sisp_transactions', function (Blueprint $table): void {
+        $table->id();
+    });
+
+    DB::table('custom_sisp_transactions')->insert(['id' => 123]);
+
+    $validator = Validator::make(['transaction' => 123], new RetryPaymentRequest()->rules());
+
+    expect($validator->passes())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Uses the configured `Transaction` model table name for retry request validation instead of the hardcoded `sisp_transactions` table.
- Adds request-level coverage for a custom transaction table name.
- Documents that retry validation follows `SISP_TABLE_TRANSACTIONS`.
- Increases the Rector parallel timeout so `composer test` completes reliably on the full project.

## Validation
- `vendor/bin/pest tests/Http/RetryPaymentRequestTest.php tests/Controllers/RetryPaymentControllerTest.php tests/Http/RetryPaymentControllerTest.php --compact`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Fixes #184