### PR TITLE
test(payment): cover full SISP flows

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
+    ->withParallel(timeoutSeconds: 300)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/config',

--- a/resources/views/payment-response.blade.php
+++ b/resources/views/payment-response.blade.php
@@ -151,7 +151,7 @@
 
         {{-- Action Buttons --}}
         <div class="space-y-3 fade-in-up" style="animation-delay:.4s">
-            @if($transaction->status === 'failed' && $allowRetry && $retryUrl)
+            @if($transaction->status->value === 'failed' && $allowRetry && $retryUrl)
                 <form method="POST" action="{{ $retryUrl }}">
                     @csrf
                     <button type="submit" class="flex h-14 w-full items-center justify-center gap-2 rounded-2xl bg-purple-600 hover:bg-purple-700 text-lg font-bold text-white shadow-xl shadow-purple-500/20 transition-all hover:scale-[1.02] active:scale-[0.98]">

--- a/tests/Commands/SispReconciliationFlowIntegrationTest.php
+++ b/tests/Commands/SispReconciliationFlowIntegrationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Http;
+
+it('reconciles old pending transactions to completed and failed through the command flow', function (): void {
+    config([
+        'sisp.transaction_status.portal_id' => 'portal',
+        'sisp.transaction_status.portal_password' => 'secret',
+        'sisp.transaction_status.reconciliation_enabled' => true,
+        'sisp.transaction_status.reconcile_after_minutes' => 5,
+        'sisp.transaction_status.reconcile_limit' => 10,
+    ]);
+
+    Http::fakeSequence()
+        ->push([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ])
+        ->push([
+            'result' => true,
+            'transactionSuccess' => false,
+            'transactionStatusDescription' => 'E-ERRO',
+            'msg' => 'Declined',
+        ]);
+
+    $completed = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'created_at' => now()->subMinutes(6),
+    ]);
+    $failed = Transaction::factory()->create([
+        'status' => 'pending',
+        'message_type' => null,
+        'created_at' => now()->subMinutes(6),
+    ]);
+
+    $this->artisan('sisp:reconcile-pending')
+        ->expectsOutput('Reconciled 2 of 2 pending SISP transactions.')
+        ->assertSuccessful();
+
+    expect($completed->refresh()->status->value)->toBe('completed')
+        ->and($failed->refresh()->status->value)->toBe('failed');
+});

