### PR TITLE
fix(callback): preserve failed payment retry flow

### DIFF
--- a/src/Actions/CanRetryPaymentAction.php
+++ b/src/Actions/CanRetryPaymentAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Transaction;
 
 final readonly class CanRetryPaymentAction
@@ -14,6 +15,10 @@ final readonly class CanRetryPaymentAction
     public function handle(Transaction $transaction): bool
     {
         if (! $this->config->isRetryAllowed()) {
+            return false;
+        }
+
+        if ($transaction->status !== TransactionStatus::failed) {
             return false;
         }
 

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -33,15 +33,15 @@ final readonly class HandleCallbackAction
         $transaction = $this->findOrCreateTransaction->handle($payload);
 
         if (! Sisp::validateCallback($payload)) {
-            event(new PaymentFailed($transaction, $payload));
+            $this->failTransaction($transaction, $payload, 'invalid_callback_fingerprint');
 
-            $this->updateTransaction->handle($transaction, $payload);
+            event(new PaymentFailed($transaction, $payload));
 
             return $transaction;
         }
 
         if (! $this->matchesTransaction($transaction, $payload)) {
-            $this->failTransaction($transaction, $payload);
+            $this->failTransaction($transaction, $payload, 'callback_details_mismatch');
 
             event(new PaymentFailed($transaction, $payload));
 
@@ -80,14 +80,14 @@ final readonly class HandleCallbackAction
         return SispAmount::toThousandths($expected) === SispAmount::toThousandths($actual);
     }
 
-    private function failTransaction(Transaction $transaction, CallbackPayload $payload): void
+    private function failTransaction(Transaction $transaction, CallbackPayload $payload, string $merchantResponse): void
     {
         TransactionLogContext::run(
             'callback',
             fn (): bool => $transaction->update([
                 'transaction_id' => $payload->transactionID,
                 'message_type' => $payload->messageType,
-                'merchant_response' => 'callback_details_mismatch',
+                'merchant_response' => $merchantResponse,
                 'response_code' => $payload->merchantRespCp,
                 'fingerprint' => $payload->fingerprint,
                 'status' => TransactionStatus::failed,

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -10,6 +10,7 @@ use Akira\Sisp\Actions\UpdateInvoiceStatusAction;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\CallbackPayload;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -61,10 +62,6 @@ final readonly class CallbackController
     {
         $payload = CallbackPayload::from($request->all());
 
-        if (! Sisp::validateCallback($payload)) {
-            return redirect(config('sisp.redirect_url', '/'));
-        }
-
         if ($payload->merchantRef === '' || $payload->merchantSession === '') {
             return redirect(config('sisp.redirect_url', '/'));
         }
@@ -73,7 +70,11 @@ final readonly class CallbackController
             return redirect(config('sisp.redirect_url', '/'))->with('info', 'This payment has already been processed.');
         }
 
-        $transaction = Sisp::handlePaymentCallback($payload);
+        try {
+            $transaction = Sisp::handlePaymentCallback($payload);
+        } catch (ModelNotFoundException) {
+            return redirect(config('sisp.redirect_url', '/'));
+        }
 
         $this->storeMetadata->handle($request, $transaction);
 

--- a/src/Http/Controllers/RetryPaymentController.php
+++ b/src/Http/Controllers/RetryPaymentController.php
@@ -6,6 +6,7 @@ namespace Akira\Sisp\Http\Controllers;
 
 use Akira\Sisp\Actions\RenderPaymentFormBasedOnConfigAction;
 use Akira\Sisp\Actions\RetryPaymentAction;
+use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Http\Requests\RetryPaymentRequest;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\TransactionLogContext;
@@ -25,7 +26,15 @@ final readonly class RetryPaymentController
 
         TransactionLogContext::run(
             'retry',
-            fn (): bool => $transaction->update(['merchant_session' => $paymentRequest->merchantSession])
+            fn (): bool => $transaction->update([
+                'merchant_session' => $paymentRequest->merchantSession,
+                'transaction_id' => null,
+                'message_type' => null,
+                'merchant_response' => null,
+                'response_code' => null,
+                'fingerprint' => null,
+                'status' => TransactionStatus::pending,
+            ])
         );
 
         return $this->renderForm->handle($paymentRequest, $transaction->locale);

--- a/tests/Actions/CanRetryPaymentActionTest.php
+++ b/tests/Actions/CanRetryPaymentActionTest.php
@@ -87,3 +87,18 @@ it('blocks retry when retry is disabled by configuration', function (): void {
 
     expect($canRetry)->toBeFalse();
 });
+
+it('blocks retry when transaction is not failed', function (): void {
+    config([
+        'sisp.allow_retry' => true,
+        'sisp.is_3dsec' => '0',
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'completed',
+    ]);
+
+    $canRetry = resolve(CanRetryPaymentAction::class)->handle($transaction);
+
+    expect($canRetry)->toBeFalse();
+});

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Actions\HandleCallbackAction;
-use Akira\Sisp\Enums\ErrorMessageType;
 use Akira\Sisp\Enums\SuccessMessageType;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
@@ -57,10 +56,11 @@ it('dispatches PaymentFailed and marks the transaction failed when fingerprint i
         'status' => TransactionStatus::pending,
     ]);
 
-    resolve(HandleCallbackAction::class)->handle(cb_payload(ErrorMessageType::invalidAmount->value));
+    resolve(HandleCallbackAction::class)->handle(cb_payload(SuccessMessageType::purchase->value));
 
     $transaction->refresh();
-    expect($transaction->status->value)->toBe('failed');
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('invalid_callback_fingerprint');
 
     Event::assertDispatched(PaymentFailed::class);
 });

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -25,6 +25,11 @@ it('updates merchant_session on transaction so callback can find it', function (
         'merchant_session' => 'MS-OLD',
         'amount' => 50.0,
         'currency' => '132',
+        'transaction_id' => 'OLD-TID',
+        'message_type' => '13',
+        'merchant_response' => 'old failure',
+        'response_code' => '13',
+        'fingerprint' => 'old-fingerprint',
     ]);
 
     $this->post(signedRetryUrl($t))
@@ -34,7 +39,41 @@ it('updates merchant_session on transaction so callback can find it', function (
 
     expect($t->merchant_session)
         ->not->toBe('MS-OLD')
-        ->not->toBeEmpty();
+        ->not->toBeEmpty()
+        ->and($t->status->value)->toBe('pending')
+        ->and($t->transaction_id)->toBeNull()
+        ->and($t->message_type)->toBeNull()
+        ->and($t->merchant_response)->toBeNull()
+        ->and($t->response_code)->toBeNull()
+        ->and($t->fingerprint)->toBeNull();
+});
+
+it('does not reset completed transactions through signed retry links', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'completed',
+        'merchant_ref' => 'MR-COMPLETED',
+        'merchant_session' => 'MS-COMPLETED',
+        'amount' => 50.0,
+        'currency' => '132',
+        'transaction_id' => 'PAID-TID',
+        'message_type' => '8',
+        'merchant_response' => 'paid',
+        'response_code' => '00',
+        'fingerprint' => 'paid-fingerprint',
+    ]);
+
+    $this->postJson(signedRetryUrl($t))
+        ->assertJsonValidationErrors(['transaction']);
+
+    $t->refresh();
+
+    expect($t->status->value)->toBe('completed')
+        ->and($t->merchant_session)->toBe('MS-COMPLETED')
+        ->and($t->transaction_id)->toBe('PAID-TID')
+        ->and($t->message_type)->toBe('8')
+        ->and($t->merchant_response)->toBe('paid')
+        ->and($t->response_code)->toBe('00')
+        ->and($t->fingerprint)->toBe('paid-fingerprint');
 });
 
 it('returns validation error without triggering after callback when transaction does not exist', function (): void {

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -7,7 +7,6 @@ use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Sisp as SispManager;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
-use Illuminate\Support\Facades\DB;
 
 beforeEach(function (): void {
     config()->set('sisp.sandbox', true);
@@ -24,22 +23,6 @@ function callback_controller_payload(Transaction $transaction, array $overrides 
         'transactionCode' => $transaction->transaction_code ?? '1',
     ], $overrides)))->toArray();
 }
