### PR TITLE
feat(status): expose transaction status facade API

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -156,6 +156,33 @@ php artisan sisp:transaction-status --transaction=123 --update
 
 `result=false` means the status API request itself failed and should not be treated as a definitive payment failure. `result=true` with `transactionSuccess=true` maps to `completed`; `result=true` with `transactionSuccess=false` maps to `failed`.
 
+### Public Status API
+
+Use the facade when application code needs a one-off status check or wants to reconcile a known transaction inside a domain workflow:
+
+```php
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\Transaction;
+
+$response = Sisp::queryTransactionStatus($transaction);
+$response = Sisp::queryTransactionStatus('R20260523235959');
+
+$updatedTransaction = Sisp::reconcileTransactionStatus($transaction);
+```
+
+`queryTransactionStatus()` returns `TransactionStatusResponse` and does not change local data. `reconcileTransactionStatus()` updates only pending transactions when SISP returns `result=true`.
+
+For multi-merchant applications, pass explicit credentials:
+
+```php
+$sisp = Sisp::forCredentials($credentials);
+
+$response = $sisp->queryTransactionStatus($transaction);
+$updatedTransaction = $sisp->reconcileTransactionStatus($transaction);
+```
+
+Use the Artisan commands for operations and scheduled monitoring. Use the public API when the application is already handling a specific transaction and needs the result immediately.
+
 ### Scheduled Pending Reconciliation
 
 Enable reconciliation only when the application is ready to let the package update old indeterminate pending transactions:

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -157,6 +157,32 @@ The update rules are:
 - `result=true` and `transactionSuccess=true`: status becomes `completed`
 - `result=true` and `transactionSuccess=false`: status becomes `failed`
 
+### Public Status API
+
+Use the `Sisp` facade to query or reconcile a specific transaction from application code:
+
+```php
+use Akira\Sisp\Facades\Sisp;
+
+$response = Sisp::queryTransactionStatus($transaction);
+$response = Sisp::queryTransactionStatus($transaction->merchant_ref);
+
+$updatedTransaction = Sisp::reconcileTransactionStatus($transaction);
+```
+
+`queryTransactionStatus()` returns `TransactionStatusResponse` and never writes to the database. `reconcileTransactionStatus()` returns a `Transaction` and only updates pending transactions when the SISP status API returns `result=true`.
+
+For multi-merchant flows, scope the call with explicit credentials:
+
+```php
+$sisp = Sisp::forCredentials($credentials);
+
+$response = $sisp->queryTransactionStatus($transaction);
+$updatedTransaction = $sisp->reconcileTransactionStatus($transaction);
+```
+
+Use the command for manual operations or scheduled monitoring. Use the facade API when the application already has a specific transaction and needs an immediate check.
+
 ### Automatic Scheduled Reconciliation
 
 Enable the feature:

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -305,6 +305,24 @@ Blacklist::bySeverity('high')
 
 ## Value Objects
 
+### TransactionStatusResponse
+
+Result returned by the SISP transaction status API wrapper.
+
+```php
+use Akira\Sisp\Facades\Sisp;
+
+$response = Sisp::queryTransactionStatus($transaction);
+
+$response->result;                       // true when the SISP status API returned a usable result
+$response->transactionSuccess;           // true when SISP reports the payment succeeded
+$response->transactionStatusDescription; // SISP status text
+$response->message;                      // SISP API message or package failure message
+$response->paymentStatus();              // TransactionStatus enum
+```
+
+`result=false` means the status lookup failed and must not be treated as a payment failure.
+
 ### PaymentRequestData
 
 Container for payment request fields and 3D Secure customer data.
