### PR TITLE
fix(config): use timestamp generator

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -26,6 +26,20 @@ The locale for each transaction is automatically stored in the `locale` field of
 
 ## Optional Configuration
 
+### Generators
+
+The package resolves generator classes through the Laravel container and invokes them with no arguments:
+
+```php
+'generators' => [
+    'merchantSession' => App\Sisp\GenerateMerchantSession::class,
+    'merchantReference' => App\Sisp\GenerateMerchantReference::class,
+    'timeStamp' => App\Sisp\GenerateTimeStamp::class,
+],
+```
+
+Each generator must be an invokable class that returns a string. The `timeStamp` generator must return the SISP timestamp format `Y-m-d H:i:s`, for example `2026-05-26 14:30:00`. If a configured generator cannot be resolved or invoked, Laravel raises an exception while building the payment request.
+
 ### Retry Payments
 
 ```env

--- a/src/Actions/Generators/TimeStampGeneratorAction.php
+++ b/src/Actions/Generators/TimeStampGeneratorAction.php
@@ -10,6 +10,6 @@ final readonly class TimeStampGeneratorAction implements Generator
 {
     public function __invoke(): string
     {
-        return date('YmdHis');
+        return now()->format('Y-m-d H:i:s');
     }
 }

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -49,21 +49,17 @@ final readonly class LoadConfig
 
     public function getMerchantReference(): string
     {
-        $generator = $this->config->get('sisp.generators.merchantReference');
-
-        return resolve($generator)();
+        return resolve($this->config->get('sisp.generators.merchantReference'))();
     }
 
     public function getMerchantSession(): string
     {
-        $generator = $this->config->get('sisp.generators.merchantSession');
-
-        return resolve($generator)();
+        return resolve($this->config->get('sisp.generators.merchantSession'))();
     }
 
     public function getTimeStamp(): string
     {
-        return date('Y-m-d H:i:s');
+        return resolve($this->config->get('sisp.generators.timeStamp'))();
     }
 
     public function getCurrency(): string
@@ -93,9 +89,7 @@ final readonly class LoadConfig
 
     public function getUrlMerchantResponse(): string
     {
-        $configured = $this->config->get('sisp.url_merchant_response');
-
-        return $configured ?? route('sisp.callback');
+        return $this->config->get('sisp.url_merchant_response') ?? route('sisp.callback');
     }
 
     public function getLanguageMessages(): string

--- a/tests/Actions/Generators/TimeStampGeneratorActionTest.php
+++ b/tests/Actions/Generators/TimeStampGeneratorActionTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use Akira\Sisp\Actions\Generators\TimeStampGeneratorAction;
 
-it('generates a timestamp in YmdHis format', function (): void {
+it('generates a timestamp in SISP format', function (): void {
     $gen = resolve(TimeStampGeneratorAction::class);
     $ts = $gen();
 
     expect($ts)->toBeString()
-        ->and(mb_strlen($ts))->toBe(14)
-        ->and((bool) preg_match('/^\d{14}$/', $ts))->toBeTrue();
+        ->and(mb_strlen($ts))->toBe(19)
+        ->and((bool) preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $ts))->toBeTrue();
 });

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -91,7 +91,7 @@ it('defaults unsupported advanced security controls to disabled', function (): v
         ->and($this->cfg->shouldBlockNewCountryPayments())->toBeFalse();
 });
 
-it('uses configured merchant identifier generators', function (): void {
+it('uses configured payment value generators', function (): void {
     app()->singleton('sisp.test.merchantReference', fn (): object => new class
     {
         private int $next = 0;
@@ -118,10 +118,19 @@ it('uses configured merchant identifier generators', function (): void {
 
     config()->set('sisp.generators.merchantReference', 'sisp.test.merchantReference');
     config()->set('sisp.generators.merchantSession', 'sisp.test.merchantSession');
+    app()->bind('sisp.test.timeStamp', fn (): object => new class
+    {
+        public function __invoke(): string
+        {
+            return '2030-01-02 03:04:05';
+        }
+    });
+    config()->set('sisp.generators.timeStamp', 'sisp.test.timeStamp');
 
     $merchantReferences = array_map(fn (): string => $this->cfg->getMerchantReference(), range(1, 3));
     $merchantSessions = array_map(fn (): string => $this->cfg->getMerchantSession(), range(1, 3));
 
     expect($merchantReferences)->toBe(['CUSTOM-REF-1', 'CUSTOM-REF-2', 'CUSTOM-REF-3'])
-        ->and($merchantSessions)->toBe(['CUSTOM-SESSION-1', 'CUSTOM-SESSION-2', 'CUSTOM-SESSION-3']);
+        ->and($merchantSessions)->toBe(['CUSTOM-SESSION-1', 'CUSTOM-SESSION-2', 'CUSTOM-SESSION-3'])
+        ->and($this->cfg->getTimeStamp())->toBe('2030-01-02 03:04:05');
 });


### PR DESCRIPTION
## Summary
- Makes `LoadConfig::getTimeStamp()` resolve and invoke `sisp.generators.timeStamp`.
- Keeps the default timestamp output in the existing SISP format `Y-m-d H:i:s`.
- Adds coverage proving a custom timestamp generator is used.
- Documents the generator contract and expected timestamp format.
- Increases the Rector parallel timeout so `composer test` completes reliably on the full project.

## Validation
- `vendor/bin/pest tests/Configuration/LoadConfigMoreTest.php tests/Actions/Generators/TimeStampGeneratorActionTest.php --compact`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Fixes #179