-
-function callback_query_reads_transactions_table(string $query): bool
-{
-    $normalizedQuery = str_replace(['`', '"', '[', ']'], '', mb_strtolower($query));
-
-    return preg_match('/\bfrom\s+(?:[a-z0-9_]+\.)?transactions\b/', $normalizedQuery) === 1;
-}
-
-it('detects transaction table lookups across database grammars', function (string $query): void {
-    expect(callback_query_reads_transactions_table($query))->toBeTrue();
-})->with([
-    'sqlite quoted table' => ['select * from "transactions" where "merchant_ref" = ?'],
-    'mysql quoted table' => ['select * from `transactions` where `merchant_ref` = ?'],
-    'unquoted table' => ['select * from transactions where merchant_ref = ?'],
-    'qualified quoted table' => ['select * from `main`.`transactions` where `merchant_ref` = ?'],
-]);
 
 it('redirects when user cancelled flag present', function (): void {
     config()->set('sisp.redirect_url', '/home');
@@ -92,12 +75,13 @@ it('handles POST callback and redirects to GET with ref', function (): void {
         ->and($t->fingerprint)->toBe($payload->fingerprint);
 });
 
-it('rejects invalid callback payload before transaction lookups', function (): void {
-    config()->set('sisp.redirect_url', '/home');
-
-    Transaction::factory()->create([
+it('records callbacks with invalid fingerprints as failed and redirects to response page', function (): void {
+    $transaction = Transaction::factory()->create([
         'merchant_ref' => 'MR-G3',
         'merchant_session' => 'MS-G3',
+        'amount' => 20,
+        'currency' => '132',
+        'status' => 'pending',
     ]);
 
     $payload = Sisp::generateSandboxPayload(PaymentRequestData::from([
@@ -110,17 +94,31 @@ it('rejects invalid callback payload before transaction lookups', function (): v
     ]))->toArray();
     $payload['resultFingerPrint'] = 'invalid-fingerprint';
 
-    DB::flushQueryLog();
-    DB::enableQueryLog();
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-G3']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('invalid_callback_fingerprint')
+        ->and($transaction->fingerprint)->toBe('invalid-fingerprint');
+});
+
+it('redirects invalid callbacks with unknown transaction keys', function (): void {
+    config()->set('sisp.redirect_url', '/home');
+
+    $payload = Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => 20,
+        'merchantRef' => 'MR-UNKNOWN',
+        'merchantSession' => 'MS-UNKNOWN',
+        'timeStamp' => '2024-01-01 00:00:00',
+        'currency' => '132',
+        'transactionCode' => '1',
+    ]))->toArray();
+    $payload['resultFingerPrint'] = 'invalid-fingerprint';
 
     $this->post(route('sisp.callback'), $payload)
         ->assertRedirect('/home');
-
-    $queries = collect(DB::getQueryLog())->pluck('query');
-
-    expect($queries->filter(
-        fn (string $query): bool => callback_query_reads_transactions_table($query)
-    ))->toHaveCount(0);
 });
 
 it('skips duplicate lookup when callback payload has no transaction keys', function (): void {


### PR DESCRIPTION
## Summary

Fixes the SISP callback/retry flow for failed payment attempts.

## What changed

- Let invalid callback fingerprints reach the callback handler instead of redirecting before the transaction is loaded.
- Mark invalid callback fingerprints as failed transactions with invalid_callback_fingerprint metadata and dispatch PaymentFailed.
- Keep callback detail mismatches marked separately as callback_details_mismatch.
- Reset stale SISP response fields when retrying a failed transaction so the retry starts from a clean pending state.
- Updated callback and retry tests around invalid fingerprints and stale retry state.

## Why

In 0.7.0, invalid SISP callbacks could bypass the transaction failure flow and fall back to the configured redirect. That breaks the app-level retry/alert behavior because the transaction is not consistently persisted as failed. Retrying after an error could also keep old response metadata, making the next attempt behave like the previous failure was still active.
