### PR TITLE
fix(callback): harden retry diagnostics

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -287,6 +287,7 @@ return [
         'path' => env('SISP_INVOICE_PATH', 'invoices'),
         'template' => env('SISP_INVOICE_TEMPLATE', 'branded'),
         'temporary_url_expiration_hours' => env('SISP_INVOICE_TEMPORARY_URL_EXPIRATION_HOURS', 24),
+        'pdf_url_generator' => null,
         'company_name' => env('SISP_COMPANY_NAME', ''),
         'company_address' => env('SISP_COMPANY_ADDRESS', ''),
         'company_code' => env('SISP_COMPANY_CODE', ''),

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ Route::post('sisp/payment', PaymentController::class)
     ->middleware(config()->array('sisp.middleware.payment', [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class]))
     ->name('sisp.payment');
 
-Route::post('sisp/retry-payment', RetryPaymentController::class)
+Route::match(['get', 'post'], 'sisp/retry-payment', RetryPaymentController::class)
     ->middleware(config()->array('sisp.middleware.retry', []))
     ->name('sisp.retry-payment');
 

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -70,9 +70,9 @@ final readonly class HandleCallbackAction
         return $this->transactionString($transaction, 'merchant_ref') === $payload->merchantRef
             && $this->transactionString($transaction, 'merchant_session') === $payload->merchantSession
             && $this->amountMatches($this->transactionAmount($transaction), $payload->amount)
-            && $this->transactionString($transaction, 'currency') === $payload->currency
-            && $this->transactionCode($transaction) === $payload->transactionCode
-            && $this->credentialsResolver->resolve()->posId === $payload->posID;
+            && (! $payload->currencyProvided || $this->transactionString($transaction, 'currency') === $payload->currency)
+            && (! $payload->transactionCodeProvided || $this->transactionCode($transaction) === $payload->transactionCode)
+            && (! $payload->posIDProvided || $this->credentialsResolver->resolve()->posId === $payload->posID);
     }
 
     private function amountMatches(float|int|string $expected, float|int|string $actual): bool

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -14,19 +14,19 @@ final readonly class RetryPaymentAction
 
     public function __construct(private BuildRequestPayloadAction $buildRequestPayload) {}
 
-    public function handle(Transaction $transaction): PaymentRequest
+    public function handle(Transaction $transaction, bool $rotateMerchantSession = true): PaymentRequest
     {
-        $paymentRequestData = $this->extractFromTransaction($transaction);
+        $paymentRequestData = $this->extractFromTransaction($transaction, $rotateMerchantSession);
 
         return $this->buildRequestPayload->handle($paymentRequestData);
     }
 
-    private function extractFromTransaction(Transaction $transaction): PaymentRequestData
+    private function extractFromTransaction(Transaction $transaction, bool $rotateMerchantSession): PaymentRequestData
     {
         return new PaymentRequestData(
             amount: $transaction->amount,
             merchantRef: $transaction->merchant_ref,
-            merchantSession: null,
+            merchantSession: $rotateMerchantSession ? null : $this->merchantSession($transaction),
             timeStamp: null,
             currency: $transaction->currency,
             transactionCode: $transaction->transaction_code,
@@ -48,5 +48,12 @@ final readonly class RetryPaymentAction
         $postalCode = $transaction->getAttribute('customer_postal_code');
 
         return is_string($postalCode) && $postalCode !== '' ? $postalCode : self::FALLBACK_POSTAL_CODE;
+    }
+
+    private function merchantSession(Transaction $transaction): ?string
+    {
+        $merchantSession = $transaction->getAttribute('merchant_session');
+
+        return is_string($merchantSession) && $merchantSession !== '' ? $merchantSession : null;
     }
 }

--- a/src/Actions/StoreRequestMetadataAction.php
+++ b/src/Actions/StoreRequestMetadataAction.php
@@ -40,7 +40,60 @@ final readonly class StoreRequestMetadataAction
                 'is_mobile' => $this->isMobileDevice($request),
                 'risk_score' => 0,
                 'risk_reason' => null,
+                'custom_metadata' => $this->customMetadata($request),
             ]);
