### PR TITLE
feat(refund): support partial refunds and history

### DIFF
--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -252,7 +252,7 @@ $action = app(RefundTransactionAction::class);
 try {
     $transaction = $action->handle(
         transaction: $transaction,
-        refundAmount: 500.00,      // Must equal the original transaction amount
+        refundAmount: 500.00,
         reason: 'customer_request' // Optional reason
     );
     echo "Refunded " . $transaction->formatted_amount;
@@ -264,7 +264,7 @@ try {
 ### Refund Rules
 
 Can be refunded:
-- `completed` - Full refund only
+- `completed` - Total reversal or partial refund
 
 Cannot be refunded:
 - `pending` - Waiting for payment
@@ -275,12 +275,29 @@ Cannot be refunded:
 ### Refund Amount Rules
 
 - Must be greater than 0
-- Must equal the original transaction amount
-- SISP does not support partial refunds
-- Successful refunds preserve the original transaction amount and change status to `refunded`
-- SISP refund requests use `transactionCode = 4`, and the request amount must be the original transaction amount
-- Refunds are limited to the SISP-supported reversal window, currently no more than 30 days after the original purchase
+- Must not exceed the refundable balance known by the package
+- Total reversal uses `transactionCode = 4`
+- Partial refund uses `transactionCode = 8`
+- Refund history lookup uses `transactionCode = 9` and `amount = 0`
+- Refund and history requests use `reversal = R`
+- Refund operations use the dedicated refund FingerPrint with version `2`
+- Successful full refunds preserve the original transaction amount and change status to `refunded`
+- Successful partial refunds preserve the transaction as `completed` until the known refunded balance reaches the original amount
 - For refunds on a different day, SISP may require enough daily purchase liquidity to cover the refunded amount
+- For DCC transactions, refund in the original transaction currency
+
+The original SISP callback must provide `merchantRespCP` and `merchantRespTid`; these are used as `clearingPeriod` and `transactionID` in refund requests.
+
+Build a refund history request without changing local transaction status:
+
+```php
+use Akira\Sisp\Actions\BuildRefundRequestAction;
+
+$request = app(BuildRefundRequestAction::class)->history($transaction);
+$payload = $request->toArray();
+```
+
+Sandbox certification should validate SISP test cases 29-31 for total reversal, 32-34 for partial refund, and 35 for refund history. Confirm final accounting in the daily VBVT reconciliation file.
 
 ### Refund via Route
 

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -128,7 +128,7 @@ you must provide:
 
 ### Can I refund a payment?
 
-Yes, refund completed transactions using `RefundTransactionAction`. SISP only supports full-amount refunds, so the refund amount must equal the original transaction amount.
+Yes. Refund completed transactions using `RefundTransactionAction`. Current SISP specifications support total reversal and partial refund. The package validates that the requested amount does not exceed the refundable balance it knows locally.
 
 ### Can I cancel a pending payment?
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -461,7 +461,7 @@ TransactionStatus::pending        // Awaiting SISP response
 TransactionStatus::completed      // Payment successful
 TransactionStatus::failed         // Payment rejected
 TransactionStatus::cancelled      // Transaction cancelled
-TransactionStatus::refunded       // Fully refunded through SISP full-amount reversal
+TransactionStatus::refunded       // Fully refunded through SISP reversal or partial refunds
 ```
 
 ### InvoiceStatus
@@ -585,7 +585,7 @@ app(CancelTransactionAction::class)->handle(
 
 ### RefundTransactionAction
 
-Refund a completed transaction. SISP only supports full-amount refunds, so `refundAmount` must equal the original transaction amount.
+Refund a completed transaction. The action supports SISP total reversal and partial refund requests.
 
 ```php
 app(RefundTransactionAction::class)->handle(
@@ -596,6 +596,26 @@ app(RefundTransactionAction::class)->handle(
 
 // Throws LogicException if cannot refund
 ```
+
+### BuildRefundRequestAction
+
+Build SISP refund and refund-history request payloads with the dedicated refund FingerPrint.
+
+```php
+$total = app(BuildRefundRequestAction::class)->total($transaction);
+$partial = app(BuildRefundRequestAction::class)->partial($transaction, 500.00);
+$history = app(BuildRefundRequestAction::class)->history($transaction);
+
+$payload = $history->toArray();
+```
+
+Transaction codes:
+
+- `4` - total reversal
+- `8` - partial refund
+- `9` - refund history lookup
+
+Refund-history payloads use `amount = 0`. All refund payloads use `reversal = R`, `fingerprintversion = 2`, the original `clearingPeriod`, and the original `transactionID`.
 
 ### GenerateInvoiceAction
 

--- a/src/Actions/BuildRefundRequestAction.php
+++ b/src/Actions/BuildRefundRequestAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions;
+
+use Akira\Sisp\Actions\FingerPrint\RefundFingerPrintAction;
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\RefundRequest;
+use LogicException;
+
+final readonly class BuildRefundRequestAction
+{
+    public const string TOTAL_REVERSAL = '4';
+
+    public const string PARTIAL_REFUND = '8';
+
+    public const string REFUND_HISTORY = '9';
+
+    public function __construct(
+        private RefundFingerPrintAction $fingerPrint,
+        private SispCredentialsResolver $credentialsResolver,
+        private LoadConfig $config,
+    ) {}
+
+    public function total(Transaction $transaction): RefundRequest
+    {
+        return $this->handle($transaction, (float) $transaction->amount, self::TOTAL_REVERSAL);
+    }
+
+    public function partial(Transaction $transaction, float $amount): RefundRequest
+    {
+        return $this->handle($transaction, $amount, self::PARTIAL_REFUND);
+    }
+
+    public function history(Transaction $transaction): RefundRequest
+    {
+        return $this->handle($transaction, 0.0, self::REFUND_HISTORY);
+    }
+
+    public function handle(Transaction $transaction, float $amount, string $transactionCode): RefundRequest
+    {
+        $credentials = $this->credentialsResolver->resolve();
+        $clearingPeriod = $this->requiredTransactionString($transaction, 'response_code', 'clearingPeriod');
+        $transactionID = $this->requiredTransactionString($transaction, 'transaction_id', 'transactionID');
+
+        $payload = [
+            'posID' => $credentials->posId,
+            'merchantRef' => $this->requiredTransactionString($transaction, 'merchant_ref', 'merchantRef'),
+            'merchantSession' => $this->requiredTransactionString($transaction, 'merchant_session', 'merchantSession'),
+            'amount' => $amount,
+            'currency' => $this->requiredTransactionString($transaction, 'currency', 'currency'),
+            'timeStamp' => $this->config->getTimeStamp(),
+            'fingerprintversion' => '2',
+            'transactionCode' => $transactionCode,
+            'reversal' => 'R',
+            'clearingPeriod' => $clearingPeriod,
+            'transactionID' => $transactionID,
+        ];
+
+        $payload['fingerprint'] = $this->fingerPrint->handle($payload);
+
+        return RefundRequest::from($payload);
+    }
+
+    private function requiredTransactionString(Transaction $transaction, string $attribute, string $field): string
+    {
+        $value = $transaction->getAttribute($attribute);
+        $value = is_scalar($value) ? mb_trim((string) $value) : '';
+
+        throw_if($value === '', LogicException::class, "SISP refund requires original {$field}.");
+
+        return $value;
+    }
+}

--- a/src/Actions/FingerPrint/RefundFingerPrintAction.php
+++ b/src/Actions/FingerPrint/RefundFingerPrintAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions\FingerPrint;
+
+use Akira\Sisp\Actions\PostAutCode;
+use Akira\Sisp\Support\SispAmount;
+
+final readonly class RefundFingerPrintAction
+{
+    public function __construct(private PostAutCode $postAutCode) {}
+
+    /**
+     * @param  array<string, float|int|string>  $data
+     */
+    public function handle(array $data): string
+    {
+        $fields = [
+            $this->postAutCode->handle(),
+            mb_trim((string) ($data['timeStamp'] ?? '')),
+            SispAmount::toThousandths($data['amount'] ?? 0),
+            mb_trim((string) ($data['merchantRef'] ?? '')),
+            mb_trim((string) ($data['merchantSession'] ?? '')),
+            mb_trim((string) ($data['posID'] ?? '')),
+            mb_trim((string) ($data['currency'] ?? '')),
+            mb_trim((string) ($data['transactionCode'] ?? '')),
+            mb_str_pad(mb_trim((string) ($data['clearingPeriod'] ?? '')), 4, '0', STR_PAD_LEFT),
+            mb_str_pad(mb_trim((string) ($data['transactionID'] ?? '')), 8, '0', STR_PAD_LEFT),
+        ];
+
+        return base64_encode(hash('sha512', implode('', $fields), true));
+    }
+}

--- a/src/Actions/RefundTransactionAction.php
+++ b/src/Actions/RefundTransactionAction.php
@@ -9,10 +9,13 @@ use Akira\Sisp\Events\TransactionRefunded;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\Support\TransactionLogContext;
+use Akira\Sisp\ValueObjects\RefundRequest;
 use LogicException;
 
 final readonly class RefundTransactionAction
 {
+    public function __construct(private BuildRefundRequestAction $buildRefundRequest) {}
+
     public function handle(
         Transaction $transaction,
         float $refundAmount,
@@ -26,17 +29,27 @@ final readonly class RefundTransactionAction
 
         throw_if($refundAmount <= 0, LogicException::class, 'Refund amount must be greater than 0.');
 
-        if ($this->amountInMinorUnits($refundAmount) !== $this->amountInMinorUnits($transaction->amount)) {
-            throw new LogicException(
-                "SISP only supports full-amount refunds. Refund amount ({$refundAmount}) must equal transaction amount ({$transaction->amount})."
-            );
-        }
+        $refundThousandths = SispAmount::toThousandths($refundAmount);
+        $refundableThousandths = $this->refundableThousandths($transaction);
+
+        throw_if($refundThousandths <= 0, LogicException::class, 'Refund amount must be greater than 0.');
+
+        throw_if(
+            $refundThousandths > $refundableThousandths,
+            LogicException::class,
+            "Refund amount ({$refundAmount}) exceeds refundable balance."
+        );
+
+        $request = $this->buildRefundRequest($transaction, $refundAmount);
+        $payload = $this->appendRefundPayload($transaction, $request->toArray(), $reason);
+        $remainingThousandths = $refundableThousandths - $refundThousandths;
 
         TransactionLogContext::run(
             'refund',
             fn (): bool => $transaction->update([
-                'status' => TransactionStatus::refunded->value,
+                'status' => $remainingThousandths === 0 ? TransactionStatus::refunded->value : TransactionStatus::completed->value,
                 'merchant_response' => "{$reason}::{$refundAmount}",
+                'payload' => $payload,
                 'refunded_at' => now(),
             ])
         );
@@ -51,8 +64,54 @@ final readonly class RefundTransactionAction
         return $transaction->status->value === 'completed';
     }
 
-    private function amountInMinorUnits(float $amount): int
+    private function buildRefundRequest(Transaction $transaction, float $refundAmount): RefundRequest
     {
-        return SispAmount::toCents($amount);
+        $transactionAmount = SispAmount::toThousandths($transaction->amount);
+        $alreadyRefunded = $this->refundedThousandths($transaction);
+        $refundAmount = SispAmount::toThousandths($refundAmount);
+
+        if ($alreadyRefunded === 0 && $refundAmount === $transactionAmount) {
+            return $this->buildRefundRequest->total($transaction);
+        }
+
+        return $this->buildRefundRequest->partial($transaction, $refundAmount / 1000);
+    }
+
+    private function refundableThousandths(Transaction $transaction): int
+    {
+        return max(0, SispAmount::toThousandths($transaction->amount) - $this->refundedThousandths($transaction));
+    }
+
+    private function refundedThousandths(Transaction $transaction): int
+    {
+        $payload = $transaction->getAttribute('payload');
+        $payload = is_array($payload) ? $payload : [];
+        $refunds = $payload['refunds'] ?? [];
+        $refunds = is_array($refunds) ? $refunds : [];
+
+        return array_sum(array_map(
+            fn (mixed $refund): int => is_array($refund) ? SispAmount::toThousandths($refund['amount'] ?? 0) : 0,
+            $refunds,
+        ));
+    }
+
+    /**
+     * @param  array<string, float|string>  $request
+     * @return array<string, mixed>
+     */
+    private function appendRefundPayload(Transaction $transaction, array $request, string $reason): array
+    {
+        $payload = $transaction->getAttribute('payload');
+        $payload = is_array($payload) ? $payload : [];
+        $refunds = $payload['refunds'] ?? [];
+        $refunds = is_array($refunds) ? $refunds : [];
+        $refunds[] = [
+            'amount' => $request['amount'],
+            'reason' => $reason,
+            'request' => $request,
+        ];
+        $payload['refunds'] = $refunds;
+
+        return $payload;
     }
 }

--- a/src/Http/Controllers/RefundTransactionController.php
+++ b/src/Http/Controllers/RefundTransactionController.php
@@ -29,7 +29,7 @@ final readonly class RefundTransactionController
         $reason = $request->input('reason', 'user_refund');
 
         try {
-            $this->refundTransaction->handle($transaction, $refundAmount, $reason);
+            $transaction = $this->refundTransaction->handle($transaction, $refundAmount, $reason);
 
             return response()->json([
                 'success' => true,

--- a/src/ValueObjects/RefundRequest.php
+++ b/src/ValueObjects/RefundRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\ValueObjects;
+
+final readonly class RefundRequest
+{
+    public function __construct(
+        public string $posID,
+        public string $merchantRef,
+        public string $merchantSession,
+        public float $amount,
+        public string $currency,
+        public string $timeStamp,
+        public string $fingerprintVersion,
+        public string $transactionCode,
+        public string $fingerprint,
+        public string $reversal,
+        public string $clearingPeriod,
+        public string $transactionID,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function from(array $data): self
+    {
+        return new self(
+            posID: (string) $data['posID'],
+            merchantRef: (string) $data['merchantRef'],
+            merchantSession: (string) $data['merchantSession'],
+            amount: (float) $data['amount'],
+            currency: (string) $data['currency'],
+            timeStamp: (string) $data['timeStamp'],
+            fingerprintVersion: (string) $data['fingerprintversion'],
+            transactionCode: (string) $data['transactionCode'],
+            fingerprint: (string) $data['fingerprint'],
+            reversal: (string) $data['reversal'],
+            clearingPeriod: (string) $data['clearingPeriod'],
+            transactionID: (string) $data['transactionID'],
+        );
+    }
+
+    /**
+     * @return array<string, float|string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'posID' => $this->posID,
+            'merchantRef' => $this->merchantRef,
+            'merchantSession' => $this->merchantSession,
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+            'timeStamp' => $this->timeStamp,
+            'fingerprintversion' => $this->fingerprintVersion,
+            'transactionCode' => $this->transactionCode,
+            'fingerprint' => $this->fingerprint,
+            'reversal' => $this->reversal,
+            'clearingPeriod' => $this->clearingPeriod,
+            'transactionID' => $this->transactionID,
+        ];
+    }
+}

--- a/tests/Actions/BuildRefundRequestActionTest.php
+++ b/tests/Actions/BuildRefundRequestActionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\BuildRefundRequestAction;
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Models\Transaction;
+
+it('builds total reversal requests with refund fingerprint version 2', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 1500.0,
+        'currency' => '132',
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    $request = resolve(BuildRefundRequestAction::class)->total($transaction);
+    $payload = $request->toArray();
+
+    expect($payload['transactionCode'])->toBe('4')
+        ->and($payload['fingerprintversion'])->toBe('2')
+        ->and($payload['reversal'])->toBe('R')
+        ->and($payload['clearingPeriod'])->toBe('5')
+        ->and($payload['transactionID'])->toBe('123')
+        ->and($payload['fingerprint'])->not->toBe('');
+});
+
+it('builds partial refund requests with transaction code 8', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 1500.0,
+        'currency' => '132',
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    $payload = resolve(BuildRefundRequestAction::class)->partial($transaction, 500.0)->toArray();
+
+    expect($payload['transactionCode'])->toBe('8')
+        ->and($payload['amount'])->toBe(500.0)
+        ->and($payload['reversal'])->toBe('R');
+});
+
+it('builds refund history requests with transaction code 9 and zero amount', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 1500.0,
+        'currency' => '132',
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    $payload = resolve(BuildRefundRequestAction::class)->history($transaction)->toArray();
+
+    expect($payload['transactionCode'])->toBe('9')
+        ->and($payload['amount'])->toBe(0.0)
+        ->and($payload['reversal'])->toBe('R');
+});
+
+it('requires original clearing period and transaction id', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 1500.0,
+    ]);
+
+    expect(fn () => resolve(BuildRefundRequestAction::class)->total($transaction))
+        ->toThrow(LogicException::class, 'SISP refund requires original clearingPeriod.');
+});

--- a/tests/Actions/RefundFingerPrintActionTest.php
+++ b/tests/Actions/RefundFingerPrintActionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\FingerPrint\RefundFingerPrintAction;
+
+it('generates the known SISP refund fingerprint vector', function (): void {
+    $fingerprint = resolve(RefundFingerPrintAction::class)->handle([
+        'timeStamp' => '2026-05-14 10:30:00',
+        'amount' => 1500,
+        'merchantRef' => 'R20260514103000',
+        'merchantSession' => 'S20260514103000',
+        'posID' => 'TEST_POS_001',
+        'currency' => '132',
+        'transactionCode' => '8',
+        'clearingPeriod' => '5',
+        'transactionID' => '123',
+    ]);
+
+    expect($fingerprint)->toBe('4Gdsr9+jbhQ97aDAQJ9DJge4giSG9hgEKEJxFaCWl4U/upDJWRCqs3xHkX21rpejYBHS1oQW6OBXaMPW4zN4+w==');
+});
+
+it('uses refund identifiers when generating fingerprints', function (): void {
+    $action = resolve(RefundFingerPrintAction::class);
+
+    $base = [
+        'timeStamp' => '2026-05-14 10:30:00',
+        'amount' => 1500,
+        'merchantRef' => 'R20260514103000',
+        'merchantSession' => 'S20260514103000',
+        'posID' => 'TEST_POS_001',
+        'currency' => '132',
+        'transactionCode' => '8',
+        'clearingPeriod' => '5',
+        'transactionID' => '123',
+    ];
+
+    expect($action->handle($base))->not->toBe($action->handle([...$base, 'transactionID' => '124']));
+});

--- a/tests/Actions/RefundTransactionActionTest.php
+++ b/tests/Actions/RefundTransactionActionTest.php
@@ -10,6 +10,8 @@ it('refunds a completed transaction for the full original amount', function (): 
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $updated = resolve(RefundTransactionAction::class)->handle($t, 100.0, 'customer_request');
@@ -19,10 +21,12 @@ it('refunds a completed transaction for the full original amount', function (): 
         ->and($updated->merchant_response)->toBe('customer_request::100');
 });
 
-it('compares decimal refund amounts using canonical cents', function (): void {
+it('compares decimal refund amounts using canonical thousandths', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 8.03,
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $updated = resolve(RefundTransactionAction::class)->handle($t, 8.03, 'decimal_refund');
@@ -32,32 +36,56 @@ it('compares decimal refund amounts using canonical cents', function (): void {
         ->and($updated->amount_cents)->toBe(803);
 });
 
-it('does not allow partial refund amounts', function (): void {
+it('allows partial refund amounts and keeps the transaction completed', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
-    expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 50.0))
-        ->toThrow(LogicException::class, 'SISP only supports full-amount refunds')
-        ->and($t->refresh()->status)->toBe(TransactionStatus::completed)
-        ->and($t->amount)->toBe(100.0);
+    $updated = resolve(RefundTransactionAction::class)->handle($t, 50.0, 'partial_request');
+
+    expect($updated->status)->toBe(TransactionStatus::completed)
+        ->and($updated->payload['refunds'][0]['request']['transactionCode'])->toBe('8')
+        ->and($updated->payload['refunds'][0]['amount'])->toBe(50);
+});
+
+it('records refund updates with the refund log source', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    resolve(RefundTransactionAction::class)->handle($t, 50.0, 'partial_request');
+
+    $log = $t->logs()->sole();
+
+    expect($log->source)->toBe('refund')
+        ->and($log->changed_attributes)->toContain('payload')
+        ->and($log->new_values['payload']['refunds'][0]['reason'])->toBe('partial_request');
 });
 
 it('does not allow refund amounts above the transaction amount', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 10.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 15.0))
-        ->toThrow(LogicException::class, 'SISP only supports full-amount refunds');
+        ->toThrow(LogicException::class, 'Refund amount (15) exceeds refundable balance.');
 });
 
 it('does not allow refund for non-completed status', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::pending->value,
         'amount' => 10.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 5.0))
@@ -68,8 +96,27 @@ it('does not allow zero or negative refund', function (): void {
     $t = Transaction::factory()->create([
         'status' => TransactionStatus::completed->value,
         'amount' => 10.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 0.0))
         ->toThrow(LogicException::class);
+});
+
+it('does not allow refunds above the remaining local balance', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+        'payload' => [
+            'refunds' => [
+                ['amount' => 75.0],
+            ],
+        ],
+    ]);
+
+    expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 50.0))
+        ->toThrow(LogicException::class, 'Refund amount (50) exceeds refundable balance.');
 });

--- a/tests/Controllers/RefundTransactionControllerTest.php
+++ b/tests/Controllers/RefundTransactionControllerTest.php
@@ -12,6 +12,8 @@ it('refunds a completed transaction and returns json', function (): void {
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -38,6 +40,8 @@ it('returns 400 when refund amount exceeds transaction', function (): void {
         'status' => 'completed',
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -56,11 +60,13 @@ it('returns 400 when refund amount exceeds transaction', function (): void {
     expect($response->getStatusCode())->toBe(400);
 });
 
-it('returns 400 when refund amount is below transaction total', function (): void {
+it('allows partial refund amounts', function (): void {
     $t = Transaction::factory()->create([
         'status' => 'completed',
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -74,9 +80,9 @@ it('returns 400 when refund amount is below transaction total', function (): voi
     });
 
     $response = $controller($t, $request);
-    expect($response->getStatusCode())->toBe(400)
-        ->and($response->getData(true)['message'])->toContain('SISP only supports full-amount refunds')
-        ->and($t->refresh()->amount)->toBe(100.0);
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getData(true)['success'])->toBeTrue()
+        ->and($t->refresh()->payload['refunds'][0]['request']['transactionCode'])->toBe('8');
 });
 
 it('returns 403 when user is not authorized for the transaction', function (): void {
@@ -84,6 +90,8 @@ it('returns 403 when user is not authorized for the transaction', function (): v
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -110,6 +118,8 @@ it('returns 403 when customer email matches but user lacks refund ability', func
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -136,6 +146,8 @@ it('returns 403 when no authenticated user is present', function (): void {
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -153,6 +165,8 @@ it('returns 403 when user has no email and no refund ability', function (): void
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);
@@ -177,6 +191,8 @@ it('allows authorized users through can refund ability', function (): void {
         'status' => TransactionStatus::completed->value,
         'amount' => 100.0,
         'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
     ]);
 
     $controller = resolve(RefundTransactionController::class);


### PR DESCRIPTION
Problem: #189 requires support for the SISP 2026-05-14 refund flow: total reversal, partial refund, refund history, and the dedicated refund FingerPrint.

Root cause: the package still modeled refunds as full-amount local reversals only, which matched the older documentation but not the current SISP specification.

Solution:
- Added `RefundFingerPrintAction` for the refund-specific SHA-512/Base64 field order.
- Added `RefundRequest` and `BuildRefundRequestAction` for transaction codes 4, 8, and 9.
- Updated `RefundTransactionAction` to allow partial refunds up to the locally known refundable balance.
- Persisted refund request history in the transaction payload so later partial refunds can respect local balance.
- Updated controller response to return the refreshed transaction.
- Updated docs for total reversal, partial refund, refund history, required SISP identifiers, sandbox cases, and VBVT validation.

Validation:
- `vendor/bin/pest --compact tests/Actions/RefundFingerPrintActionTest.php tests/Actions/BuildRefundRequestActionTest.php tests/Actions/RefundTransactionActionTest.php tests/Controllers/RefundTransactionControllerTest.php`
- `vendor/bin/phpstan analyse --no-progress`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Risk/rollback: Medium. This changes refund behavior from full-only to partial-capable. Roll back by reverting the PR to restore full-only guard behavior.

Fixes #189
