### PR TITLE
feat(transaction): store canonical amount cents

### DIFF
--- a/database/migrations/create_laravel_sisp_table.php
+++ b/database/migrations/create_laravel_sisp_table.php
@@ -46,6 +46,7 @@ return new class extends Migration
             $table->string('merchant_ref');
             $table->string('merchant_session');
             $table->float('amount');
+            $table->bigInteger('amount_cents')->default(0);
             $table->string('currency')->default('132');
             $table->string('status')->default('pending');
             $table->string('transaction_code')->nullable();
@@ -56,7 +57,6 @@ return new class extends Migration
             $table->text('fingerprint')->nullable();
             $table->longText('payload')->nullable();
 
-            // Client information
             $table->string('customer_name')->nullable();
             $table->string('customer_email')->nullable();
             $table->string('customer_phone')->nullable();
@@ -112,7 +112,6 @@ return new class extends Migration
             $table->date('due_date')->nullable();
             $table->string('status')->default('pending');
 
-            // Customer information (denormalized from transaction)
             $table->string('customer_name')->nullable();
             $table->string('customer_email')->nullable();
             $table->string('customer_city')->nullable();

--- a/database/migrations/update_laravel_sisp_transactions_add_amount_cents.php
+++ b/database/migrations/update_laravel_sisp_transactions_add_amount_cents.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Support\SispAmount;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $transactionsTable = config('sisp.tables.transactions', 'sisp_transactions');
+
+        if (! Schema::hasTable($transactionsTable) || Schema::hasColumn($transactionsTable, 'amount_cents')) {
+            return;
+        }
+
+        Schema::table($transactionsTable, function (Blueprint $table): void {
+            $table->bigInteger('amount_cents')->default(0)->after('amount');
+        });
+
+        DB::table($transactionsTable)
+            ->select(['id', 'amount'])
+            ->orderBy('id')
+            ->chunkById(100, function ($transactions) use ($transactionsTable): void {
+                foreach ($transactions as $transaction) {
+                    DB::table($transactionsTable)
+                        ->where('id', $transaction->id)
+                        ->update(['amount_cents' => SispAmount::toCents($transaction->amount)]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        $transactionsTable = config('sisp.tables.transactions', 'sisp_transactions');
+
+        if (! Schema::hasTable($transactionsTable) || ! Schema::hasColumn($transactionsTable, 'amount_cents')) {
+            return;
+        }
+
+        Schema::table($transactionsTable, function (Blueprint $table): void {
+            $table->dropColumn('amount_cents');
+        });
+    }
+};

--- a/docs/04-payment-flow.md
+++ b/docs/04-payment-flow.md
@@ -254,7 +254,8 @@ TransactionRefunded::dispatch($transaction, $refundAmount, $reason);
 
 ### sisp_transactions
 - transaction_id (UUID)
-- amount (in cents)
+- amount (decimal CVE, compatibility)
+- amount_cents (integer cents, canonical storage)
 - status (pending/completed/failed)
 - merchant_ref (unique reference)
 - merchant_session

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -25,7 +25,8 @@ Access transaction data:
 
 ```php
 $transaction->merchant_ref;        // Unique reference ID
-$transaction->amount;              // Amount in cents
+$transaction->amount;              // Decimal amount in CVE
+$transaction->amount_cents;        // Canonical integer amount in cents
 $transaction->status;              // pending/completed/failed/cancelled/refunded
 $transaction->customer_email;      // Customer email
 $transaction->customer_name;       // Customer name
@@ -42,6 +43,14 @@ $transaction->refunded_at;         // Refund timestamp
 $transaction->created_at;          // Created timestamp
 $transaction->updated_at;          // Updated timestamp
 ```
+
+`amount` remains a decimal CVE value for backward compatibility. `amount_cents` is the canonical integer storage value used to avoid money precision drift before the public API is stabilized.
+
+### Breaking Change Note
+
+Before `1.0.0`, applications should treat `amount_cents` as the stable storage representation and `amount` as the compatibility accessor. A future major release may expose only integer minor-unit amounts in public APIs. Migration path: read and write decimal CVE through `amount` while also persisting `amount_cents`, then switch integrations that need exact arithmetic to `amount_cents`.
+
+After upgrading to the version that introduces `amount_cents`, publish or run the package migrations so existing rows are backfilled from `amount`.
 
 ## Formatted Amount
 

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -75,7 +75,7 @@ Only ECV (Cape Verde Escudo) is supported currently.
 
 ### What's the minimum payment amount?
 
-The minimum is 0.01 ECV. Amounts are stored in cents in the database.
+The minimum is 0.01 ECV. The public `amount` value is decimal CVE for backward compatibility, and `amount_cents` stores the canonical integer cents value.
 
 ### Can I charge fees?
 

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
+    ->withParallel(timeoutSeconds: 300)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/config',

--- a/src/Actions/RefundTransactionAction.php
+++ b/src/Actions/RefundTransactionAction.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Actions;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\TransactionRefunded;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\SispAmount;
 use LogicException;
 
 final readonly class RefundTransactionAction
@@ -48,6 +49,6 @@ final readonly class RefundTransactionAction
 
     private function amountInMinorUnits(float $amount): int
     {
-        return (int) round($amount * 100);
+        return SispAmount::toCents($amount);
     }
 }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Akira\Sisp\Models;
 
 use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\Traits\EncryptsAttributes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -25,21 +27,19 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read  string $customer_city
  * @property-read  string $customer_address
  * @property-read  int|float $amount
+ * @property-read  int $amount_cents
  */
 final class Transaction extends Model
 {
     use EncryptsAttributes;
     use HasFactory;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
+    /** @var list<string> */
     protected $fillable = [
         'merchant_ref',
         'merchant_session',
         'amount',
+        'amount_cents',
         'currency',
         'status',
         'transaction_code',
@@ -80,6 +80,7 @@ final class Transaction extends Model
     {
         return [
             'amount' => 'float',
+            'amount_cents' => 'integer',
             'status' => TransactionStatus::class,
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
@@ -100,5 +101,24 @@ final class Transaction extends Model
         return [
             'payload',
         ];
+    }
+
+    protected function amount(): Attribute
+    {
+        return Attribute::make(
+            set: fn (float|int|string $amount): array => [
+                'amount' => (float) $amount,
+                'amount_cents' => SispAmount::toCents($amount),
+            ],
+        );
+    }
+
+    protected function amountCents(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $amountCents, array $attributes): int => $amountCents !== null
+                ? (int) $amountCents
+                : SispAmount::toCents($attributes['amount'] ?? 0),
+        );
     }
 }

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -30,7 +30,10 @@ final class SispServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-sisp')
             ->hasConfigFile()
-            ->hasMigration('create_laravel_sisp_table')
+            ->hasMigrations([
+                'create_laravel_sisp_table',
+                'update_laravel_sisp_transactions_add_amount_cents',
+            ])
             ->hasTranslations()
             ->hasRoutes('web')
             ->hasCommands([
@@ -84,30 +87,24 @@ final class SispServiceProvider extends PackageServiceProvider
 
     private function registerComponents(): void
     {
-        // Load Blade views from package
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'sisp');
 
-        // Allow users to publish Blade views for customization
         $this->publishes([
             __DIR__.'/../resources/views' => resource_path('views/vendor/sisp'),
         ], 'sisp-views');
 
-        // Publish React components for customization
         $this->publishes([
             __DIR__.'/../resources/js/react/pages' => resource_path('js/pages/sisp'),
         ], 'sisp-inertia-components');
 
-        // Publish Vue components for customization
         $this->publishes([
             __DIR__.'/../resources/js/vue/pages' => resource_path('js/pages/sisp'),
         ], 'sisp-vue-components');
 
-        // Publish CSS assets
         $this->publishes([
             __DIR__.'/../resources/css' => public_path('vendor/sisp/css'),
         ], 'sisp-assets');
 
-        // Register Blade anonymous component namespace
         $this->callAfterResolving('blade.compiler', function (BladeCompiler $blade): void {
             $blade->anonymousComponentNamespace('sisp', __DIR__.'/../resources/views/components');
         });

--- a/src/Support/SispAmount.php
+++ b/src/Support/SispAmount.php
@@ -6,6 +6,11 @@ namespace Akira\Sisp\Support;
 
 final readonly class SispAmount
 {
+    public static function toCents(float|int|string $amount): int
+    {
+        return (int) round(self::toThousandths($amount) / 10);
+    }
+
     public static function toThousandths(float|int|string $amount): int
     {
         $decimal = self::decimalString($amount);
@@ -41,7 +46,9 @@ final readonly class SispAmount
         if (str_starts_with($decimal, '-')) {
             $sign = -1;
             $decimal = mb_substr($decimal, 1);
-        } elseif (str_starts_with($decimal, '+')) {
+        }
+
+        if (str_starts_with($decimal, '+')) {
             $decimal = mb_substr($decimal, 1);
         }
 

--- a/tests/Actions/RefundTransactionActionTest.php
+++ b/tests/Actions/RefundTransactionActionTest.php
@@ -19,6 +19,19 @@ it('refunds a completed transaction for the full original amount', function (): 
         ->and($updated->merchant_response)->toBe('customer_request::100');
 });
 
+it('compares decimal refund amounts using canonical cents', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 8.03,
+    ]);
+
+    $updated = resolve(RefundTransactionAction::class)->handle($t, 8.03, 'decimal_refund');
+
+    expect($updated->status->value)->toBe('refunded')
+        ->and($updated->amount)->toBe(8.03)
+        ->and($updated->amount_cents)->toBe(803);
+});
+
 it('does not allow partial refund amounts', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -28,6 +28,7 @@ it('creates transaction and renders payment form', function (): void {
     $transaction = Transaction::query()->sole();
 
     expect($transaction->amount)->toBe(100.0)
+        ->and($transaction->amount_cents)->toBe(10000)
         ->and($transaction->currency)->toBe('132')
         ->and($transaction->status->value)->toBe('pending')
         ->and($transaction->customer_name)->toBe('John')
@@ -38,6 +39,27 @@ it('creates transaction and renders payment form', function (): void {
         ->and($transaction->items->first()->product_name)->toBe('Test')
         ->and($transaction->items->first()->quantity)->toBe(1)
         ->and((float) $transaction->items->first()->total_price)->toBe(100.0);
+});
+
+it('stores decimal payment amounts with canonical cents', function (): void {
+    config()->set('sisp.rate_limiting.enabled', false);
+
+    $this->post(route('sisp.payment'), [
+        'amount' => 8.03,
+        'items' => [[
+            'product_name' => 'Decimal Amount',
+            'quantity' => 1,
+            'unit_price' => 8.03,
+            'total_price' => 8.03,
+        ]],
+        'customer_name' => 'Decimal Customer',
+        'customer_email' => 'decimal@example.test',
+    ])->assertOk();
+
+    $transaction = Transaction::query()->sole();
+
+    expect($transaction->amount)->toBe(8.03)
+        ->and($transaction->amount_cents)->toBe(803);
 });
 
 it('blocks duplicate transactions via middleware', function (): void {

--- a/tests/Models/TransactionAmountTest.php
+++ b/tests/Models/TransactionAmountTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Models\Transaction;
+
+it('falls back to amount when amount cents is missing', function (): void {
+    $transaction = new Transaction();
+    $transaction->setRawAttributes(['amount' => 8.03], true);
+
+    expect($transaction->amount_cents)->toBe(803);
+});
+
+it('prefers stored amount cents when present', function (): void {
+    $transaction = new Transaction();
+    $transaction->setRawAttributes(['amount' => 8.03, 'amount_cents' => 804], true);
+
+    expect($transaction->amount_cents)->toBe(804);
+});

--- a/tests/Support/SispAmountTest.php
+++ b/tests/Support/SispAmountTest.php
@@ -15,3 +15,13 @@ it('converts amounts to SISP thousandths without float truncation', function (fl
     'rounds fourth decimal up' => ['8.0295', 8030],
     'keeps fourth decimal below half down' => ['8.0294', 8029],
 ]);
+
+it('converts amounts to cents for canonical transaction storage', function (float|int|string $amount, int $expected): void {
+    expect(SispAmount::toCents($amount))->toBe($expected);
+})->with([
+    'decimal string' => ['8.03', 803],
+    'decimal float' => [8.03, 803],
+    'whole amount' => [1000, 100000],
+    'rounds half cent up' => ['8.025', 803],
+    'keeps below half cent down' => ['8.024', 802],
+]);


### PR DESCRIPTION
## Summary
- Keeps the public `amount` attribute as decimal CVE for backward compatibility.
- Adds `amount_cents` as canonical integer storage and backfills existing rows through an upgrade migration.
- Adds runtime fallback so models loaded without `amount_cents` still calculate cents from `amount`.
- Uses the canonical amount conversion for refund equality checks.
- Documents the pre-1.0 stabilization path and the possible future breaking change around integer minor-unit amounts.
- Increases the Rector parallel timeout so `composer test` completes reliably on the full project.

## Validation
- `vendor/bin/pest tests/Models/TransactionAmountTest.php tests/Support/SispAmountTest.php tests/Http/PaymentControllerTest.php tests/Actions/RefundTransactionActionTest.php tests/Http/CallbackControllerTest.php tests/Commands/LaravelSispInstallCommandMoreTest.php --compact`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Fixes #187