+    }
+
+    /**
+     * @return array{
+     *     method: string,
+     *     path: string,
+     *     query: array<string, mixed>,
+     *     payload: array<string, mixed>,
+     *     headers: array<string, mixed>
+     * }
+     */
+    private function customMetadata(Request $request): array
+    {
+        return [
+            'method' => $request->method(),
+            'path' => $request->path(),
+            'query' => $this->redactSensitiveData($request->query()),
+            'payload' => $this->redactSensitiveData($request->request->all()),
+            'headers' => $this->redactSensitiveData($request->headers->all()),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function redactSensitiveData(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if ($this->isSensitiveKey((string) $key)) {
+                $data[$key] = '[redacted]';
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                /** @var array<string, mixed> $value */
+                $data[$key] = $this->redactSensitiveData($value);
+            }
+        }
+
+        return $data;
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        $key = mb_strtolower($key);
+
+        return array_any(
+            ['authorization', 'cookie', 'password', 'passwd', 'secret', 'token', 'card', 'cvv', 'cvc', 'key', 'pin'],
+            fn (string $sensitiveKey): bool => str_contains($key, $sensitiveKey),
+        );
     }
 
     private function generateDeviceFingerprint(Request $request): string

--- a/src/Http/Controllers/RetryPaymentController.php
+++ b/src/Http/Controllers/RetryPaymentController.php
@@ -22,6 +22,13 @@ final readonly class RetryPaymentController
     {
         $transaction = Transaction::query()->findOrFail($request->integer('transaction'));
 
+        if ($request->isMethod('get')) {
+            return $this->renderForm->handle(
+                $this->retryPayment->handle($transaction, rotateMerchantSession: false),
+                $transaction->locale,
+            );
+        }
+
         $paymentRequest = $this->retryPayment->handle($transaction);
 
         TransactionLogContext::run(

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Models;
 use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Enums\InvoiceStatus;
 use Carbon\CarbonInterface;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -81,6 +82,12 @@ final class Invoice extends Model
             return null;
         }
 
+        $configuredUrl = $this->configuredPdfUrl();
+
+        if ($configuredUrl !== null) {
+            return $configuredUrl;
+        }
+
         $disk = config('sisp.invoice.disk', 'public');
 
         if ($disk === 's3') {
@@ -90,5 +97,27 @@ final class Invoice extends Model
         }
 
         return Storage::disk($disk)->url($this->pdf_path);
+    }
+
+    private function configuredPdfUrl(): ?string
+    {
+        $generator = config('sisp.invoice.pdf_url_generator');
+
+        if (is_string($generator) && $generator !== '') {
+            try {
+                $generator = resolve($generator);
+            } catch (BindingResolutionException) {
+                return null;
+            }
+        }
+
+        if (! is_callable($generator)) {
+            return null;
+        }
+
+        /** @var callable(self): mixed $generator */
+        $url = $generator($this);
+
+        return is_string($url) && $url !== '' ? $url : null;
     }
 }

--- a/src/ValueObjects/CallbackPayload.php
+++ b/src/ValueObjects/CallbackPayload.php
@@ -28,6 +28,9 @@ final readonly class CallbackPayload
         public string $additionalErrorMessage = '',
         public string $merchantRespCp = '',
         public string $reloadCode = '',
+        public bool $currencyProvided = true,
+        public bool $transactionCodeProvided = true,
+        public bool $posIDProvided = true,
     ) {}
 
     public static function from(array $data): self
@@ -54,6 +57,9 @@ final readonly class CallbackPayload
             additionalErrorMessage: $data['merchantRespAdditionalErrorMessage'] ?? '',
             merchantRespCp: $data['merchantRespCP'] ?? '',
             reloadCode: $data['reloadCode'] ?? '',
+            currencyProvided: array_key_exists('currency', $data),
+            transactionCodeProvided: array_key_exists('transactionCode', $data),
+            posIDProvided: array_key_exists('posID', $data),
         );
     }
 

--- a/tests/Actions/StoreRequestMetadataActionTest.php
+++ b/tests/Actions/StoreRequestMetadataActionTest.php
@@ -29,6 +29,56 @@ it('stores request metadata with basic fields', function (): void {
         ->and(is_string($meta->browser))->toBeTrue();
 });
 
