### PR TITLE
docs(readme): add akira readme scaffold

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one of
+          the following places: within a NOTICE text file distributed as
+          part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution notices
+          within Derivative Works that You distribute, alongside or as an
+          addendum to the NOTICE text from the Work, provided that such
+          additional attribution notices cannot be construed as modifying
+          the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed" page as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Kidiatoliny
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kidiatoliny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,156 +1,120 @@
-# Laravel SISP Documentation
+<p align="center"><img src="assets/banner.svg" alt="Laravel SISP" width="768"></p>
 
-Welcome to **Laravel SISP** - a robust Laravel 12+ package for integrating SISP Cabo Verde payment gateway with
-comprehensive transaction management, invoice generation, and fraud detection.
+<p align="center">
+<a href="https://packagist.org/packages/akira/laravel-sisp"><img src="https://img.shields.io/packagist/v/akira/laravel-sisp.svg" alt="Packagist Version"></a>
+<a href="https://packagist.org/packages/akira/laravel-sisp"><img src="https://img.shields.io/packagist/dt/akira/laravel-sisp.svg" alt="downloads"></a>
+<a href="https://github.com/akira-io/laravel-sisp/actions/workflows/run-tests.yml"><img src="https://github.com/akira-io/laravel-sisp/actions/workflows/run-tests.yml/badge.svg" alt="tests"></a>
+<img src="https://img.shields.io/packagist/l/akira/laravel-sisp.svg" alt="license">
+<img src="https://img.shields.io/packagist/php-v/akira/laravel-sisp" alt="php">
+</p>
 
-## Quick Start
+Laravel SISP is a Laravel package for SISP Cabo Verde payment flows, with transaction management, invoice generation, callback validation, sandbox tooling, and multi-merchant credential support.
 
-```bash
+## Install
+
+```sh
 composer require akira/laravel-sisp
 php artisan laravel-sisp:install
 ```
 
-Configure your `.env`:
+```json
+{
+  "require": {
+    "akira/laravel-sisp": "^0.7"
+  }
+}
+```
+
+| Area | Included |
+| --- | --- |
+| Payments | Payment request building, SISP form rendering, callbacks, cancellation, retry, and refunds |
+| Transactions | Eloquent models, audit logs, reconciliation, and status queries |
+| Invoices | PDF invoice generation after approved payments |
+| Security | Fingerprint validation, signed retry and cancellation requests, rate limits, metadata collection, and blacklist support |
+| Frontend | Blade views and optional Inertia rendering |
+
+## Quick Start
 
 ```env
 SISP_URL=https://mc.vinti4net.cv/Client_VbV_v2/biz_vbv_clientdata.jsp
 SISP_POS_ID=your_pos_id
 SISP_POS_AUT_CODE=your_authorization_code
 SISP_MERCHANT_ID=your_merchant_id
+SISP_SANDBOX=true
 ```
 
-## Documentation Index
+```blade
+<form action="{{ route('sisp.payment') }}" method="POST">
+    @csrf
 
-### Getting Started
+    <input type="number" name="amount" required>
+    <input type="text" name="items[0][product_name]" required>
+    <input type="number" name="items[0][quantity]" required>
+    <input type="number" name="items[0][unit_price]" required>
+    <input type="number" name="items[0][total_price]" required>
+    <input type="email" name="customer_email">
 
