### PR TITLE
docs(callback): align callback flow

### DIFF
--- a/docs/04-payment-flow.md
+++ b/docs/04-payment-flow.md
@@ -26,12 +26,15 @@ SISP Gateway (Real or Sandbox)
     v
 GET|POST /sisp/callback
     |
-    ├─ Prevent Duplicate Callback
     ├─ Validate Fingerprint
-    ├─ Find Transaction
+    ├─ Require Merchant Ref and Session
+    ├─ Check Duplicate Callback
+    ├─ Find or Create Transaction
+    ├─ Reconcile Callback Details
     ├─ Parse Error Response (if failed)
     ├─ Update Status
     ├─ Store Callback Response
+    ├─ Store Callback Metadata
     ├─ Generate Invoice (if configured)
     ├─ Dispatch Event
     |
@@ -147,44 +150,82 @@ After payment, SISP POSTs to `/sisp/callback` with:
 
 `CallbackController` with `HandleCallbackAction`:
 
-### 9.1 Duplicate Prevention
-Uses `PreventDuplicateCallback` middleware to:
-- Check if callback already processed for this transaction
-- Prevent double-charging from duplicate callback requests
-- Redirect already-processed callbacks to response page
-
-### 9.2 Fingerprint Validation
+### 9.1 Fingerprint Validation
 `ValidatePaymentResponseFingerprintAction` validates:
 - SHA512 hash of callback fields with pos auth code
 - Verifies data integrity from SISP
 - Prevents callback tampering or spoofing
 - Fields included: messageType, amount, reference, timestamp, and 13+ others
 
-### 9.3 Error Response Parsing
+Invalid POST callbacks are redirected to `config('sisp.redirect_url', '/')` before any transaction lookup.
+
+### 9.2 Required Callback Keys
+After the fingerprint passes, the callback must include:
+
+- `merchantRespMerchantRef`
+- `merchantRespMerchantSession`
+
+If either value is missing, the request is redirected to `config('sisp.redirect_url', '/')`.
+
+### 9.3 Duplicate Prevention
+Duplicate callback detection happens inside `CallbackController` after signature validation.
+
+The controller:
+- Looks up the transaction by merchant reference and merchant session
+- Treats it as already processed when the local `transaction_id` is already set
+- Redirects to `config('sisp.redirect_url', '/')` with an `info` flash message
+
+This keeps invalid unsigned traffic from triggering database lookups.
+
+### 9.4 Transaction Lookup and Reconciliation
+`HandleCallbackAction` finds or creates the transaction, then reconciles the signed callback against the stored transaction.
+
+The callback must match:
+
+- Merchant reference
+- Merchant session
+- Amount
+- Currency
+- Transaction code
+- POS ID
+
+If any value does not match, the transaction is marked `failed` with `merchant_response` set to `callback_details_mismatch`.
+
+### 9.5 Error Response Parsing
 `GetPaymentErrorResponseAction` transforms error codes into structured responses:
 - Maps error code (e.g., "6") to human-readable label
 - Categorizes error: card, funds, security, validation, system, issuer
 - Suggests action: contact-issuer, use-different-card, retry, etc.
 - Provides translated messages for EN and PT
 
-### 9.4 Transaction Lookup
-- Finds transaction by merchant reference
-- Returns 404 if transaction not found
-- Validates transaction state
-
-### 9.5 Status Update
+### 9.6 Status Update
 - Sets status: `completed`, `failed`, or `pending`
 - Stores SISP response data
 - Records error code and response details
 
-### 9.6 Invoice Generation (if enabled)
+### 9.7 Callback Metadata
+The controller stores request metadata for the signed callback before updating invoice status.
+
+### 9.8 Invoice Status Update
+The controller updates the linked invoice status after the transaction is updated.
+
+### 9.9 Invoice Generation (if enabled)
 - Generates PDF invoice
 - Stores path in database
 
-### 9.7 Event Dispatch
+### 9.10 Event Dispatch
 - `PaymentCompleted` - Payment successful
 - `PaymentFailed` - Payment rejected
 - `PaymentPending` - Still processing
+
+### 9.11 Response Rendering
+The POST callback redirects to:
+
+```php
+route('sisp.callback', ['ref' => $transaction->merchant_ref])
+```
+
+The GET callback renders the payment response for the `ref` query parameter. Missing or unknown references redirect to `config('sisp.redirect_url', '/')`.
 
 ## Step 10: Timeout Reconciliation
 
@@ -288,7 +329,7 @@ TransactionRefunded::dispatch($transaction, $refundAmount, $reason);
 ### Security Errors
 - **Rate Limit** - Returns 429 (Too Many Requests)
 - **Blacklist** - Returns 403 (Forbidden) for blacklisted IP/email
-- **Duplicate Callback** - Returns 409 if callback already processed
+- **Duplicate Callback** - Redirects to `config('sisp.redirect_url', '/')` with an `info` flash message
 
 ### Callback/Payment Errors
 Payment failures return structured error information:
@@ -307,9 +348,9 @@ Payment failures return structured error information:
 These error responses are shown to user with retry option if configured.
 
 ### Fingerprint Validation Errors
-- Returns 403 if fingerprint validation fails
+- Redirects to `config('sisp.redirect_url', '/')` if fingerprint validation fails
 - Indicates potential tampering or replay attack
-- Callback is not processed
+- Callback is not processed and no transaction lookup is performed by the controller
 
 ### Invoice Generation Errors
 - Logs error but doesn't fail payment

--- a/docs/07-security.md
+++ b/docs/07-security.md
@@ -235,12 +235,12 @@ All callbacks from SISP are automatically verified using cryptographic signature
 
 The package:
 1. Validates the SISP signature on every callback