--- a/tests/Http/SispPaymentFlowIntegrationTest.php
+++ b/tests/Http/SispPaymentFlowIntegrationTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\PdfInvoices\Contracts\PdfGeneratorContract;
+use Akira\PdfInvoices\DTO\InvoiceData as PdfInvoiceData;
+use Akira\Sisp\Enums\InvoiceStatus;
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\Invoice;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+
+final class RealSispFlowUser implements Authenticatable
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+    ) {}
+
+    public function getAuthIdentifierName(): string
+    {
+        return 'id';
+    }
+
+    public function getAuthIdentifier(): int
+    {
+        return $this->id;
+    }
+
+    public function getAuthPasswordName(): string
+    {
+        return 'password';
+    }
+
+    public function getAuthPassword(): string
+    {
+        return '';
+    }
+
+    public function getRememberToken(): ?string
+    {
+        return null;
+    }
+
+    public function setRememberToken($value): void {}
+
+    public function getRememberTokenName(): string
+    {
+        return 'remember_token';
+    }
+
+    public function can(string $ability, mixed $arguments = []): bool
+    {
+        return Gate::forUser($this)->check($ability, $arguments);
+    }
+}
+
+beforeEach(function (): void {
+    config([
+        'sisp.sandbox' => true,
+        'sisp.rate_limiting.enabled' => false,
+        'sisp.invoice.company_name' => 'Akira Test',
+        'sisp.invoice.company_address' => 'Rua Teste',
+        'sisp.invoice.company_code' => 'NIF-123',
+        'sisp.invoice.company_email' => 'billing@example.test',
+        'sisp.invoice.company_country' => 'CV',
+        'sisp.invoice.company_phone' => '+238 000 0000',
+        'sisp.invoice.company_website' => 'https://example.test',
+    ]);
+
+    Storage::fake('public');
+    app()->instance(PdfGeneratorContract::class, new class implements PdfGeneratorContract
+    {
+        public function generate(PdfInvoiceData $invoice, string $template = 'modern'): string
+        {
+            return '%PDF-INTEGRATION%';
+        }
+
+        public function save(PdfInvoiceData $invoice, string $template = 'modern', ?string $path = null): string
+        {
+            return '%PDF-SAVED%';
+        }
+    });
+});
+
+it('runs a successful payment from payment request through signed callback and invoice rendering', function (): void {
+    $this->post(route('sisp.payment'), real_sisp_flow_payment_payload(amount: 150.0))
+        ->assertOk()
+        ->assertSee('sisp-payment-form');
+
+    defer()->invoke();
+
+    $transaction = Transaction::query()->with(['items', 'invoice'])->sole();
+
+    expect($transaction->items)->toHaveCount(1)
+        ->and($transaction->customer_email)->toBe('buyer@example.test')
+        ->and($transaction->invoice)->toBeInstanceOf(Invoice::class)
+        ->and($transaction->invoice->status)->toBe(InvoiceStatus::pending);
+
+    $payload = real_sisp_flow_callback_payload($transaction, 'success');
+
+    $this->post(route('sisp.callback'), $payload->toArray())
+        ->assertRedirect(route('sisp.callback', ['ref' => $transaction->merchant_ref]));
+
+    $transaction->refresh();
+    $invoice = $transaction->invoice()->firstOrFail();
+
+    expect($transaction->status->value)->toBe('completed')
+        ->and($transaction->transaction_id)->toBe($payload->transactionID)
+        ->and($invoice->status)->toBe(InvoiceStatus::paid)
+        ->and($invoice->pdf_path)->not->toBeNull();
+
+    Storage::disk('public')->assertExists($invoice->pdf_path);
+
+    $this->get(route('sisp.callback', ['ref' => $transaction->merchant_ref]))
+        ->assertOk()
+        ->assertSee($transaction->merchant_ref);
+});
+
+it('runs a failed payment flow and exposes signed retry without paying the invoice', function (): void {
+    $this->post(route('sisp.payment'), real_sisp_flow_payment_payload(amount: 75.0))
+        ->assertOk();
+
+    defer()->invoke();
+
+    $transaction = Transaction::query()->with('invoice')->sole();
+
+    $this->post(route('sisp.callback'), real_sisp_flow_callback_payload($transaction, 'failed')->toArray())
+        ->assertRedirect(route('sisp.callback', ['ref' => $transaction->merchant_ref]));
+
+    $transaction->refresh();
+    $invoice = $transaction->invoice()->firstOrFail();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($invoice->status)->toBe(InvoiceStatus::cancelled)
+        ->and($invoice->pdf_path)->toBeNull();
+
+    $this->get(route('sisp.callback', ['ref' => $transaction->merchant_ref]))
+        ->assertOk()
+        ->assertSee('/sisp/retry-payment', false);
+});
+
+it('runs retry through the signed public route and refreshes payment identifiers', function (): void {
+    $transaction = Transaction::factory()->create([
+        'amount' => 123.0,
+        'currency' => '132',
+        'status' => 'failed',
+        'merchant_session' => 'old-session',
+        'transaction_code' => '1',
+        'locale' => 'pt',
+        'customer_email' => 'buyer@example.test',
+        'customer_country' => 'CV',
+        'customer_city' => 'Praia',
+        'customer_address' => 'Rua Teste',
+        'customer_postal_code' => '0000',
+    ]);
+
+    $this->post(URL::temporarySignedRoute('sisp.retry-payment', now()->addMinutes(30), ['transaction' => $transaction->id]))
+        ->assertOk()
+        ->assertSee('name="timeStamp"', false);
+
+    $transaction->refresh();
+
+    expect($transaction->merchant_session)->not->toBe('old-session')
+        ->and($transaction->merchant_session)->not->toBe('');
+});
+
+it('runs authorized full refund through the public route', function (): void {
+    Gate::define('refund', fn (RealSispFlowUser $user, Transaction $transaction): bool => true);
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'completed',
+        'amount' => 90.0,
+        'customer_email' => 'buyer@example.test',
+    ]);
+
+    $this->actingAs(new RealSispFlowUser(1, 'agent@example.test'))
+        ->post(route('sisp.refund', $transaction), ['amount' => 90.0, 'reason' => 'integration'])
+        ->assertOk()
+        ->assertJsonPath('success', true);
+
+    expect($transaction->refresh()->status->value)->toBe('refunded')
+        ->and($transaction->merchant_response)->toBe('integration::90');
+});
+
+function real_sisp_flow_payment_payload(float $amount): array
+{
+    return [
+        'amount' => $amount,
+        'items' => [[
+            'product_name' => 'Integration Ticket',
+            'quantity' => 1,
+            'unit_price' => $amount,
+            'total_price' => $amount,
+        ]],
+        'customer_name' => 'Buyer Test',
+        'customer_email' => 'buyer@example.test',
+        'customer_phone' => '+238 000 0000',
+        'customer_country' => 'CV',
+        'customer_city' => 'Praia',
+        'customer_address' => 'Rua Teste',
+        'customer_postal_code' => '0000',
+        'locale' => 'pt',
+    ];
+}
+
+function real_sisp_flow_callback_payload(Transaction $transaction, string $status): Akira\Sisp\ValueObjects\CallbackPayload
+{
+    return Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => $transaction->amount,
+        'merchantRef' => $transaction->merchant_ref,
+        'merchantSession' => $transaction->merchant_session,
+        'timeStamp' => '2026-05-26 10:00:00',
+        'currency' => $transaction->currency,
+        'transactionCode' => $transaction->transaction_code ?? '1',
+    ]), $status);
+}


### PR DESCRIPTION
Problem: #182 requires end-to-end coverage for complete SISP flows instead of only action/controller slices.

Root cause: payment creation, callback validation, invoice updates, retry, refund, and reconciliation were tested mostly in isolation, so regressions across route-level flows could pass unnoticed.

Solution:
- Added route-level successful payment flow coverage from payment POST through signed callback, invoice payment, PDF generation, and response rendering.
- Added failed payment coverage through signed failed callback, cancelled invoice state, and visible retry action.
- Added signed retry route coverage verifying refreshed payment identifiers.
- Added authorized refund route coverage.
- Added reconciliation command flow coverage for completed and failed SISP status API responses.
- Fixed Blade retry visibility by comparing the transaction status enum value instead of comparing the enum object to a string.

Validation:
- `vendor/bin/pest --compact tests/Http/SispPaymentFlowIntegrationTest.php tests/Commands/SispReconciliationFlowIntegrationTest.php`
- `vendor/bin/phpstan analyse --no-progress`
- `COMPOSER_PROCESS_TIMEOUT=0 composer test`

Risk/rollback: Low. Main behavior change is limited to showing the existing retry form correctly for failed Blade responses. Roll back by reverting the Blade condition and removing the new tests.

Fixes #182