-- [Installation](./01-installation.md) - Install and configure the package
-- [Configuration](./02-configuration.md) - Configure SISP credentials and options
-- [Quick Start Guide](./03-quick-start.md) - Create your first payment in 5 minutes
-
-### Core Concepts
-
-- [Payment Flow](./04-payment-flow.md) - Complete payment process overview
-- [Transaction Management](./05-transaction-management.md) - Create and manage transactions
-- [Invoice Generation](./06-invoice-generation.md) - Auto-generate PDF invoices after payments
-
-### Features & Security
-
-- [Security](./07-security.md) - Rate limiting, metadata collection, fraud detection
-
-### Learning & Reference
-
-- [Examples](./08-examples.md) - Real-world integration examples and code samples
-- [API Reference](./11-api-reference.md) - Complete API methods and classes
-- [FAQ](./10-faq.md) - Frequently asked questions
-- [Troubleshooting](./09-troubleshooting.md) - Common issues and solutions
-
-## Key Features
-
-- Multi-merchant/SaaS support with runtime credential injection
-- Payment form rendering (Blade or Inertia.js)
-- Automatic PDF invoice generation
-- Multi-item transaction support
-- Comprehensive rate limiting
-- Security metadata collection
-- Complete transaction audit trail
-- Webhook signature verification
-- Type-safe DTOs and builders
-
-## System Requirements
-
-- PHP 8.4 or higher
-- Laravel 12 or higher
-- PostgreSQL or MySQL database
-- Node.js for frontend assets (if using Inertia)
-
-## What's Included
-
-After installation, you get:
-
-- Service provider and service container bindings
-- Database migrations for transactions, invoices, and security tables
-- Payment routes and webhook handling
-- Blade views or Inertia.js components for payment forms
-- Invoice generation via Laravel PDF Invoices package
-- Rate limiting middleware
-- Security metadata collection
-
-## Package Structure
-
-```
-laravel-sisp/
-├── src/
-│   ├── Actions/              # Business logic
-│   ├── Controllers/          # HTTP controllers
-│   ├── DTO/                  # Data transfer objects
-│   ├── Models/               # Eloquent models
-│   ├── Facades/              # Facade classes
-│   ├── Middleware/           # HTTP middleware
-│   └── Providers/            # Service providers
-├── database/
-│   ├── migrations/           # Database migrations
-│   └── factories/            # Model factories
-├── resources/
-│   ├── views/                # Blade templates
-│   └── components/           # Vue/React components
-├── config/
-│   └── sisp.php             # Package configuration
-└── docs/                     # This documentation
+    <button type="submit">Pay</button>
+</form>
 ```
 
-## Next Steps
+Use the facade when application code needs lower-level package operations:
 
-1. Start with [Installation](./01-installation.md)
-2. Follow [Configuration](./02-configuration.md) for your setup
-3. Try the [Quick Start Guide](./03-quick-start.md)
-4. Read [Payment Flow](./04-payment-flow.md) to understand the process
+```php
+use Akira\Sisp\Facades\Sisp;
 
-## Support
+$transaction = Sisp::reconcileTransactionStatus($transaction);
+$countries = Sisp::countries();
+```
 
-For issues or questions:
+## Documentation
 
