### PR TITLE
feat(transaction): add audit logs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92
         with:
           tool: git-cliff
 
@@ -58,7 +58,7 @@ jobs:
             --latest
 
       - name: Send GitHub Release to Discord
-        uses: SethCohen/github-releases-to-discord@v1.20.0
+        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682
         with:
           webhook_url: ${{ secrets.DISCORD }}
           release_name: ${{ github.ref_name }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv

--- a/config/sisp.php
+++ b/config/sisp.php
@@ -166,6 +166,7 @@ return [
         'request_metadata' => env('SISP_TABLE_REQUEST_METADATA', 'sisp_request_metadata'),
         'rate_limits' => env('SISP_TABLE_RATE_LIMITS', 'sisp_rate_limits'),
         'blacklist' => env('SISP_TABLE_BLACKLIST', 'sisp_blacklist'),
+        'transaction_logs' => env('SISP_TABLE_TRANSACTION_LOGS', 'sisp_transaction_logs'),
     ],
 
     /*

--- a/database/migrations/create_sisp_transaction_logs_table.php
+++ b/database/migrations/create_sisp_transaction_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $transactionsTable = config('sisp.tables.transactions', 'sisp_transactions');
+        $logsTable = config('sisp.tables.transaction_logs', 'sisp_transaction_logs');
+
+        Schema::create($logsTable, function (Blueprint $table) use ($transactionsTable): void {
+            $table->id();
+            $table->foreignId('transaction_id')
+                ->constrained($transactionsTable)
+                ->onDelete('cascade');
+            $table->string('source')->default('model');
+            $table->json('changed_attributes');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->timestamps();
+            $table->index(['transaction_id', 'created_at']);
+            $table->index(['source', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('sisp.tables.transaction_logs', 'sisp_transaction_logs'));
+    }
+};

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -275,6 +275,7 @@ SISP_TABLE_INVOICES=sisp_invoices
 SISP_TABLE_REQUEST_METADATA=sisp_request_metadata
 SISP_TABLE_RATE_LIMITS=sisp_rate_limits
 SISP_TABLE_BLACKLIST=sisp_blacklist
+SISP_TABLE_TRANSACTION_LOGS=sisp_transaction_logs
 ```
 
 The transaction model and retry request validation read `SISP_TABLE_TRANSACTIONS`, so retry links continue to validate correctly when the transaction table is renamed.

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -92,6 +92,32 @@ if ($invoice) {
 }
 ```
 
+## Transaction Change History
+
+Every transaction update is recorded in `sisp_transaction_logs`.
+
+```php
+$logs = $transaction->logs()->latest()->get();
+
+foreach ($logs as $log) {
+    echo $log->source;
+    dump($log->changed_attributes);
+    dump($log->old_values);
+    dump($log->new_values);
+}
+```
+
+Each log stores:
+
+- `transaction_id` - Transaction that changed
+- `source` - Flow that changed the transaction, such as `callback`, `refund`, `cancel`, `retry`, `reconciliation`, `customer-data`, or `model`
+- `changed_attributes` - Changed column names
+- `old_values` - Values before the update
+- `new_values` - Values after the update
+- `created_at` - When the change was recorded
+
+Timestamp-only updates are ignored. Encrypted payload values are stored in decrypted array form so the history remains inspectable.
+
 ## Cancel Transaction
 
 Cancel a pending or failed transaction:

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -102,6 +102,7 @@ $transaction->formatted_amount    // "1000,00 ECV"
 ```php
 $transaction->items()             // HasMany TransactionItem
 $transaction->invoice()           // HasOne Invoice
+$transaction->logs()              // HasMany TransactionLog
 ```
 
 #### Scopes
@@ -113,6 +114,29 @@ Transaction::where('customer_email', 'test@example.com')
 Transaction::whereBetween('created_at', [$start, $end])
 Transaction::with('items', 'invoice')
 Transaction::paginate(15)
+```
+
+### TransactionLog
+
+Append-only history record for transaction updates.
+
+#### Attributes
+
+```php
+$log->id                          // Primary key
+$log->transaction_id              // FK to Transaction
+$log->source                      // callback, refund, cancel, retry, reconciliation, customer-data, or model
+$log->changed_attributes          // Changed attributes (array)
+$log->old_values                  // Values before the update (array)
+$log->new_values                  // Values after the update (array)
+$log->created_at                  // Created timestamp
+$log->updated_at                  // Updated timestamp
+```
+
+#### Relations
+
+```php
+$log->transaction()               // BelongsTo Transaction
 ```
 
 ### TransactionItem
@@ -1037,6 +1061,7 @@ config('sisp.tables.invoices')
 config('sisp.tables.request_metadata')
 config('sisp.tables.rate_limits')
 config('sisp.tables.blacklist')
+config('sisp.tables.transaction_logs')
 ```
 
 ## Next Steps

--- a/src/Actions/CancelTransactionAction.php
+++ b/src/Actions/CancelTransactionAction.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Actions;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\TransactionCancelled;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
 use LogicException;
 
 final readonly class CancelTransactionAction
@@ -20,12 +21,15 @@ final readonly class CancelTransactionAction
             );
         }
 
-        $transaction->update([
-            'status' => TransactionStatus::cancelled->value,
-            'message_type' => 'cancelled',
-            'merchant_response' => $reason,
-            'cancelled_at' => now(),
-        ]);
+        TransactionLogContext::run(
+            'cancel',
+            fn (): bool => $transaction->update([
+                'status' => TransactionStatus::cancelled->value,
+                'message_type' => 'cancelled',
+                'merchant_response' => $reason,
+                'cancelled_at' => now(),
+            ])
+        );
 
         event(new TransactionCancelled($transaction, $reason));
 

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -15,6 +15,7 @@ use Akira\Sisp\Events\PaymentPending;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\SispAmount;
+use Akira\Sisp\Support\TransactionLogContext;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 
 final readonly class HandleCallbackAction
@@ -81,14 +82,17 @@ final readonly class HandleCallbackAction
 
     private function failTransaction(Transaction $transaction, CallbackPayload $payload): void
     {
-        $transaction->update([
-            'transaction_id' => $payload->transactionID,
-            'message_type' => $payload->messageType,
-            'merchant_response' => 'callback_details_mismatch',
-            'response_code' => $payload->merchantRespCp,
-            'fingerprint' => $payload->fingerprint,
-            'status' => TransactionStatus::failed,
-        ]);
+        TransactionLogContext::run(
+            'callback',
+            fn (): bool => $transaction->update([
+                'transaction_id' => $payload->transactionID,
+                'message_type' => $payload->messageType,
+                'merchant_response' => 'callback_details_mismatch',
+                'response_code' => $payload->merchantRespCp,
+                'fingerprint' => $payload->fingerprint,
+                'status' => TransactionStatus::failed,
+            ])
+        );
     }
 
     private function transactionAmount(Transaction $transaction): float|int|string

--- a/src/Actions/LogTransactionChangesAction.php
+++ b/src/Actions/LogTransactionChangesAction.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions;
+
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
+use BackedEnum;
+use DateTimeInterface;
+use Illuminate\Support\Facades\Crypt;
+use Throwable;
+
+final readonly class LogTransactionChangesAction
+{
+    public function handle(Transaction $transaction): void
+    {
+        $changes = $this->changes($transaction);
+
+        if ($changes['changed_attributes'] === []) {
+            return;
+        }
+
+        $transaction->logs()->create([
+            'source' => TransactionLogContext::current(),
+            'changed_attributes' => $changes['changed_attributes'],
+            'old_values' => $changes['old_values'],
+            'new_values' => $changes['new_values'],
+        ]);
+    }
+
+    private function changes(Transaction $transaction): array
+    {
+        $changedAttributes = [];
+        $oldValues = [];
+        $newValues = [];
+
+        foreach (array_keys($transaction->getChanges()) as $attribute) {
+            if ($attribute === 'updated_at') {
+                continue;
+            }
+
+            $oldValue = $this->normalize($transaction->getOriginal($attribute));
+            $newValue = $this->normalize($transaction->getAttribute($attribute));
+
+            if ($oldValue === $newValue) {
+                continue;
+            }
+
+            $changedAttributes[] = $attribute;
+            $oldValues[$attribute] = $oldValue;
+            $newValues[$attribute] = $newValue;
+        }
+
+        return [
+            'changed_attributes' => $changedAttributes,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+        ];
+    }
+
+    private function normalize(mixed $value): mixed
+    {
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DateTimeInterface::ATOM);
+        }
+
+        if (is_string($value)) {
+            return $this->normalizeString($value);
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $normalized = [];
+
+        foreach ($value as $key => $item) {
+            $normalized[$key] = $this->normalize($item);
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeString(string $value): mixed
+    {
+        try {
+            $decrypted = Crypt::decryptString($value);
+        } catch (Throwable) {
+            return $value;
+        }
+
+        $decoded = json_decode($decrypted, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $this->normalize($decoded);
+        }
+
+        return $decrypted;
+    }
+}

--- a/src/Actions/ReconcileTransactionStatusAction.php
+++ b/src/Actions/ReconcileTransactionStatusAction.php
@@ -6,6 +6,7 @@ namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
 use Akira\Sisp\ValueObjects\TransactionStatusResponse;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -49,11 +50,14 @@ final readonly class ReconcileTransactionStatusAction
         $payload = is_array($payload) ? $payload : [];
         $payload['transaction_status_response'] = $response->raw;
 
-        $transaction->update([
-            'status' => $status->value,
-            'merchant_response' => $response->transactionStatusDescription ?: $response->message,
-            'payload' => $payload,
-        ]);
+        TransactionLogContext::run(
+            'reconciliation',
+            fn (): bool => $transaction->update([
+                'status' => $status->value,
+                'merchant_response' => $response->transactionStatusDescription ?: $response->message,
+                'payload' => $payload,
+            ])
+        );
 
         $this->updateInvoiceStatus->handle($transaction, $status);
 

--- a/src/Actions/RefundTransactionAction.php
+++ b/src/Actions/RefundTransactionAction.php
@@ -8,6 +8,7 @@ use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\TransactionRefunded;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\SispAmount;
+use Akira\Sisp\Support\TransactionLogContext;
 use LogicException;
 
 final readonly class RefundTransactionAction
@@ -31,11 +32,14 @@ final readonly class RefundTransactionAction
             );
         }
 
-        $transaction->update([
-            'status' => TransactionStatus::refunded->value,
-            'merchant_response' => "{$reason}::{$refundAmount}",
-            'refunded_at' => now(),
-        ]);
+        TransactionLogContext::run(
+            'refund',
+            fn (): bool => $transaction->update([
+                'status' => TransactionStatus::refunded->value,
+                'merchant_response' => "{$reason}::{$refundAmount}",
+                'refunded_at' => now(),
+            ])
+        );
 
         event(new TransactionRefunded($transaction, $refundAmount, $reason));
 

--- a/src/Actions/StoreCustomerDataAction.php
+++ b/src/Actions/StoreCustomerDataAction.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
 use Akira\Sisp\ValueObjects\CustomerData;
 
 final readonly class StoreCustomerDataAction
 {
     public function handle(Transaction $transaction, CustomerData $customerData): Transaction
     {
-        $transaction->update($customerData->toArray());
+        TransactionLogContext::run(
+            'customer-data',
+            fn (): bool => $transaction->update($customerData->toArray())
+        );
 
         return $transaction;
     }

--- a/src/Actions/Transaction/UpdateTransactionAction.php
+++ b/src/Actions/Transaction/UpdateTransactionAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions\Transaction;
 
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 
 final readonly class UpdateTransactionAction
@@ -16,14 +17,17 @@ final readonly class UpdateTransactionAction
     public function handle(Transaction $transaction, CallbackPayload $payload): bool
     {
 
-        return $transaction->update([
-            'transaction_id' => $payload->transactionID,
-            'message_type' => $payload->messageType,
-            'merchant_response' => $payload->merchantResponse,
-            'response_code' => $payload->merchantRespCp,
-            'fingerprint' => $payload->fingerprint,
-            'payload' => $transaction->payload,
-            'status' => $this->mapStatus->handle($payload->messageType),
-        ]);
+        return TransactionLogContext::run(
+            'callback',
+            fn (): bool => $transaction->update([
+                'transaction_id' => $payload->transactionID,
+                'message_type' => $payload->messageType,
+                'merchant_response' => $payload->merchantResponse,
+                'response_code' => $payload->merchantRespCp,
+                'fingerprint' => $payload->fingerprint,
+                'payload' => $transaction->payload,
+                'status' => $this->mapStatus->handle($payload->messageType),
+            ])
+        );
     }
 }

--- a/src/Http/Controllers/RetryPaymentController.php
+++ b/src/Http/Controllers/RetryPaymentController.php
@@ -8,6 +8,7 @@ use Akira\Sisp\Actions\RenderPaymentFormBasedOnConfigAction;
 use Akira\Sisp\Actions\RetryPaymentAction;
 use Akira\Sisp\Http\Requests\RetryPaymentRequest;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
 
 final readonly class RetryPaymentController
 {
@@ -22,7 +23,10 @@ final readonly class RetryPaymentController
 
         $paymentRequest = $this->retryPayment->handle($transaction);
 
-        $transaction->update(['merchant_session' => $paymentRequest->merchantSession]);
+        TransactionLogContext::run(
+            'retry',
+            fn (): bool => $transaction->update(['merchant_session' => $paymentRequest->merchantSession])
+        );
 
         return $this->renderForm->handle($paymentRequest, $transaction->locale);
     }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Models;
 
+use Akira\Sisp\Actions\LogTransactionChangesAction;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\Traits\EncryptsAttributes;
@@ -74,6 +75,18 @@ final class Transaction extends Model
     public function invoice(): HasOne
     {
         return $this->hasOne(Invoice::class, 'transaction_id');
+    }
+
+    public function logs(): HasMany
+    {
+        return $this->hasMany(TransactionLog::class, 'transaction_id');
+    }
+
+    protected static function booted(): void
+    {
+        self::updated(static function (Transaction $transaction): void {
+            resolve(LogTransactionChangesAction::class)->handle($transaction);
+        });
     }
 
     protected function casts(): array

--- a/src/Models/TransactionLog.php
+++ b/src/Models/TransactionLog.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class TransactionLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'transaction_id',
+        'source',
+        'changed_attributes',
+        'old_values',
+        'new_values',
+    ];
+
+    public function getTable(): string
+    {
+        return config('sisp.tables.transaction_logs', 'sisp_transaction_logs');
+    }
+
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'changed_attributes' => 'array',
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+}

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -33,6 +33,7 @@ final class SispServiceProvider extends PackageServiceProvider
             ->hasMigrations([
                 'create_laravel_sisp_table',
                 'update_laravel_sisp_transactions_add_amount_cents',
+                'create_sisp_transaction_logs_table',
             ])
             ->hasTranslations()
             ->hasRoutes('web')

--- a/src/Support/TransactionLogContext.php
+++ b/src/Support/TransactionLogContext.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Support;
+
+final class TransactionLogContext
+{
+    private static array $sources = [];
+
+    public static function run(string $source, callable $callback): mixed
+    {
+        self::$sources[] = $source;
+
+        try {
+            return $callback();
+        } finally {
+            array_pop(self::$sources);
+        }
+    }
+
+    public static function current(): string
+    {
+        $source = end(self::$sources);
+
+        return is_string($source) && $source !== '' ? $source : 'model';
+    }
+}

--- a/tests/Models/TransactionLogTest.php
+++ b/tests/Models/TransactionLogTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\CancelTransactionAction;
+use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Models\TransactionLog;
+use Illuminate\Support\Facades\Http;
+
+it('records changed transaction attributes with previous and new values', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::pending->value,
+        'merchant_response' => null,
+    ]);
+
+    $transaction->update([
+        'status' => TransactionStatus::completed->value,
+        'merchant_response' => 'C-SUCESSO',
+    ]);
+
+    $log = $transaction->logs()->sole();
+
+    expect($log)->toBeInstanceOf(TransactionLog::class)
+        ->and($log->source)->toBe('model')
+        ->and($log->changed_attributes)->toBe(['status', 'merchant_response'])
+        ->and($log->old_values)->toMatchArray([
+            'status' => 'pending',
+            'merchant_response' => null,
+        ])
+        ->and($log->new_values)->toMatchArray([
+            'status' => 'completed',
+            'merchant_response' => 'C-SUCESSO',
+        ]);
+});
+
+it('does not record timestamp-only transaction updates', function (): void {
+    $transaction = Transaction::factory()->create();
+
+    $transaction->touch();
+
+    expect($transaction->logs()->count())->toBe(0);
+});
+
+it('records payload changes as decrypted arrays', function (): void {
+    $transaction = Transaction::factory()->create([
+        'payload' => ['attempt' => 1],
+    ]);
+
+    $transaction->update([
+        'payload' => ['attempt' => 2, 'status' => ['approved' => true]],
+    ]);
+
+    $log = $transaction->logs()->sole();
+
+    expect($log->changed_attributes)->toBe(['payload'])
+        ->and($log->old_values['payload'])->toBe(['attempt' => 1])
+        ->and($log->new_values['payload'])->toBe([
+            'attempt' => 2,
+            'status' => ['approved' => true],
+        ]);
+});
+
+it('uses package flow source for cancellation updates', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::pending->value,
+    ]);
+
+    resolve(CancelTransactionAction::class)->handle($transaction, 'user_cancelled');
+
+    $log = $transaction->logs()->sole();
+
+    expect($log->source)->toBe('cancel')
+        ->and($log->new_values['status'])->toBe('cancelled')
+        ->and($log->new_values['merchant_response'])->toBe('user_cancelled');
+});
+
+it('uses package flow source for reconciliation updates', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'status' => TransactionStatus::pending->value,
+        'payload' => ['existing' => true],
+    ]);
+
+    resolve(ReconcileTransactionStatusAction::class)->handle($transaction);
+
+    $log = $transaction->logs()->sole();
+
+    expect($log->source)->toBe('reconciliation')
+        ->and($log->new_values['status'])->toBe('completed')
+        ->and($log->new_values['payload']['transaction_status_response']['transactionSuccess'])->toBeTrue();
+});


### PR DESCRIPTION
Problem: #202 tracks missing transaction change history. Transaction updates changed payment state without a persisted audit trail.

Root cause: the package stored only the latest transaction row state. Callback, retry, cancel, refund, reconciliation, and direct model updates had no append-only history.

Solution:
- Add a configurable `sisp_transaction_logs` table and publishable package migration.
- Add `TransactionLog` and `Transaction::logs()` for inspecting history.
- Record changed attributes, old values, new values, source, and timestamps from Eloquent transaction updates.
- Add transaction log source context for package flows: callback, cancel, refund, retry, reconciliation, and customer-data.
- Normalize encrypted payload values before storing history so logs stay inspectable.
- Document table configuration and transaction history access.
- Pin GitHub workflow actions to full commit SHAs because the organization now blocks tag-based actions.

Validation:
- vendor/bin/pest --compact tests/Models/TransactionLogTest.php tests/Models/TransactionAmountTest.php tests/Actions/RefundTransactionActionTest.php tests/Actions/ReconcileTransactionStatusActionTest.php
- vendor/bin/pint --dirty --test
- vendor/bin/phpstan analyse --no-progress
- COMPOSER_PROCESS_TIMEOUT=0 composer test
- GitHub Actions matrix passed on PR #203
- git diff --check
- commit-guard staged scans for comments, chained if, AI-tells, and secrets

Risk/rollback: adds one migration and one model relation. Roll back by reverting this PR before publishing the new migration, or by dropping the log table if already migrated.

Fixes #202