@@ -431,6 +449,32 @@ InvoiceStatus::paid               // Payment confirmed
 InvoiceStatus::overdue            // Past due date
 InvoiceStatus::cancelled          // Cancelled
 ```
+
+## Facade API
+
+### Transaction Status
+
+```php
+use Akira\Sisp\Facades\Sisp;
+
+$response = Sisp::queryTransactionStatus($transaction);
+$response = Sisp::queryTransactionStatus('R20260523235959');
+
+$updatedTransaction = Sisp::reconcileTransactionStatus($transaction);
+```
+
+`queryTransactionStatus()` accepts a local `Transaction` or merchant reference and returns `TransactionStatusResponse`. `reconcileTransactionStatus()` accepts a local `Transaction` and returns the refreshed transaction after applying any definitive SISP result.
+
+For multi-merchant integrations:
+
+```php
+$sisp = Sisp::forCredentials($credentials);
+
+$response = $sisp->queryTransactionStatus($transaction);
+$updatedTransaction = $sisp->reconcileTransactionStatus($transaction);
+```
+
+Use `sisp:transaction-status` and `sisp:reconcile-pending` for operational workflows. Use the facade methods inside application code for explicit transaction checks.
 
 ## Actions
 

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
+    ->withParallel(timeoutSeconds: 300)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/config',

--- a/src/Facades/Sisp.php
+++ b/src/Facades/Sisp.php
@@ -11,6 +11,7 @@ use Akira\Sisp\ValueObjects\PaymentRequest;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
 use Akira\Sisp\ValueObjects\TransactionData;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Facade;
 
@@ -20,6 +21,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static PaymentRequest buildRequestPayload(PaymentRequestData $data)
  * @method static bool validateCallback(CallbackPayload $payload)
  * @method static Transaction handlePaymentCallback(CallbackPayload $payload)
+ * @method static TransactionStatusResponse queryTransactionStatus(Transaction|string $transaction)
+ * @method static Transaction reconcileTransactionStatus(Transaction $transaction)
  * @method static CallbackPayload generateSandboxPayload(PaymentRequestData $data, string $status = 'success')
  * @method static Transaction storeTransaction(TransactionData $data)
  * @method static string getMerchantReference()
@@ -38,14 +41,9 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getCountryNumericCode(string $alpha2)
  * @method static string getCountryFlag(string $alpha2)
  * @method static string|null getCountryName(string $alpha2)
- *
- * @see \Akira\Sisp\Sisp
  */
 final class Sisp extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     */
     protected static function getFacadeAccessor(): string
     {
         return \Akira\Sisp\Sisp::class;

--- a/src/ScopedSisp.php
+++ b/src/ScopedSisp.php
@@ -8,6 +8,8 @@ use Akira\Sisp\Actions\BuildRequestPayloadAction;
 use Akira\Sisp\Actions\BuildSandboxPayloadAction;
 use Akira\Sisp\Actions\CreateTransactionAction;
 use Akira\Sisp\Actions\HandleCallbackAction;
+use Akira\Sisp\Actions\QueryTransactionStatusAction;
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
 use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
 use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Configuration\ScopedSispCredentialsResolver;
@@ -18,6 +20,7 @@ use Akira\Sisp\ValueObjects\PaymentRequest;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
 use Akira\Sisp\ValueObjects\TransactionData;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
 use Illuminate\Contracts\Container\Container;
 
 final readonly class ScopedSisp
@@ -50,6 +53,16 @@ final readonly class ScopedSisp
     public function handlePaymentCallback(CallbackPayload $payload): Transaction
     {
         return $this->withResolver(fn (): Transaction => $this->container->make(HandleCallbackAction::class)->handle($payload));
+    }
+
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse
+    {
+        return $this->withResolver(fn (): TransactionStatusResponse => $this->container->make(QueryTransactionStatusAction::class)->handle($transaction));
+    }
+
+    public function reconcileTransactionStatus(Transaction $transaction): Transaction
+    {
+        return $this->withResolver(fn (): Transaction => $this->container->make(ReconcileTransactionStatusAction::class)->handle($transaction));
     }
 
     public function generateSandboxPayload(PaymentRequestData $data, string $status = 'success'): CallbackPayload

--- a/src/Sisp.php
+++ b/src/Sisp.php
@@ -8,6 +8,8 @@ use Akira\Sisp\Actions\BuildRequestPayloadAction;
 use Akira\Sisp\Actions\BuildSandboxPayloadAction;
 use Akira\Sisp\Actions\CreateTransactionAction;
 use Akira\Sisp\Actions\HandleCallbackAction;
+use Akira\Sisp\Actions\QueryTransactionStatusAction;
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
 use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
 use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Models\Transaction;
@@ -17,6 +19,7 @@ use Akira\Sisp\ValueObjects\PaymentRequest;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
 use Akira\Sisp\ValueObjects\TransactionData;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
 
 final readonly class Sisp
 {
@@ -26,6 +29,8 @@ final readonly class Sisp
         private ValidatePaymentResponseFingerprintAction $validateFingerprint,
         private CreateTransactionAction $createTransaction,
         private HandleCallbackAction $handleCallback,
+        private QueryTransactionStatusAction $queryTransactionStatus,
+        private ReconcileTransactionStatusAction $reconcileTransactionStatus,
         private LoadConfig $loadConfig,
     ) {}
 
@@ -56,6 +61,16 @@ final readonly class Sisp
     public function handlePaymentCallback(CallbackPayload $payload): Transaction
     {
         return $this->handleCallback->handle($payload);
+    }
+
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse
+    {
+        return $this->queryTransactionStatus->handle($transaction);
+    }
+
+    public function reconcileTransactionStatus(Transaction $transaction): Transaction
+    {
+        return $this->reconcileTransactionStatus->handle($transaction);
     }
 
     public function generateSandboxPayload(PaymentRequestData $data, string $status = 'success'): CallbackPayload

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -8,6 +8,8 @@ use Akira\Sisp\Actions\BuildRequestPayloadAction;
 use Akira\Sisp\Actions\BuildSandboxPayloadAction;
 use Akira\Sisp\Actions\CreateTransactionAction;
 use Akira\Sisp\Actions\HandleCallbackAction;
+use Akira\Sisp\Actions\QueryTransactionStatusAction;
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
 use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
 use Akira\Sisp\Commands\DoctorCommand;
 use Akira\Sisp\Commands\LaravelSispInstallCommand;
@@ -59,6 +61,8 @@ final class SispServiceProvider extends PackageServiceProvider
             validateFingerprint: $app->make(ValidatePaymentResponseFingerprintAction::class),
             createTransaction: $app->make(CreateTransactionAction::class),
             handleCallback: $app->make(HandleCallbackAction::class),
+            queryTransactionStatus: $app->make(QueryTransactionStatusAction::class),
+            reconcileTransactionStatus: $app->make(ReconcileTransactionStatusAction::class),
             loadConfig: $app->make(LoadConfig::class),
         ));
     }
@@ -84,30 +88,24 @@ final class SispServiceProvider extends PackageServiceProvider
 
     private function registerComponents(): void
     {
-        // Load Blade views from package
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'sisp');
 
-        // Allow users to publish Blade views for customization
         $this->publishes([
             __DIR__.'/../resources/views' => resource_path('views/vendor/sisp'),
         ], 'sisp-views');
 
-        // Publish React components for customization
         $this->publishes([
             __DIR__.'/../resources/js/react/pages' => resource_path('js/pages/sisp'),
         ], 'sisp-inertia-components');
 
-        // Publish Vue components for customization
         $this->publishes([
             __DIR__.'/../resources/js/vue/pages' => resource_path('js/pages/sisp'),
         ], 'sisp-vue-components');
 
-        // Publish CSS assets
         $this->publishes([
             __DIR__.'/../resources/css' => public_path('vendor/sisp/css'),
         ], 'sisp-assets');
 
-        // Register Blade anonymous component namespace
         $this->callAfterResolving('blade.compiler', function (BladeCompiler $blade): void {
             $blade->anonymousComponentNamespace('sisp', __DIR__.'/../resources/views/components');
         });

--- a/tests/Sisp/ScopedSispTest.php
+++ b/tests/Sisp/ScopedSispTest.php
@@ -9,6 +9,8 @@ use Akira\Sisp\Sisp;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
 use Akira\Sisp\ValueObjects\TransactionData;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 
 it('scoped sisp uses credentials and restores resolver', function (): void {
     config()->set('sisp.merchant_ref', 'CFG-REF');
@@ -122,4 +124,48 @@ it('scoped sisp handles sandbox callbacks and transactions', function (): void {
 
     expect($updated->status->value)->toBe('completed')
         ->and($updated->id)->toBe($transaction->id);
+});
+
+it('scoped sisp queries and reconciles transaction status with explicit credentials', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $credentials = SispCredentials::from([
+        'pos_id' => 'SCOPED_STATUS_POS',
+        'pos_aut_code' => 'SCOPED_STATUS_AUT',
+        'currency' => '132',
+        'merchant_id' => 'MID3',
+        'url' => 'https://scoped.example.com',
+        'language_messages' => 'EN',
+        'fingerprint_version' => '1',
+        'is_3d_sec' => '0',
+        'sandbox' => true,
+        'url_merchant_response' => null,
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-SCOPED-STATUS',
+        'status' => 'pending',
+    ]);
+
+    $scoped = resolve(Sisp::class)->forCredentials($credentials);
+
+    $response = $scoped->queryTransactionStatus($transaction);
+    $updated = $scoped->reconcileTransactionStatus($transaction);
+
+    expect($response->paymentStatus()->value)->toBe('completed')
+        ->and($updated->status->value)->toBe('completed');
+
+    Http::assertSent(fn (Request $request): bool => $request['posID'] === 'SCOPED_STATUS_POS'
+        && $request['posAuthCode'] === 'SCOPED_STATUS_AUT'
+        && $request['merchantRef'] === 'MR-SCOPED-STATUS');
 });

--- a/tests/Sisp/SispTest.php
+++ b/tests/Sisp/SispTest.php
@@ -7,6 +7,7 @@ use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\TransactionData;
+use Illuminate\Support\Facades\Http;
 
 it('builds request payload via facade with deterministic fingerprint', function (): void {
     $data = PaymentRequestData::from([
@@ -97,4 +98,71 @@ it('handles payment callback and updates status', function (): void {
     $updated = Sisp::handlePaymentCallback($payload);
 
     expect($updated->status->value)->toBe('completed');
+});
+
+it('queries transaction status through the facade', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $response = Sisp::queryTransactionStatus('MR-FACADE-STATUS');
+
+    expect($response->result)->toBeTrue()
+        ->and($response->transactionSuccess)->toBeTrue()
+        ->and($response->paymentStatus()->value)->toBe('completed');
+});
+
+it('does not expose failed status API requests as payment failures through the facade', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        '*' => Http::response(['msg' => 'Forbidden'], 403),
+    ]);
+
+    $response = Sisp::queryTransactionStatus('MR-FACADE-FAILED-QUERY');
+
+    expect($response->result)->toBeFalse()
+        ->and($response->paymentStatus()->value)->toBe('pending')
+        ->and($response->message)->toContain('HTTP 403');
+});
+
+it('reconciles completed and failed payments through the facade', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fakeSequence()
+        ->push([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ])
+        ->push([
+            'result' => true,
+            'transactionSuccess' => false,
+            'transactionStatusDescription' => 'E-ERRO',
+            'msg' => 'Declined',
+        ]);
+
+    $completed = Transaction::factory()->create([
+        'status' => 'pending',
+        'merchant_response' => null,
+    ]);
+
+    $failed = Transaction::factory()->create([
+        'status' => 'pending',
+        'merchant_response' => null,
+    ]);
+
+    expect(Sisp::reconcileTransactionStatus($completed)->status->value)->toBe('completed')
+        ->and(Sisp::reconcileTransactionStatus($failed)->status->value)->toBe('failed');
 });


### PR DESCRIPTION
Problem: #183 requires transaction status checks and pending reconciliation to be available through the public package API, not only internal actions or Artisan commands.

Root cause: `QueryTransactionStatusAction` and `ReconcileTransactionStatusAction` existed, but `Sisp`, `ScopedSisp`, and the facade did not expose them as stable public methods.

Solution:
- Added `queryTransactionStatus(Transaction|string): TransactionStatusResponse` to `Sisp` and `ScopedSisp`.
- Added `reconcileTransactionStatus(Transaction): Transaction` to `Sisp` and `ScopedSisp`.
- Registered the new action dependencies in the service provider binding.
- Documented command versus public API usage and scoped multi-merchant calls.
- Added facade and scoped tests for successful, failed, and failed-query status flows.

Validation:
- `vendor/bin/pest --compact --filter='queries transaction status through the facade|does not expose failed status API requests|reconciles completed and failed payments through the facade|scoped sisp queries and reconciles transaction status|queries the configured SISP transaction-status endpoint|maps a successful API call with failed payment|does not treat a failed API query|updates pending transactions when SISP returns a definitive successful payment|updates pending transactions when SISP returns a definitive failed payment|keeps pending transactions unchanged'`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Risk/rollback: Low. The change only exposes existing action behavior through the public API. Roll back by removing the new facade/scoped methods and docs.

Fixes #183