-- Check [Troubleshooting](./09-troubleshooting.md)
-- Review [Examples](./08-examples.md)
-- Read [API Reference](./11-api-reference.md)
-- Visit [FAQ](./10-faq.md) for common questions
+- [Roadmap](docs/00-roadmap.md)
+- [Installation](docs/01-installation.md)
+- [Configuration](docs/02-configuration.md)
+- [Quick Start](docs/03-quick-start.md)
+- [Payment Flow](docs/04-payment-flow.md)
+- [Transaction Management](docs/05-transaction-management.md)
+- [Invoice Generation](docs/06-invoice-generation.md)
+- [Security](docs/07-security.md)
+- [Examples](docs/08-examples.md)
+- [Troubleshooting](docs/09-troubleshooting.md)
+- [FAQ](docs/10-faq.md)
+- [API Reference](docs/11-api-reference.md)
+
+Reference documentation is maintained in this repository under [`docs`](docs).
+
+## Testing
+
+```sh
+composer test
+```
+
+Additional focused checks are available through Composer scripts:
+
+```sh
+composer test:coverage
+composer test:type-coverage
+composer test:types
+composer test:lint
+```
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history. Releases are generated with `git-cliff`.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, test expectations, commit style, and pull request guidance.
+
+## Security
+
+Report security issues through the process documented in [SECURITY.md](SECURITY.md).
+
+## Credits
+
+Laravel SISP is maintained by [Kidiatoliny](https://github.com/Kidiatoliny) and the Akira team. Contributor recognition is managed through [All Contributors](https://allcontributors.org).
 
 ## License
 
-MIT License. See LICENSE file for details.
-
-## Testing & Coverage
-
-- Run full test suite with code coverage at exactly 100%:
-
-  - `vendor/bin/pest --parallel --coverage --compact --exactly=100`
-
-- Enforce 100% type coverage:
-
-  - `vendor/bin/pest --type-coverage --min=100`
-
-### Driving sisp:install in tests (no TTY, no mocks)
-
-In tests, interactive prompts for `sisp:install` are controlled by config flags under `sisp.tests.*`. These flags are only read when `app()->runningUnitTests()` is true. In normal usage the command remains fully interactive.
-
-Available toggles (bool):
-
-- `sisp.tests.publish_config` / `sisp.tests.force_config`
-- `sisp.tests.publish_migrations` / `sisp.tests.force_migrations`
-- `sisp.tests.publish_inertia` / `sisp.tests.force_inertia`
-- `sisp.tests.publish_blade` / `sisp.tests.force_blade`
-- `sisp.tests.run_migrations` – whether to run migrations step
-- `sisp.tests.fake_migrate` – short-circuit actual `migrate` call in tests (defaults to true)
-- `sisp.tests.give_star` – whether to show the “give a star” note
-
-Example (Pest test):
-
-```php
-config()->set('sisp.tests.publish_config', true);
-config()->set('sisp.tests.publish_migrations', true);
-config()->set('sisp.tests.run_migrations', true);
-config()->set('sisp.tests.fake_migrate', true); // don’t run real migrations again
-config()->set('sisp.tests.publish_inertia', false); // avoid vendor:publish in CI
-config()->set('sisp.tests.publish_blade', false);
-```
-
-This keeps tests stable and fast in parallel CI runs while allowing full branch coverage without using mocks.
+Laravel SISP is dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE). Unless you state otherwise, contributions are licensed under both licenses.

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 1024" width="1536" height="1024" role="img" aria-label="Laravel SISP">
+  <defs>
+    <linearGradient id="purple" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#9a7df5"/>
+      <stop offset="100%" stop-color="#5b3acb"/>
+    </linearGradient>
+    <linearGradient id="foldDark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#000000" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1a1726"/>
+      <stop offset="100%" stop-color="#0e0b18"/>
+    </linearGradient>
+    <linearGradient id="sheen" x1="100%" y1="0%" x2="40%" y2="80%">
+      <stop offset="0%" stop-color="#7c5cf0" stop-opacity="0.25"/>
+      <stop offset="60%" stop-color="#7c5cf0" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#7c5cf0" stop-opacity="0"/>
+    </linearGradient>
+    <clipPath id="cardClip">
+      <path d="M 24 360 Q 24 332 52 332 L 1484 332 Q 1512 332 1512 360 L 1512 1024 L 24 1024 Z"/>
+    </clipPath>
+    <style>
+      .title { font: 800 100px ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; fill: #ffffff; text-anchor: middle; }
+      .subtitle { font: 400 36px ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; fill: #ffffff; fill-opacity: 0.65; text-anchor: middle; }
+      .wordmark { font: 800 132px ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; fill: #7c5cf0; text-anchor: middle; }
+      .icon { fill: none; stroke: #7c5cf0; stroke-width: 7; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+  <rect width="1536" height="1024" fill="url(#purple)"/>
+  <polygon points="0,0 760,0 0,560" fill="url(#foldDark)"/>
+  <text class="title" x="768" y="180">Laravel SISP</text>
+  <text class="subtitle" x="768" y="270">Laravel package for SISP payment flows</text>
+  <g clip-path="url(#cardClip)">
+    <rect x="24" y="332" width="1488" height="692" fill="url(#card)"/>
+    <rect x="24" y="332" width="1488" height="692" fill="url(#sheen)"/>
+  </g>
+  <g transform="translate(768, 590)">
+    <path class="icon" d="M 0 -72 L 60 -48 L 60 16 Q 60 60 0 80 Q -60 60 -60 16 L -60 -48 Z"/>
+    <polyline class="icon" points="-24,4 -4,24 32,-12"/>
+  </g>
+  <text class="wordmark" x="768" y="820">SISP</text>
+</svg>


### PR DESCRIPTION
Summary: Reworks README in the akira pattern, adds assets/banner.svg, and adds MIT and Apache license companion files. Tests: composer test.