+it('stores sanitized request payload for diagnostics', function (): void {
+    $action = resolve(StoreRequestMetadataAction::class);
+    $transaction = Transaction::factory()->create();
+
+    $request = Request::create(
+        uri: '/sisp/callback?ref=MR-DIAG',
+        method: 'POST',
+        parameters: [
+            'merchantRespMerchantRef' => 'MR-DIAG',
+            'merchantRespMerchantSession' => 'MS-DIAG',
+            'merchantRespPurchaseAmount' => '10',
+            'resultFingerPrint' => 'signed-fingerprint',
+            'card_number' => '4111111111111111',
+            'api_key' => 'api-secret',
+            'pin' => '1234',
+            'nested' => [
+                'token' => 'secret-token',
+                'safe' => 'visible',
+            ],
+        ],
+        server: [
+            'REMOTE_ADDR' => '127.0.0.1',
+            'HTTP_AUTHORIZATION' => 'Bearer secret',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0',
+        ],
+    );
+
+    $meta = $action->handle($request, $transaction);
+
+    expect($meta->custom_metadata)->toMatchArray([
+        'method' => 'POST',
+        'path' => 'sisp/callback',
+        'query' => ['ref' => 'MR-DIAG'],
+        'payload' => [
+            'merchantRespMerchantRef' => 'MR-DIAG',
+            'merchantRespMerchantSession' => 'MS-DIAG',
+            'merchantRespPurchaseAmount' => '10',
+            'resultFingerPrint' => 'signed-fingerprint',
+            'card_number' => '[redacted]',
+            'api_key' => '[redacted]',
+            'pin' => '[redacted]',
+            'nested' => [
+                'token' => '[redacted]',
+                'safe' => 'visible',
+            ],
+        ],
+    ])
+        ->and($meta->custom_metadata['headers']['authorization'])->toBe('[redacted]');
+});
+
 it('detects browser/OS/device/mobile flags from user-agent variants', function (): void {
     $action = resolve(StoreRequestMetadataAction::class);
 

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -18,6 +18,34 @@ it('retries payment and renders form', function (): void {
     $response->assertStatus(200);
 });
 
+it('opens signed retry links with get requests without mutating transactions', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_ref' => 'MR-GET',
+        'merchant_session' => 'MS-GET-OLD',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_id' => 'OLD-TID',
+        'message_type' => '13',
+        'merchant_response' => 'old failure',
+        'response_code' => '13',
+        'fingerprint' => 'old-fingerprint',
+    ]);
+
+    $this->get(signedRetryUrl($t))
+        ->assertStatus(200);
+
+    $t->refresh();
+
+    expect($t->merchant_session)->toBe('MS-GET-OLD')
+        ->and($t->status->value)->toBe('failed')
+        ->and($t->transaction_id)->toBe('OLD-TID')
+        ->and($t->message_type)->toBe('13')
+        ->and($t->merchant_response)->toBe('old failure')
+        ->and($t->response_code)->toBe('13')
+        ->and($t->fingerprint)->toBe('old-fingerprint');
+});
+
 it('updates merchant_session on transaction so callback can find it', function (): void {
     $t = Transaction::factory()->create([
         'status' => 'failed',

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -75,6 +75,77 @@ it('handles POST callback and redirects to GET with ref', function (): void {
         ->and($t->fingerprint)->toBe($payload->fingerprint);
 });
 
+it('accepts successful callbacks when the signed response omits transaction code', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-NO-TRANSACTION-CODE',
+        'merchant_session' => 'MS-NO-TRANSACTION-CODE',
+        'amount' => 1500,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $payload = callback_controller_payload($transaction);
+    unset($payload['transactionCode']);
+
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-NO-TRANSACTION-CODE']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('completed')
+        ->and($transaction->message_type)->toBe('8')
+        ->and($transaction->merchant_response)->not->toBe('callback_details_mismatch');
+});
+
+it('accepts successful callbacks when optional unsigned response fields are omitted', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-OPTIONAL-UNSIGNED-FIELDS',
+        'merchant_session' => 'MS-OPTIONAL-UNSIGNED-FIELDS',
+        'amount' => 10,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $payload = callback_controller_payload($transaction);
+    unset($payload['currency'], $payload['transactionCode'], $payload['posID']);
+
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-OPTIONAL-UNSIGNED-FIELDS']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('completed')
+        ->and($transaction->message_type)->toBe('8')
+        ->and($transaction->transaction_id)->not->toBeNull()
+        ->and($transaction->merchant_response)->not->toBe('callback_details_mismatch');
+});
+
+it('rejects callbacks when optional unsigned response fields are present but empty', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-EMPTY-UNSIGNED-FIELDS',
+        'merchant_session' => 'MS-EMPTY-UNSIGNED-FIELDS',
+        'amount' => 10,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $payload = callback_controller_payload($transaction);
+    $payload['currency'] = '';
+    $payload['transactionCode'] = '';
+    $payload['posID'] = '';
+
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-EMPTY-UNSIGNED-FIELDS']));
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('callback_details_mismatch');
+});
+
 it('records callbacks with invalid fingerprints as failed and redirects to response page', function (): void {
     $transaction = Transaction::factory()->create([
         'merchant_ref' => 'MR-G3',

--- a/tests/Models/InvoiceTest.php
+++ b/tests/Models/InvoiceTest.php
@@ -41,6 +41,41 @@ it('computes pdf_url from public disk and respects table config', function (): v
         ->and($invoice->pdf_url)->not->toBeNull();
 });
 
+it('uses configured pdf url generator when present', function (): void {
+    config()->set('sisp.invoice.pdf_url_generator', fn (Invoice $invoice): string => "https://billing.test/invoices/{$invoice->id}/download");
+
+    $t = Transaction::factory()->create();
+    $invoice = Invoice::query()->create([
+        'transaction_id' => $t->id,
+        'invoice_number' => 'INV-2B',
+        'invoice_date' => now(),
+        'status' => 'pending',
+        'pdf_path' => 'invoices/test.pdf',
+    ]);
+
+    expect($invoice->pdf_url)->toBe("https://billing.test/invoices/{$invoice->id}/download");
+});
+
+it('falls back when configured pdf url generator cannot be resolved', function (): void {
+    Storage::fake('public');
+    config()->set('sisp.invoice.disk', 'public');
+    config()->set('sisp.invoice.pdf_url_generator', 'Missing\\InvoicePdfUrlGenerator');
+
+    Storage::disk('public')->put('invoices/test.pdf', 'PDF');
+
+    $t = Transaction::factory()->create();
+    $invoice = Invoice::query()->create([
+        'transaction_id' => $t->id,
+        'invoice_number' => 'INV-2C',
+        'invoice_date' => now(),
+        'status' => 'pending',
+        'pdf_path' => 'invoices/test.pdf',
+    ]);
+
+    expect($invoice->pdf_url)->not->toBeNull()
+        ->and($invoice->toArray())->toHaveKey('pdf_url');
+});
+
 it('items relation proxies transaction items', function (): void {
     $t = Transaction::factory()->create();
     // Criar um item

--- a/tests/ValueObjects/CallbackPayloadTest.php
+++ b/tests/ValueObjects/CallbackPayloadTest.php
@@ -60,3 +60,25 @@ it('withoutFingerprint removes fingerprint key from array', function (): void {
         ->and($arr['merchantRespMerchantRef'])->toBe('R2')
         ->and($arr['merchantRespTid'])->toBe('T2');
 });
+
+it('tracks whether optional unsigned fields were provided', function (): void {
+    $missing = CallbackPayload::from([
+        'merchantRespMerchantRef' => 'R3',
+        'merchantRespMerchantSession' => 'S3',
+    ]);
+
+    $empty = CallbackPayload::from([
+        'merchantRespMerchantRef' => 'R4',
+        'merchantRespMerchantSession' => 'S4',
+        'currency' => '',
+        'transactionCode' => '',
+        'posID' => '',
+    ]);
+
+    expect($missing->currencyProvided)->toBeFalse()
+        ->and($missing->transactionCodeProvided)->toBeFalse()
+        ->and($missing->posIDProvided)->toBeFalse()
+        ->and($empty->currencyProvided)->toBeTrue()
+        ->and($empty->transactionCodeProvided)->toBeTrue()
+        ->and($empty->posIDProvided)->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Accept successful signed callbacks when SISP omits optional unsigned fields such as currency, transactionCode, or posID.
- Preserve graceful redirects for unknown callback transaction keys instead of surfacing 404s.
- Allow signed retry links to open via GET while keeping retry guarded to failed transactions.
- Store sanitized callback request metadata for diagnostics.
- Add configurable invoice PDF URL generation for host apps that need signed application download routes.