-2. Rejects any callbacks with invalid signatures
+2. Redirects invalid callback requests to `config('sisp.redirect_url', '/')`
 3. Prevents status tampering
 
 No manual configuration needed.
 
-Invalid signatures raise `InvalidSignatureException` inside the callback handler.
+Invalid POST callbacks are rejected by `CallbackController` before transaction lookup or duplicate checks. Signed callbacks are then checked for required merchant reference and merchant session values before processing.
 
 ## Data Encryption
 

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -276,12 +276,14 @@ Test callback manually:
 ```bash
 curl -X POST http://localhost:8000/sisp/callback \
   -H "Content-Type: application/json" \
-  -d '{"merchantRespMerchantRef":"test","merchantRespMerchantSession":"test","messageType":"success","merchantResp":"Approved"}'
+  -d '{"merchantRespMerchantRef":"test","merchantRespMerchantSession":"test","merchantResp":"C","messageType":"8","resultFingerPrint":"valid-sisp-fingerprint"}'
 ```
+
+Unsigned test payloads are expected to redirect to `config('sisp.redirect_url', '/')`. Use the sandbox route or `BuildSandboxPayloadAction` when you need a locally generated callback with a valid fingerprint.
 
 ### Callback signature validation fails
 
-Error: Invalid fingerprint or signature
+Symptom: the callback redirects to `config('sisp.redirect_url', '/')` and the transaction is not updated.
 
 This means SISP's response was tampered with or your credentials are wrong.
 
@@ -299,11 +301,23 @@ Check logs for exact error:
 tail -f storage/logs/laravel.log | grep -i signature
 ```
 
+### Callback redirects before processing
+
+The controller redirects without processing when:
+
+1. `UserCancelled` is truthy
+2. The request is a GET without a valid `ref` query parameter
+3. The POST fingerprint is invalid
+4. `merchantRespMerchantRef` or `merchantRespMerchantSession` is missing
+5. The callback was already processed and the transaction already has a SISP transaction ID
+
+Duplicate callbacks redirect with an `info` flash message: `This payment has already been processed.`
+
 ### Transaction not found in callback
 
 Error: "No transaction found" when SISP calls callback
 
-The transaction may not have been created. Verify:
+The action can create a missing transaction from a signed callback, but a normal payment callback should match a transaction created by `POST /sisp/payment`. Verify:
 
 ```php
 php artisan tinker
@@ -446,8 +460,10 @@ php artisan tinker
 If status is still `pending`, callback wasn't processed. Check:
 
 1. Callback route is accessible
-2. No middleware blocking the callback
-3. No exceptions thrown in CallbackController (check logs)
+2. The callback payload has a valid fingerprint
+3. `merchantRespMerchantRef` and `merchantRespMerchantSession` are present
+4. The callback values match the stored transaction amount, currency, transaction code, and POS ID
+5. No exceptions were thrown in CallbackController (check logs)
 
 If the customer reached SISP but no callback arrived after about 5 minutes, query the SISP POS transaction-status API:
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -597,15 +597,21 @@ $isValid = app(ValidatePaymentResponseFingerprintAction::class)->handle(
 // Returns false if tampering detected
 ```
 
-### PreventDuplicateCallbackAction
+### CallbackController
 
-Prevent double-processing of callback requests.
-
-Registered as `PreventDuplicateCallback` middleware on callback routes.
+Handles the SISP callback route.
 
 ```php
-// Automatically redirects already-processed callbacks
-// to payment response page
+// GET /sisp/callback?ref=<merchant_ref>
+// Renders the payment response for a known merchant reference.
+
+// POST /sisp/callback
+// 1. Redirects cancelled requests.
+// 2. Validates the callback fingerprint before transaction lookup.
+// 3. Requires merchant reference and merchant session.
+// 4. Redirects duplicate callbacks when transaction_id is already set.
+// 5. Handles the callback, stores metadata, updates invoice status,
+//    then redirects to GET /sisp/callback?ref=<merchant_ref>.
 ```
 
 ### RenderPaymentResponseAction
@@ -666,15 +672,6 @@ Protects the payment route from duplicate submissions.
 ```php
 // Applied to POST /sisp/payment
 // Blocks duplicate merchantRef + merchantSession combinations
-```
-
-### PreventDuplicateCallback
-
-Prevents double-processing of callback requests.
-
-```php
-// Applied to GET|POST /sisp/callback
-// Redirects already-processed callbacks to response page
 ```
 
 ## Enums
@@ -760,16 +757,6 @@ Thrown when 3D Secure is enabled but required customer data is missing.
 ```php
 catch (MissingThreeDSecureDataException $e) {
     // Provide the missing fields and retry
-}
-```
-
-### InvalidSignatureException
-
-Thrown when a callback fingerprint/signature is invalid.
-
-```php
-catch (InvalidSignatureException $e) {
-    // Reject callback and log attempt
 }
 ```
 


### PR DESCRIPTION
Problem: #181 reports stale callback documentation that still described the removed duplicate-callback middleware and old invalid-signature behavior.

Root cause: callback handling moved into CallbackController, but the flow, security, troubleshooting, and API docs were not updated to match the shipped implementation.

Solution:
- Document the current callback order: fingerprint validation, required merchant keys, duplicate check, callback handling, metadata storage, and invoice status update.
- Remove PreventDuplicateCallback and PreventDuplicateCallbackAction references from the API reference.
- Update security and troubleshooting docs to describe redirect behavior for invalid signatures and duplicate callbacks.

Validation:
- COMPOSER_PROCESS_TIMEOUT=0 composer test
- git diff --check
- commit-guard staged scans for comments, chained if, AI-tells, and secrets

Risk/rollback: documentation-only change. Roll back the commit if wording needs to be revised.

Fixes #181
