### PR TITLE
feat!: rewrite package architecture for Laravel 13 and PHP 8.5 (v2)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ 1.x ]
+    branches: [ 1.x, 2.x ]
   pull_request:
-    branches: [ 1.x ]
+    branches: [ 1.x, 2.x ]
 
 jobs:
   test:
@@ -13,12 +13,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.4, 8.5 ]
-        laravel: [ 12.*, 13.* ]
+        php: [ 8.5 ]
+        laravel: [ 13.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: 12.*
-            testbench: ^10.0
           - laravel: 13.*
             testbench: ^11.0
 
@@ -45,5 +43,8 @@ jobs:
           composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-progress --no-interaction
 
-      - name: Run tests (Pest)
+      - name: Run static analysis and quality gates (Pest)
         run: composer test
+
+      - name: Run test suite (Pest)
+        run: vendor/bin/pest --compact

--- a/README.md
+++ b/README.md
@@ -67,6 +67,68 @@ $transaction = Sisp::reconcileTransactionStatus($transaction);
 $countries = Sisp::countries();
 ```
 
+## Requirements (v2)
+
+- PHP 8.5+
+- Laravel 13+
+
+## Architecture (v2)
+
+Version 2 is built on four explicit patterns. Each one is an extension point.
+
+### Builders
+
+Compose payment and refund requests fluently instead of assembling value objects by hand:
+
+```php
+use Akira\Sisp\Facades\Sisp;
+
+$paymentRequest = Sisp::payment()
+    ->amount(1500.0)
+    ->currency('132')
+    ->customerEmail('buyer@example.cv')
+    ->locale('pt')
+    ->build();
+
+$transaction = Sisp::refund($transaction)
+    ->amount(500.0)
+    ->reason('partial_return')
+    ->process();
+```
+
+### Drivers
+
+Gateway interactions go through a driver resolved by `SispManager`. The `production` driver targets the live Vinti4 gateway and the `sandbox` driver targets the local simulator. Selection follows `config('sisp.driver')`, falling back to the resolved credentials' sandbox flag. Register custom gateways with `SispManager::extend()`:
+
+```php
+use Akira\Sisp\Drivers\SispManager;
+
+resolve(SispManager::class)->extend('custom', fn () => new CustomDriver());
+```
+
+### Pipelines
+
+The payment and callback flows run through Laravel pipelines. Every stage is a small, single-purpose pipe, and the stages are configurable in `config/sisp.php` under `pipelines.payment` and `pipelines.callback`, so you can reorder, remove, or append your own pipes:
+
+```php
+'pipelines' => [
+    'payment' => [
+        EnsureIpIsNotBlacklisted::class,
+        EnforceRateLimits::class,
+        BuildPaymentRequest::class,
+        PersistTransaction::class,
+        CaptureRequestMetadata::class,
+        YourCustomPipe::class, // implements Akira\Sisp\Contracts\PaymentPipe
+    ],
+],
+```
+
+### Actions
+
+Every unit of work remains a dedicated, final, constructor-injected action class with a single `handle()` method. Pipes and builders delegate to actions, and actions depend on contracts, never on concrete infrastructure.
+
+The package also uses native Laravel 13 syntax throughout: `#[Fillable]`, `#[UseFactory]`, and `#[Scope]` attributes on Eloquent models, `#[Signature]` and `#[Description]` on console commands, and `#[Bind]`/`#[Singleton]` container attributes on contracts and services.
+
 ## Documentation
 
 - [Roadmap](docs/00-roadmap.md)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ The package also uses native Laravel 13 syntax throughout: `#[Fillable]`, `#[Use
 - [Troubleshooting](docs/09-troubleshooting.md)
 - [FAQ](docs/10-faq.md)
 - [API Reference](docs/11-api-reference.md)
+- [Architecture (v2)](docs/12-architecture.md)
+- [Upgrade Guide (v2)](docs/13-upgrade-v2.md)
 
 Reference documentation is maintained in this repository under [`docs`](docs).
 

--- a/composer.json
+++ b/composer.json
@@ -16,20 +16,21 @@
     }
   ],
   "require": {
-    "php": "^8.4 || ^8.5",
+    "php": "^8.5",
     "akira/laravel-pdf-invoices": "^1.8",
-    "illuminate/contracts": "^12.0 || ^13.0",
+    "illuminate/contracts": "^13.0",
     "pinkary-project/type-guard": "^0.1.0",
     "spatie/laravel-package-tools": "^1.16",
     "stevebauman/location": "^7.6"
   },
   "require-dev": {
+    "driftingly/rector-laravel": "^2.3",
     "inertiajs/inertia-laravel": "^3.1",
-    "larastan/larastan": "^3.0",
+    "larastan/larastan": "^3.10",
     "laravel/pint": "^1.29",
     "nunomaduro/collision": "^8.1.1",
-    "orchestra/testbench": "^10.0.0 || ^11.0.0",
-    "peckphp/peck": "^0.1.3",
+    "orchestra/testbench": "^11.0.0",
+    "peckphp/peck": "^0.3.0",
     "pestphp/pest": "^4.0",
     "pestphp/pest-plugin-arch": "^4.0",
     "pestphp/pest-plugin-laravel": "^4.0",
@@ -37,8 +38,7 @@
     "phpstan/extension-installer": "^1.3",
     "phpstan/phpstan-deprecation-rules": "^2.0.0",
     "phpstan/phpstan-phpunit": "^2.0.0",
-    "rector/rector": "^2.4",
-    "driftingly/rector-laravel": "^2.3"
+    "rector/rector": "^2.4"
   },
   "autoload": {
     "psr-4": {

--- a/config/sisp.php
+++ b/config/sisp.php
@@ -17,6 +17,50 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | SISP Driver
+    |--------------------------------------------------------------------------
+    |
+    | The gateway driver used to talk to SISP. When null, the driver is
+    | derived from the resolved credentials: 'sandbox' when sandbox mode is
+    | enabled, 'production' otherwise. Custom drivers can be registered via
+    | SispManager::extend().
+    |
+    | Supported: null, 'production', 'sandbox'
+    |
+    */
+    'driver' => env('SISP_DRIVER'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Processing Pipelines
+    |--------------------------------------------------------------------------
+    |
+    | The payment and callback flows are processed through pipelines. Each
+    | pipe is a small, single-purpose class. You can reorder, remove, or add
+    | your own pipes here. Payment pipes implement
+    | Akira\Sisp\Contracts\PaymentPipe and callback pipes implement
+    | Akira\Sisp\Contracts\CallbackPipe.
+    |
+    */
+    'pipelines' => [
+        'payment' => [
+            Akira\Sisp\Pipelines\Payment\Pipes\EnsureIpIsNotBlacklisted::class,
+            Akira\Sisp\Pipelines\Payment\Pipes\EnforceRateLimits::class,
+            Akira\Sisp\Pipelines\Payment\Pipes\BuildPaymentRequest::class,
+            Akira\Sisp\Pipelines\Payment\Pipes\PersistTransaction::class,
+            Akira\Sisp\Pipelines\Payment\Pipes\CaptureRequestMetadata::class,
+        ],
+        'callback' => [
+            Akira\Sisp\Pipelines\Callback\Pipes\ResolveTransaction::class,
+            Akira\Sisp\Pipelines\Callback\Pipes\ValidateFingerprint::class,
+            Akira\Sisp\Pipelines\Callback\Pipes\EnsureCallbackMatchesTransaction::class,
+            Akira\Sisp\Pipelines\Callback\Pipes\ApplyTransactionStatus::class,
+            Akira\Sisp\Pipelines\Callback\Pipes\DispatchPaymentEvents::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Generators Configuration
     |--------------------------------------------------------------------------
     |

--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -3,6 +3,14 @@
 This roadmap outlines future enhancements and improvements for Laravel SISP based on the current architecture and
 extension points.
 
+## Delivered in v2
+
+- Laravel 13 and PHP 8.5 baseline, with native framework attributes throughout (`#[Fillable]`, `#[UseFactory]`, `#[Scope]`, `#[Signature]`, `#[Description]`, `#[Bind]`, `#[Singleton]`)
+- Driver pattern: `SispManager` with `production` and `sandbox` drivers behind the `SispDriver` contract, extensible via `SispManager::extend()`
+- Builder pattern: fluent `Sisp::payment()` and `Sisp::refund()` builders
+- Pipeline pattern: configurable payment and callback pipelines with single-purpose pipes (custom action hooks at key lifecycle points)
+- Contract-driven internals (`CallbackFingerprintValidator`, `SispCredentialsResolver`, `SispDriver`) for replaceable service implementations
+
 ## Transaction Features
 
 **Enhanced Transaction Management**

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -2,8 +2,8 @@
 
 ## Requirements
 
-- PHP 8.4 or higher
-- Laravel 12 or higher
+- PHP 8.5 or higher
+- Laravel 13 or higher
 - Composer
 - Database (PostgreSQL or MySQL)
 

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -77,6 +77,51 @@ SISP_SANDBOX=true              # true for testing, false for production
 
 When enabled, uses the fake gateway instead of real SISP server for testing.
 
+### Gateway Driver (v2)
+
+```env
+SISP_DRIVER=                   # null (auto), production, sandbox, or a custom driver
+```
+
+Gateway interactions are routed through a driver resolved by `Akira\Sisp\Drivers\SispManager`. When `SISP_DRIVER` is empty, the driver is derived from the resolved credentials: `sandbox` when sandbox mode is enabled, `production` otherwise. Setting it explicitly overrides the sandbox flag.
+
+Custom drivers implement `Akira\Sisp\Contracts\SispDriver` and are registered in a service provider:
+
+```php
+use Akira\Sisp\Drivers\SispManager;
+
+resolve(SispManager::class)->extend('custom', fn () => new CustomDriver());
+```
+
+```env
+SISP_DRIVER=custom
+```
+
+### Processing Pipelines (v2)
+
+The payment and callback flows run through Laravel pipelines. Each stage is a single-purpose pipe class, configured in `config/sisp.php`:
+
+```php
+'pipelines' => [
+    'payment' => [
+        Akira\Sisp\Pipelines\Payment\Pipes\EnsureIpIsNotBlacklisted::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\EnforceRateLimits::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\BuildPaymentRequest::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\PersistTransaction::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\CaptureRequestMetadata::class,
+    ],
+    'callback' => [
+        Akira\Sisp\Pipelines\Callback\Pipes\ResolveTransaction::class,
+        Akira\Sisp\Pipelines\Callback\Pipes\ValidateFingerprint::class,
+        Akira\Sisp\Pipelines\Callback\Pipes\EnsureCallbackMatchesTransaction::class,
+        Akira\Sisp\Pipelines\Callback\Pipes\ApplyTransactionStatus::class,
+        Akira\Sisp\Pipelines\Callback\Pipes\DispatchPaymentEvents::class,
+    ],
+],
+```
+
+You can reorder, remove, or append pipes. Payment pipes implement `Akira\Sisp\Contracts\PaymentPipe`; callback pipes implement `Akira\Sisp\Contracts\CallbackPipe`. See [Payment Flow](./04-payment-flow.md) for the responsibilities of each pipe.
+
 ## Invoice Configuration
 
 ### Company Information

--- a/docs/03-quick-start.md
+++ b/docs/03-quick-start.md
@@ -67,12 +67,27 @@ If `SISP_IS_3D_SEC=1`, these fields become required:
 
 1. User submits form to `/sisp/payment`
 2. Package validates data
-3. Creates transaction in database
+3. The payment pipeline runs: blacklist check → rate limits → request building → transaction persistence → metadata capture (see [Payment Flow](./04-payment-flow.md))
 4. Renders SISP payment form
-5. User redirected to SISP gateway
+5. User redirected to SISP gateway (resolved by the active driver: production or sandbox)
 6. After payment, redirected to `/sisp/callback`
-7. Package validates and stores response
-8. Transaction status updated (approved/failed)
+7. The callback pipeline validates the fingerprint and the transaction details
+8. Transaction status updated (approved/failed) and events dispatched
+
+## Programmatic Payments (Builder)
+
+Instead of the HTTP form, you can build a payment request in code with the fluent builder:
+
+```php
+use Akira\Sisp\Facades\Sisp;
+
+$paymentRequest = Sisp::payment()
+    ->amount(1500.0)
+    ->currency('132')
+    ->customerEmail('buyer@example.cv')
+    ->locale('pt')
+    ->build(); // returns a signed PaymentRequest value object
+```
 
 ## Test in Sandbox
 

--- a/docs/04-payment-flow.md
+++ b/docs/04-payment-flow.md
@@ -48,6 +48,32 @@ Response View
     └─ Show Result
 ```
 
+## Pipelines (v2)
+
+Since v2, both halves of the flow are implemented as Laravel pipelines made of single-purpose pipes. The defaults live in `config/sisp.php` under `pipelines` and can be reordered or extended (see [Configuration](./02-configuration.md#processing-pipelines-v2)).
+
+**Payment pipeline** (`ProcessPaymentPipeline`, runs inside `PaymentController`):
+
+| Pipe | Responsibility |
+| --- | --- |
+| `EnsureIpIsNotBlacklisted` | Rejects blacklisted IPs |
+| `EnforceRateLimits` | Applies per-IP rate limits |
+| `BuildPaymentRequest` | Builds the signed `PaymentRequest` (fingerprint, 3DS payload) |
+| `PersistTransaction` | Stores the transaction, items, customer data, and pending invoice |
+| `CaptureRequestMetadata` | Records IP, device, and geolocation metadata |
+
+**Callback pipeline** (`HandleCallbackPipeline`, runs inside `HandleCallbackAction`):
+
+| Pipe | Responsibility |
+| --- | --- |
+| `ResolveTransaction` | Finds the transaction by merchant reference and session |
+| `ValidateFingerprint` | Verifies the SHA512 callback fingerprint; fails the transaction and short-circuits on mismatch |
+| `EnsureCallbackMatchesTransaction` | Reconciles amount, currency, transaction code, and POS ID |
+| `ApplyTransactionStatus` | Maps the SISP message type to a transaction status |
+| `DispatchPaymentEvents` | Dispatches `PaymentCompleted` / `PaymentFailed` / `PaymentPending` |
+
+The form action URL is resolved by the active gateway driver (`production` or `sandbox`) through `SispManager` — see [Configuration](./02-configuration.md#gateway-driver-v2).
+
 ## Step 1: Payment Form Submission
 
 User submits payment form with:

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -207,6 +207,12 @@ $updatedTransaction = Sisp::reconcileTransactionStatus($transaction);
 
 `queryTransactionStatus()` returns `TransactionStatusResponse` and never writes to the database. `reconcileTransactionStatus()` returns a `Transaction` and only updates pending transactions when the SISP status API returns `result=true`.
 
+Since v2 the status query is routed through the active gateway driver. You can also call it on a specific driver directly:
+
+```php
+$response = Sisp::driver('production')->queryTransactionStatus($transaction);
+```
+
 For multi-merchant flows, scope the call with explicit credentials:
 
 ```php
@@ -242,23 +248,40 @@ The command reconciles only old indeterminate transactions:
 
 ## Refund Transaction
 
-Refund a completed transaction:
+Refund a completed transaction with the fluent builder (v2):
 
 ```php
-use Akira\Sisp\Actions\RefundTransactionAction;
-
-$action = app(RefundTransactionAction::class);
+use Akira\Sisp\Facades\Sisp;
 
 try {
-    $transaction = $action->handle(
-        transaction: $transaction,
-        refundAmount: 500.00,
-        reason: 'customer_request' // Optional reason
-    );
+    // Full refund
+    $transaction = Sisp::refund($transaction)
+        ->full()
+        ->reason('customer_request')
+        ->process();
+
+    // Partial refund
+    $transaction = Sisp::refund($transaction)
+        ->amount(500.00)
+        ->reason('partial_return')
+        ->process();
+
     echo "Refunded " . $transaction->formatted_amount;
 } catch (LogicException $e) {
     echo "Cannot refund: " . $e->getMessage();
 }
+```
+
+The underlying action remains available when you prefer direct invocation:
+
+```php
+use Akira\Sisp\Actions\RefundTransactionAction;
+
+$transaction = app(RefundTransactionAction::class)->handle(
+    transaction: $transaction,
+    refundAmount: 500.00,
+    reason: 'customer_request'
+);
 ```
 
 ### Refund Rules

--- a/docs/07-security.md
+++ b/docs/07-security.md
@@ -2,6 +2,8 @@
 
 Built-in security features to protect your payment system.
 
+Since v2, the blacklist and rate-limit checks run as the first pipes of the payment pipeline (`EnsureIpIsNotBlacklisted` and `EnforceRateLimits`). You can reorder or remove them — or insert your own security pipes — through `config('sisp.pipelines.payment')`. See [Configuration](./02-configuration.md#processing-pipelines-v2).
+
 ## Rate Limiting
 
 Prevent abuse by limiting payment requests per IP, merchant, or user.

--- a/docs/08-examples.md
+++ b/docs/08-examples.md
@@ -255,16 +255,28 @@ Include multiple products in a single payment.
 
 Create and process payments programmatically without a form.
 
+Build a signed payment request with the fluent builder:
+
 ```php
-use Akira\Sisp\Actions\CreateAndStorePaymentTransactionAction;
-use Akira\Sisp\Actions\PreparePaymentAction;
+use Akira\Sisp\Facades\Sisp;
+
+$paymentRequest = Sisp::payment()
+    ->amount(100.00)
+    ->currency('132')
+    ->customerEmail('customer@example.com')
+    ->locale('pt')
+    ->build(); // signed PaymentRequest value object
+```
+
+Or run the full payment pipeline (blacklist, rate limits, request building, persistence, metadata) exactly as the HTTP flow does:
+
+```php
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Akira\Sisp\Pipelines\Payment\ProcessPaymentPipeline;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Illuminate\Http\Request;
 
-$action = app(CreateAndStorePaymentTransactionAction::class);
-
-// Create a fake request object with payment data
-$request = new Request([
+$request = Request::create('/sisp/payment', 'POST', [
     'amount' => 100.00,
     'items' => [
         [
@@ -272,18 +284,20 @@ $request = new Request([
             'quantity' => 1,
             'unit_price' => 100.00,
             'total_price' => 100.00,
-        ]
+        ],
     ],
     'customer_email' => 'customer@example.com',
     'customer_name' => 'John Doe',
-    'locale' => 'pt', // Optional: customer language preference
+    'locale' => 'pt',
 ]);
 
-// Create transaction
-$transaction = $action->handle(
-    PaymentRequestData::from($request->all()),
-    $request
-);
+$context = app(ProcessPaymentPipeline::class)->run(new PaymentContext(
+    data: PaymentRequestData::from($request->all()),
+    request: $request,
+));
+
+$transaction = $context->transaction();
+$paymentRequest = $context->paymentRequest();
 
 echo "Transaction created: " . $transaction->id;
 ```
@@ -478,20 +492,17 @@ try {
 Refund a completed transaction.
 
 ```php
-use Akira\Sisp\Actions\RefundTransactionAction;
+use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 
 $transaction = Transaction::find($id);
 $refundAmount = $transaction->amount;
 
-$action = app(RefundTransactionAction::class);
-
 try {
-    $action->handle(
-        transaction: $transaction,
-        refundAmount: $refundAmount,
-        reason: 'customer_request'
-    );
+    Sisp::refund($transaction)
+        ->full()
+        ->reason('customer_request')
+        ->process();
 
     return response()->json([
         'success' => true,
@@ -718,6 +729,88 @@ it('processes payments for different merchants', function () {
     expect($requestA->toArray()['posID'])->toBe('TEST_A')
         ->and($requestB->toArray()['posID'])->toBe('TEST_B');
 });
+```
+
+## Custom Payment Pipe (v2)
+
+Add your own stage to the payment pipeline.
+
+```php
+namespace App\Sisp\Pipes;
+
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+final readonly class LogPaymentAttempt implements PaymentPipe
+{
+    public function handle(PaymentContext $context, Closure $next): PaymentContext
+    {
+        Log::info('SISP payment attempt', [
+            'amount' => $context->data->amount,
+            'ip' => $context->request->ip(),
+        ]);
+
+        return $next($context);
+    }
+}
+```
+
+Register it in `config/sisp.php`:
+
+```php
+'pipelines' => [
+    'payment' => [
+        Akira\Sisp\Pipelines\Payment\Pipes\EnsureIpIsNotBlacklisted::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\EnforceRateLimits::class,
+        App\Sisp\Pipes\LogPaymentAttempt::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\BuildPaymentRequest::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\PersistTransaction::class,
+        Akira\Sisp\Pipelines\Payment\Pipes\CaptureRequestMetadata::class,
+    ],
+],
+```
+
+## Custom Gateway Driver (v2)
+
+Register an additional gateway driver and select it by config.
+
+```php
+namespace App\Sisp;
+
+use Akira\Sisp\Contracts\SispDriver;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+
+final readonly class StagingDriver implements SispDriver
+{
+    public function name(): string
+    {
+        return 'staging';
+    }
+
+    public function paymentEndpoint(): string
+    {
+        return 'https://staging.gateway.example.com/pay';
+    }
+
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse
+    {
+        // Delegate to your staging status API...
+    }
+}
+```
+
+```php
+// In a service provider:
+use Akira\Sisp\Drivers\SispManager;
+
+resolve(SispManager::class)->extend('staging', fn () => new \App\Sisp\StagingDriver());
+```
+
+```env
+SISP_DRIVER=staging
 ```
 
 ## Next Steps

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -128,7 +128,7 @@ you must provide:
 
 ### Can I refund a payment?
 
-Yes. Refund completed transactions using `RefundTransactionAction`. Current SISP specifications support total reversal and partial refund. The package validates that the requested amount does not exceed the refundable balance it knows locally.
+Yes. Refund completed transactions with the fluent builder — `Sisp::refund($transaction)->full()->process()` or `->amount(500.0)->process()` — or invoke `RefundTransactionAction` directly. Current SISP specifications support total reversal and partial refund. The package validates that the requested amount does not exceed the refundable balance it knows locally.
 
 ### Can I cancel a pending payment?
 
@@ -152,6 +152,24 @@ Event::listen(PaymentCompleted::class, function ($event) {
 ### Can I add custom data to transactions?
 
 Yes, transactions include metadata support. You can store custom data in the `payload` field.
+
+## Customization (v2)
+
+### Can I add my own steps to the payment flow?
+
+Yes. The payment and callback flows are Laravel pipelines. Implement `Akira\Sisp\Contracts\PaymentPipe` (or `CallbackPipe`) and register your class in `config('sisp.pipelines.payment')` or `config('sisp.pipelines.callback')`. Pipes run in the configured order.
+
+### Can I point the package at a different gateway?
+
+Yes. Implement `Akira\Sisp\Contracts\SispDriver` and register it with `SispManager::extend('name', fn () => new YourDriver())`, then set `SISP_DRIVER=name`. The built-in drivers are `production` and `sandbox`.
+
+### Can I replace the fingerprint validation?
+
+Yes. Bind your own implementation of `Akira\Sisp\Contracts\CallbackFingerprintValidator` in the container; the callback pipeline resolves the contract, not the concrete class.
+
+### Can I build payment requests without the HTTP form?
+
+Yes. Use the fluent builder: `Sisp::payment()->amount(100.0)->customerEmail('a@b.cv')->build()` returns a signed `PaymentRequest` value object.
 
 ## Invoices
 
@@ -393,11 +411,11 @@ Yes, when you have valid SISP credentials. Always test in sandbox mode first.
 
 ### What Laravel versions are supported?
 
-Laravel 12+
+Laravel 13+ (v2). Use the 1.x release line for Laravel 12.
 
 ### What PHP versions are supported?
 
-PHP 8.4+
+PHP 8.5+ (v2). Use the 1.x release line for PHP 8.4.
 
 ## Still Have Questions?
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -500,6 +500,112 @@ $updatedTransaction = $sisp->reconcileTransactionStatus($transaction);
 
 Use `sisp:transaction-status` and `sisp:reconcile-pending` for operational workflows. Use the facade methods inside application code for explicit transaction checks.
 
+## Builders (v2)
+
+### PaymentBuilder
+
+Fluent composition of payment requests. Obtain it from the facade:
+
+```php
+use Akira\Sisp\Facades\Sisp;
+
+$builder = Sisp::payment();
+```
+
+| Method | Description |
+| --- | --- |
+| `amount(float $amount)` | Required. Total amount in CVE |
+| `merchantRef(string $ref)` | Optional. Defaults to the configured generator |
+| `merchantSession(string $session)` | Optional. Defaults to the configured generator |
+| `timeStamp(string $timeStamp)` | Optional. SISP format `Y-m-d H:i:s` |
+| `currency(string $currency)` | Optional. ISO 4217 numeric, defaults to config |
+| `transactionCode(TransactionCode\|string $code)` | Optional. Accepts the enum or raw code |
+| `token()` / `entityCode()` / `referenceNumber()` | Optional service-payment fields |
+| `locale(string $locale)` | Optional customer language |
+| `customerEmail()` / `customerCountry()` / `customerCity()` / `customerAddress()` / `customerPostalCode()` / `customerPhone()` | Optional 3DS customer data |
+| `toData(): PaymentRequestData` | Returns the value object; throws `LogicException` without a positive amount |
+| `build(): PaymentRequest` | Builds the signed request (fingerprint included) |
+
+### RefundBuilder
+
+```php
+$transaction = Sisp::refund($transaction)
+    ->amount(500.0)          // or ->full()
+    ->reason('user_refund')  // optional, defaults to user_refund
+    ->process();             // returns the updated Transaction
+```
+
+`process()` throws `LogicException` when no amount was set, when the transaction is not refundable, or when the amount exceeds the refundable balance.
+
+## Drivers (v2)
+
+### SispDriver Contract
+
+```php
+interface SispDriver
+{
+    public function name(): string;
+    public function paymentEndpoint(): string;
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse;
+}
+```
+
+### SispManager
+
+Extends `Illuminate\Support\Manager`. Built-in drivers: `production` (gateway URL from the resolved credentials) and `sandbox` (local fake gateway route). The default driver follows `config('sisp.driver')`, falling back to the credentials' sandbox flag.
+
+```php
+use Akira\Sisp\Drivers\SispManager;
+use Akira\Sisp\Facades\Sisp;
+
+Sisp::driver();                 // active driver
+Sisp::driver('sandbox');        // specific driver
+resolve(SispManager::class)->extend('custom', fn () => new CustomDriver());
+resolve(Akira\Sisp\Contracts\SispDriver::class); // container contract, resolves the active driver
+```
+
+## Pipelines (v2)
+
+### ProcessPaymentPipeline
+
+```php
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Akira\Sisp\Pipelines\Payment\ProcessPaymentPipeline;
+
+$context = app(ProcessPaymentPipeline::class)->run(new PaymentContext($data, $request));
+
+$context->paymentRequest(); // PaymentRequest (throws LogicException before BuildPaymentRequest ran)
+$context->transaction();    // Transaction (throws LogicException before PersistTransaction ran)
+```
+
+Default pipes (configurable via `sisp.pipelines.payment`): `EnsureIpIsNotBlacklisted`, `EnforceRateLimits`, `BuildPaymentRequest`, `PersistTransaction`, `CaptureRequestMetadata`. Custom pipes implement `Akira\Sisp\Contracts\PaymentPipe`.
+
+### HandleCallbackPipeline
+
+```php
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Akira\Sisp\Pipelines\Callback\HandleCallbackPipeline;
+
+$context = app(HandleCallbackPipeline::class)->run(new CallbackContext($payload));
+
+$context->transaction();   // resolved Transaction
+$context->failed();        // bool
+$context->failureReason;   // 'invalid_callback_fingerprint' | 'callback_details_mismatch' | null
+```
+
+Default pipes (configurable via `sisp.pipelines.callback`): `ResolveTransaction`, `ValidateFingerprint`, `EnsureCallbackMatchesTransaction`, `ApplyTransactionStatus`, `DispatchPaymentEvents`. Custom pipes implement `Akira\Sisp\Contracts\CallbackPipe`. Failing pipes mark the transaction `failed`, dispatch `PaymentFailed`, and short-circuit the pipeline.
+
+## Contracts (v2)
+
+| Contract | Default binding | Purpose |
+| --- | --- | --- |
+| `SispCredentialsResolver` | `EnvSispCredentialsResolver` (singleton) | Resolves the active merchant credentials |
+| `SispDriver` | Active driver via `SispManager` | Gateway interactions |
+| `CallbackFingerprintValidator` | `ValidatePaymentResponseFingerprintAction` | Callback fingerprint verification |
+| `PaymentPipe` / `CallbackPipe` | — | Pipeline stage contracts |
+
+Bindings are declared with Laravel 13 container attributes (`#[Bind]` on the contracts, `#[Singleton]` on services), so swapping an implementation is a standard container binding in your application.
+
 ## Actions
 
 Common actions for payment processing.
@@ -890,6 +996,10 @@ use Akira\Sisp\ValueObjects\CallbackPayload;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\TransactionData;
 
+Sisp::payment();                                       // PaymentBuilder (v2)
+Sisp::refund($transaction);                            // RefundBuilder (v2)
+Sisp::driver();                                        // SispDriver (v2)
+
 Sisp::getTransactions();                               // Builder
 Sisp::buildRequestPayload(PaymentRequestData::from([])); // PaymentRequest
 Sisp::validateCallback(CallbackPayload::from([]));     // bool
@@ -1120,4 +1230,4 @@ config('sisp.tables.transaction_logs')
 - Review [Examples](./08-examples.md) for code samples
 - Check [Troubleshooting](./09-troubleshooting.md) for solutions
 
-**Previous:** [FAQ](10-faq.md)
+**Previous:** [FAQ](10-faq.md) | **Next:** [Architecture](12-architecture.md)

--- a/docs/12-architecture.md
+++ b/docs/12-architecture.md
@@ -1,0 +1,79 @@
+# Architecture (v2)
+
+Version 2 restructures the package around four explicit, composable patterns. The public API of v1 (`Sisp` facade, `ScopedSisp`, routes, events, models) is preserved; the internals are now organized for extension.
+
+## Requirements
+
+- PHP 8.5+
+- Laravel 13+
+
+## Overview
+
+```
+HTTP / Facade
+    |
+    v
+Builders ──────────► Value Objects (PaymentRequestData, PaymentRequest, ...)
+    |
+    v
+Pipelines (payment / callback)
+    |        each pipe delegates to an
+    v
+Actions (single-purpose, final, constructor-injected)
+    |        gateway interactions go through the
+    v
+Drivers (production / sandbox / custom) ── SispManager
+```
+
+## Builder Pattern
+
+`Akira\Sisp\Builders` provides fluent composition of requests:
+
+- `PaymentBuilder` — `Sisp::payment()->amount(...)->customerEmail(...)->build()`
+- `RefundBuilder` — `Sisp::refund($transaction)->full()->process()`
+
+Builders validate their inputs (`LogicException` on missing amount) and delegate to the same actions used by the HTTP flow, so behavior is identical regardless of entry point.
+
+## Driver Pattern
+
+`Akira\Sisp\Drivers\SispManager` extends `Illuminate\Support\Manager` and resolves the gateway driver behind the `Akira\Sisp\Contracts\SispDriver` contract:
+
+- `ProductionDriver` — payment endpoint from the resolved credentials' URL; transaction-status queries through the SISP POS API (`TransactionStatusClient`)
+- `SandboxDriver` — payment endpoint at the local fake gateway route (`sisp.sandbox`)
+
+Selection order: `config('sisp.driver')` → credentials' `sandbox` flag. Custom gateways register with `SispManager::extend()` and are selected with `SISP_DRIVER`. Multi-merchant flows keep working: drivers resolve credentials lazily through `SispCredentialsResolver`, so `Sisp::forCredentials()` scoping applies to driver calls too.
+
+## Pipeline Pattern
+
+Both processing flows are `Illuminate\Pipeline\Pipeline` runs over a mutable context object. Stages are small, final pipe classes, configured in `config('sisp.pipelines')`:
+
+- **Payment** — `ProcessPaymentPipeline` over `PaymentContext` (`EnsureIpIsNotBlacklisted` → `EnforceRateLimits` → `BuildPaymentRequest` → `PersistTransaction` → `CaptureRequestMetadata`)
+- **Callback** — `HandleCallbackPipeline` over `CallbackContext` (`ResolveTransaction` → `ValidateFingerprint` → `EnsureCallbackMatchesTransaction` → `ApplyTransactionStatus` → `DispatchPaymentEvents`)
+
+Failure semantics: callback pipes that detect tampering or mismatches mark the transaction `failed`, dispatch `PaymentFailed`, record the reason on the context (`failureReason`), and short-circuit the remaining pipes — exactly the behavior of v1, now in isolated, replaceable units.
+
+## Actions Pattern
+
+Every unit of work remains a dedicated, `final readonly`, constructor-injected class with a single `handle()` method under `Akira\Sisp\Actions`. Pipes and builders delegate to actions; actions never reach back into controllers or pipelines.
+
+## SOLID Boundaries
+
+- **Single responsibility** — one pipe/action per concern; gateway HTTP isolated in `TransactionStatusClient`
+- **Open/closed** — pipelines and the driver manager extend through configuration, not modification
+- **Liskov** — drivers are interchangeable behind `SispDriver`
+- **Interface segregation** — narrow contracts (`PaymentPipe`, `CallbackPipe`, `CallbackFingerprintValidator`, `SispCredentialsResolver`)
+- **Dependency inversion** — pipes depend on contracts; tests and applications swap implementations through the container
+
+## Laravel 13 Native Syntax
+
+The package uses framework attributes throughout:
+
+| Where | Attributes |
+| --- | --- |
+| Eloquent models | `#[Fillable]`, `#[UseFactory]`, `#[Scope]`, `casts()` method |
+| Console commands | `#[Signature]`, `#[Description]` |
+| Contracts/services | `#[Bind]`, `#[Singleton]` container attributes |
+
+The service provider's `register()` is reduced to the single driver-contract closure; everything else is declared where it lives. Note: `#[Bind]` requires the container's environment resolver, which full applications register during bootstrap — the provider mirrors it for lighter harnesses such as Testbench.
+
+**Previous:** [API Reference](11-api-reference.md) | **Next:** [Upgrade Guide](13-upgrade-v2.md)

--- a/docs/13-upgrade-v2.md
+++ b/docs/13-upgrade-v2.md
@@ -1,0 +1,76 @@
+# Upgrading to v2
+
+v2 targets Laravel 13 and PHP 8.5 and reorganizes the internals around builders, drivers, and pipelines. The public surface is backward compatible for typical integrations.
+
+## Requirements
+
+| | v1 | v2 |
+| --- | --- | --- |
+| PHP | 8.4+ | **8.5+** |
+| Laravel | 12+ | **13+** |
+| Testbench (dev) | 10/11 | **11** |
+
+```bash
+composer require akira/laravel-sisp:^2.0
+```
+
+## What stays the same
+
+- All routes, controllers, form fields, and views
+- The `Sisp` facade methods and `ScopedSisp` multi-merchant API
+- Models, value objects, enums, events, exceptions, and database schema
+- Actions keep their names and `handle()` signatures
+- Configuration keys from v1 (new keys were only added)
+
+## What changed
+
+### New configuration keys
+
+```php
+// config/sisp.php
+'driver' => env('SISP_DRIVER'),     // null (auto), production, sandbox, custom
+'pipelines' => [
+    'payment' => [/* pipe class-strings */],
+    'callback' => [/* pipe class-strings */],
+],
+```
+
+Re-publish the config file or merge these keys manually:
+
+```bash
+php artisan vendor:publish --tag=sisp-config --force
+```
+
+### Behavior notes
+
+- `DeterminePaymentEndpointAction` and `QueryTransactionStatusAction` now delegate to the active driver via `SispManager`. Behavior is unchanged for the built-in `production`/`sandbox` modes.
+- `HandleCallbackAction` keeps its `handle(CallbackPayload): Transaction` signature but runs the callback pipeline internally.
+- `PaymentController` runs the payment pipeline; the same checks run in the same order as v1.
+- Retrying a payment (`POST /sisp/retry-payment`) resets the transaction to `pending` with a rotated merchant session (formalized v1 behavior).
+- Refunds require the original callback to have stored `transaction_id` and `response_code` (clearing period), as SISP mandates.
+
+### If you extended internals
+
+- Code that mocked `Sisp::validateCallback()` to influence callback handling should now bind a custom `Akira\Sisp\Contracts\CallbackFingerprintValidator` instead.
+- Container bindings are declared with `#[Bind]`/`#[Singleton]` attributes. Overriding still works the standard way: register your own binding in a service provider (explicit bindings take precedence over attributes).
+- If you run the package under a custom test harness and the contracts fail to resolve, ensure an environment resolver is registered (`$app->resolveEnvironmentUsing(...)`); full Laravel applications and this package's provider already do this.
+
+## New capabilities you can adopt
+
+```php
+// Fluent payment composition
+$request = Sisp::payment()->amount(1500.0)->customerEmail('a@b.cv')->build();
+
+// Fluent refunds
+Sisp::refund($transaction)->full()->reason('customer_request')->process();
+
+// Custom gateway drivers
+resolve(SispManager::class)->extend('custom', fn () => new CustomDriver());
+
+// Custom pipeline stages
+config(['sisp.pipelines.payment' => [...default pipes..., App\Sisp\Pipes\MyPipe::class]]);
+```
+
+See [Architecture](12-architecture.md) for the full design.
+
+**Previous:** [Architecture](12-architecture.md)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,30 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Access to an undefined property Akira\\Sisp\\Models\\RateLimit\:\:\$reset_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/CheckRateLimitAction.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$product_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/GenerateInvoicePdfAction.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$quantity\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/GenerateInvoicePdfAction.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$unit_price_cents\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Actions/GenerateInvoicePdfAction.php
-
-		-
 			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$created_at\.$#'
 			identifier: property.notFound
 			count: 2
@@ -126,14 +102,3 @@ parameters:
 			count: 1
 			path: src/Models/RateLimit.php
 
-		-
-			message: '#^Access to an undefined property Akira\\Sisp\\Models\\TransactionItem\:\:\$total_price_cents\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Models/TransactionItem.php
-
-		-
-			message: '#^Access to an undefined property Akira\\Sisp\\Models\\TransactionItem\:\:\$unit_price_cents\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Models/TransactionItem.php

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector;
 use RectorLaravel\Set\LaravelSetList;
 
 return RectorConfig::configure()
@@ -33,6 +34,7 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
+        AddOverrideAttributeToOverriddenPropertiesRector::class,
     ])
     ->withPreparedSets(
         deadCode: true,

--- a/src/Actions/DeterminePaymentEndpointAction.php
+++ b/src/Actions/DeterminePaymentEndpointAction.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
-use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Drivers\SispManager;
 
 final readonly class DeterminePaymentEndpointAction
 {
-    public function __construct(private SispCredentialsResolver $resolver) {}
+    public function __construct(private SispManager $manager) {}
 
     public function handle(): string
     {
-        $credentials = $this->resolver->resolve();
-
-        if ($credentials->sandbox) {
-            return route('sisp.sandbox');
-        }
-
-        return $credentials->url;
+        return $this->manager->driver()->paymentEndpoint();
     }
 }

--- a/src/Actions/GenerateInvoicePdfAction.php
+++ b/src/Actions/GenerateInvoicePdfAction.php
@@ -10,7 +10,7 @@ use Akira\PdfInvoices\Builder\ItemBuilder;
 use Akira\PdfInvoices\Contracts\PdfGeneratorContract;
 use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Models\Invoice;
-use Illuminate\Database\Eloquent\Model;
+use Akira\Sisp\Models\TransactionItem;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -55,13 +55,13 @@ final readonly class GenerateInvoicePdfAction
             $invoiceBuilder->dueAt($invoice->due_date);
         }
 
-        foreach ($transaction->items->groupBy(fn (Model $item): string => $item->getAttribute('product_name')."\0".$item->getAttribute('unit_price_cents')) as $items) {
+        foreach ($transaction->items->groupBy(fn (TransactionItem $item): string => $item->product_name."\0".$item->unit_price_cents) as $items) {
             $firstItem = $items->first();
 
             $itemData = ItemBuilder::make()
                 ->description($firstItem->product_name)
                 ->unitPrice($firstItem->unit_price_cents / 100)
-                ->quantity($items->sum(fn (Model $item): int => $item->quantity))
+                ->quantity($items->sum(fn (TransactionItem $item): int => $item->quantity))
                 ->build();
 
             $invoiceBuilder->addItem($itemData);

--- a/src/Actions/GenerateInvoicePdfAction.php
+++ b/src/Actions/GenerateInvoicePdfAction.php
@@ -35,9 +35,9 @@ final readonly class GenerateInvoicePdfAction
             ->build();
 
         $buyer = EntityBuilder::make()
-            ->name($invoice->customer_name ?? $transaction->customer_name)
-            ->email($invoice->customer_email ?? $transaction->customer_email)
-            ->address($invoice->customer_address ?? $transaction->customer_address)
+            ->name($invoice->customer_name ?? $transaction->customer_name ?? '')
+            ->email($invoice->customer_email ?? $transaction->customer_email ?? '')
+            ->address($invoice->customer_address ?? $transaction->customer_address ?? '')
             ->set('country', $invoice->customer_country ?? $transaction->customer_country)
             ->set('phone', $transaction->customer_phone)
             ->set('city', $invoice->customer_city ?? $transaction->customer_city)

--- a/src/Actions/HandleCallbackAction.php
+++ b/src/Actions/HandleCallbackAction.php
@@ -4,115 +4,19 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
-use Akira\Sisp\Actions\Transaction\FindOrCreateTransactionAction;
-use Akira\Sisp\Actions\Transaction\UpdateTransactionAction;
-use Akira\Sisp\Configuration\LoadConfig;
-use Akira\Sisp\Contracts\SispCredentialsResolver;
-use Akira\Sisp\Enums\TransactionStatus;
-use Akira\Sisp\Events\PaymentCompleted;
-use Akira\Sisp\Events\PaymentFailed;
-use Akira\Sisp\Events\PaymentPending;
-use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
-use Akira\Sisp\Support\SispAmount;
-use Akira\Sisp\Support\TransactionLogContext;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Akira\Sisp\Pipelines\Callback\HandleCallbackPipeline;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 
 final readonly class HandleCallbackAction
 {
-    public function __construct(
-        private FindOrCreateTransactionAction $findOrCreateTransaction,
-        private UpdateTransactionAction $updateTransaction,
-        private SispCredentialsResolver $credentialsResolver,
-        private LoadConfig $config,
-    ) {}
+    public function __construct(private HandleCallbackPipeline $pipeline) {}
 
     public function handle(CallbackPayload $payload): Transaction
     {
+        $context = $this->pipeline->run(new CallbackContext($payload));
 
-        $transaction = $this->findOrCreateTransaction->handle($payload);
-
-        if (! Sisp::validateCallback($payload)) {
-            $this->failTransaction($transaction, $payload, 'invalid_callback_fingerprint');
-
-            event(new PaymentFailed($transaction, $payload));
-
-            return $transaction;
-        }
-
-        if (! $this->matchesTransaction($transaction, $payload)) {
-            $this->failTransaction($transaction, $payload, 'callback_details_mismatch');
-
-            event(new PaymentFailed($transaction, $payload));
-
-            return $transaction;
-        }
-
-        $this->updateTransaction->handle($transaction, $payload);
-
-        $this->dispatchEvent($transaction, $payload);
-
-        return $transaction;
-    }
-
-    private function dispatchEvent(Transaction $transaction, CallbackPayload $payload): void
-    {
-        match ($transaction->status) {
-            TransactionStatus::completed => event(new PaymentCompleted($transaction, $payload)),
-            TransactionStatus::failed => event(new PaymentFailed($transaction, $payload)),
-            TransactionStatus::pending => event(new PaymentPending($transaction, $payload)),
-            default => null, // @codeCoverageIgnore
-        };
-    }
-
-    private function matchesTransaction(Transaction $transaction, CallbackPayload $payload): bool
-    {
-        return $this->transactionString($transaction, 'merchant_ref') === $payload->merchantRef
-            && $this->transactionString($transaction, 'merchant_session') === $payload->merchantSession
-            && $this->amountMatches($this->transactionAmount($transaction), $payload->amount)
-            && (! $payload->currencyProvided || $this->transactionString($transaction, 'currency') === $payload->currency)
-            && (! $payload->transactionCodeProvided || $this->transactionCode($transaction) === $payload->transactionCode)
-            && (! $payload->posIDProvided || $this->credentialsResolver->resolve()->posId === $payload->posID);
-    }
-
-    private function amountMatches(float|int|string $expected, float|int|string $actual): bool
-    {
-        return SispAmount::toThousandths($expected) === SispAmount::toThousandths($actual);
-    }
-
-    private function failTransaction(Transaction $transaction, CallbackPayload $payload, string $merchantResponse): void
-    {
-        TransactionLogContext::run(
-            'callback',
-            fn (): bool => $transaction->update([
-                'transaction_id' => $payload->transactionID,
-                'message_type' => $payload->messageType,
-                'merchant_response' => $merchantResponse,
-                'response_code' => $payload->merchantRespCp,
-                'fingerprint' => $payload->fingerprint,
-                'status' => TransactionStatus::failed,
-            ])
-        );
-    }
-
-    private function transactionAmount(Transaction $transaction): float|int|string
-    {
-        $amount = $transaction->getAttribute('amount');
-
-        return is_float($amount) || is_int($amount) || is_string($amount) ? $amount : 0;
-    }
-
-    private function transactionString(Transaction $transaction, string $attribute): string
-    {
-        $value = $transaction->getAttribute($attribute);
-
-        return is_string($value) ? $value : '';
-    }
-
-    private function transactionCode(Transaction $transaction): string
-    {
-        $transactionCode = $this->transactionString($transaction, 'transaction_code');
-
-        return $transactionCode === '' ? $this->config->getDefaultTransactionCode() : $transactionCode;
+        return $context->transaction();
     }
 }

--- a/src/Actions/QueryTransactionStatusAction.php
+++ b/src/Actions/QueryTransactionStatusAction.php
@@ -4,52 +4,16 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
-use Akira\Sisp\Configuration\LoadConfig;
-use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Drivers\SispManager;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ValueObjects\TransactionStatusResponse;
-use Illuminate\Support\Facades\Http;
-use LogicException;
 
 final readonly class QueryTransactionStatusAction
 {
-    public function __construct(
-        private LoadConfig $config,
-        private SispCredentialsResolver $credentialsResolver,
-    ) {}
+    public function __construct(private SispManager $manager) {}
 
     public function handle(Transaction|string $transaction): TransactionStatusResponse
     {
-        $merchantRef = $transaction instanceof Transaction
-            ? (string) $transaction->getAttribute('merchant_ref')
-            : $transaction;
-
-        $portalId = $this->config->getTransactionStatusPortalId();
-        $portalPassword = $this->config->getTransactionStatusPortalPassword();
-
-        throw_if($portalId === '' || $portalPassword === '', LogicException::class, 'SISP transaction status portal credentials are not configured.');
-
-        $credentials = $this->credentialsResolver->resolve();
-
-        $response = Http::acceptJson()
-            ->asJson()
-            ->timeout($this->config->getTransactionStatusTimeoutSeconds())
-            ->withBasicAuth($portalId, $portalPassword)
-            ->post($this->config->getTransactionStatusUrl(), [
-                'posID' => $credentials->posId,
-                'posAuthCode' => $credentials->posAutCode,
-                'merchantRef' => $merchantRef,
-            ]);
-
-        if (! $response->successful()) {
-            return TransactionStatusResponse::from([
-                'result' => false,
-                'transactionSuccess' => false,
-                'transactionStatusDescription' => '',
-                'msg' => "SISP transaction status request failed with HTTP {$response->status()}.",
-            ]);
-        }
-
-        return TransactionStatusResponse::from($response->json() ?? []);
+        return $this->manager->driver()->queryTransactionStatus($transaction);
     }
 }

--- a/src/Actions/RenderPaymentFormAction.php
+++ b/src/Actions/RenderPaymentFormAction.php
@@ -21,10 +21,7 @@ final readonly class RenderPaymentFormAction
 
         $formAction = $this->buildFormAction($fields);
 
-        /** @var view-string $viewName */
-        $viewName = 'sisp::payment-form';
-
-        return view($viewName, [
+        return view('sisp::payment-form', [
             'formAction' => $formAction,
             'fields' => $fields,
         ]);

--- a/src/Actions/Transaction/FailTransactionAction.php
+++ b/src/Actions/Transaction/FailTransactionAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Actions\Transaction;
+
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
+use Akira\Sisp\ValueObjects\CallbackPayload;
+
+final readonly class FailTransactionAction
+{
+    public function handle(Transaction $transaction, CallbackPayload $payload, string $merchantResponse): void
+    {
+        TransactionLogContext::run(
+            'callback',
+            fn (): bool => $transaction->update([
+                'transaction_id' => $payload->transactionID,
+                'message_type' => $payload->messageType,
+                'merchant_response' => $merchantResponse,
+                'response_code' => $payload->merchantRespCp,
+                'fingerprint' => $payload->fingerprint,
+                'status' => TransactionStatus::failed,
+            ])
+        );
+    }
+}

--- a/src/Actions/UpdateInvoiceStatusAction.php
+++ b/src/Actions/UpdateInvoiceStatusAction.php
@@ -8,6 +8,8 @@ use Akira\Sisp\Enums\InvoiceStatus;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 final readonly class UpdateInvoiceStatusAction
 {
@@ -33,7 +35,25 @@ final readonly class UpdateInvoiceStatusAction
         $invoice->update(['status' => $invoiceStatus->value]);
 
         if ($status === TransactionStatus::completed && ! $invoice->pdf_path) {
+            $this->generatePdfQuietly($invoice, $transaction);
+        }
+    }
+
+    /**
+     * PDF generation must never fail the payment flow: the transaction is
+     * already completed at this point and missing PDF files can be recovered
+     * later with the regenerate command.
+     */
+    private function generatePdfQuietly(Invoice $invoice, Transaction $transaction): void
+    {
+        try {
             $this->generateInvoicePdf->handle($invoice);
+        } catch (Throwable $exception) {
+            Log::error('SISP invoice PDF generation failed.', [
+                'invoice_id' => $invoice->getKey(),
+                'transaction_id' => $transaction->getKey(),
+                'message' => $exception->getMessage(),
+            ]);
         }
     }
 }

--- a/src/Actions/ValidatePaymentResponseFingerprintAction.php
+++ b/src/Actions/ValidatePaymentResponseFingerprintAction.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions;
 
 use Akira\Sisp\Actions\FingerPrint\PaymentResponseFingerPrintAction;
+use Akira\Sisp\Contracts\CallbackFingerprintValidator;
 use Akira\Sisp\ValueObjects\CallbackPayload;
 
-final readonly class ValidatePaymentResponseFingerprintAction
+final readonly class ValidatePaymentResponseFingerprintAction implements CallbackFingerprintValidator
 {
     public function __construct(private PaymentResponseFingerPrintAction $fingerPrint) {}
 

--- a/src/Builders/PaymentBuilder.php
+++ b/src/Builders/PaymentBuilder.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Builders;
+
+use Akira\Sisp\Actions\PreparePaymentAction;
+use Akira\Sisp\Enums\TransactionCode;
+use Akira\Sisp\ValueObjects\PaymentRequest;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+use LogicException;
+
+final class PaymentBuilder
+{
+    private ?float $amount = null;
+
+    private ?string $merchantRef = null;
+
+    private ?string $merchantSession = null;
+
+    private ?string $timeStamp = null;
+
+    private ?string $currency = null;
+
+    private ?string $transactionCode = null;
+
+    private ?string $token = null;
+
+    private ?string $entityCode = null;
+
+    private ?string $referenceNumber = null;
+
+    private ?string $locale = null;
+
+    private ?string $customerEmail = null;
+
+    private ?string $customerCountry = null;
+
+    private ?string $customerCity = null;
+
+    private ?string $customerAddress = null;
+
+    private ?string $customerPostalCode = null;
+
+    private ?string $customerPhone = null;
+
+    public function __construct(private readonly PreparePaymentAction $preparePayment) {}
+
+    public function amount(float $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function merchantRef(string $merchantRef): self
+    {
+        $this->merchantRef = $merchantRef;
+
+        return $this;
+    }
+
+    public function merchantSession(string $merchantSession): self
+    {
+        $this->merchantSession = $merchantSession;
+
+        return $this;
+    }
+
+    public function timeStamp(string $timeStamp): self
+    {
+        $this->timeStamp = $timeStamp;
+
+        return $this;
+    }
+
+    public function currency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function transactionCode(TransactionCode|string $transactionCode): self
+    {
+        $this->transactionCode = $transactionCode instanceof TransactionCode
+            ? $transactionCode->value
+            : $transactionCode;
+
+        return $this;
+    }
+
+    public function token(string $token): self
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    public function entityCode(string $entityCode): self
+    {
+        $this->entityCode = $entityCode;
+
+        return $this;
+    }
+
+    public function referenceNumber(string $referenceNumber): self
+    {
+        $this->referenceNumber = $referenceNumber;
+
+        return $this;
+    }
+
+    public function locale(string $locale): self
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    public function customerEmail(string $email): self
+    {
+        $this->customerEmail = $email;
+
+        return $this;
+    }
+
+    public function customerCountry(string $country): self
+    {
+        $this->customerCountry = $country;
+
+        return $this;
+    }
+
+    public function customerCity(string $city): self
+    {
+        $this->customerCity = $city;
+
+        return $this;
+    }
+
+    public function customerAddress(string $address): self
+    {
+        $this->customerAddress = $address;
+
+        return $this;
+    }
+
+    public function customerPostalCode(string $postalCode): self
+    {
+        $this->customerPostalCode = $postalCode;
+
+        return $this;
+    }
+
+    public function customerPhone(string $phone): self
+    {
+        $this->customerPhone = $phone;
+
+        return $this;
+    }
+
+    public function toData(): PaymentRequestData
+    {
+        throw_if($this->amount === null || $this->amount <= 0, LogicException::class, 'A payment amount greater than zero is required.');
+
+        return new PaymentRequestData(
+            amount: $this->amount,
+            merchantRef: $this->merchantRef,
+            merchantSession: $this->merchantSession,
+            timeStamp: $this->timeStamp,
+            currency: $this->currency,
+            transactionCode: $this->transactionCode,
+            token: $this->token,
+            entityCode: $this->entityCode,
+            referenceNumber: $this->referenceNumber,
+            locale: $this->locale,
+            customerEmail: $this->customerEmail,
+            customerCountry: $this->customerCountry,
+            customerCity: $this->customerCity,
+            customerAddress: $this->customerAddress,
+            customerPostalCode: $this->customerPostalCode,
+            customerPhone: $this->customerPhone,
+        );
+    }
+
+    public function build(): PaymentRequest
+    {
+        return $this->preparePayment->handle($this->toData());
+    }
+}

--- a/src/Builders/RefundBuilder.php
+++ b/src/Builders/RefundBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Builders;
+
+use Akira\Sisp\Actions\RefundTransactionAction;
+use Akira\Sisp\Models\Transaction;
+use LogicException;
+
+final class RefundBuilder
+{
+    private ?float $amount = null;
+
+    private string $reason = 'user_refund';
+
+    public function __construct(
+        private readonly RefundTransactionAction $refundTransaction,
+        private readonly Transaction $transaction,
+    ) {}
+
+    public function amount(float $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function full(): self
+    {
+        $this->amount = (float) $this->transaction->amount;
+
+        return $this;
+    }
+
+    public function reason(string $reason): self
+    {
+        $this->reason = $reason;
+
+        return $this;
+    }
+
+    public function process(): Transaction
+    {
+        throw_if($this->amount === null, LogicException::class, 'A refund amount is required. Call amount() or full() first.');
+
+        return $this->refundTransaction->handle($this->transaction, $this->amount, $this->reason);
+    }
+}

--- a/src/Commands/DoctorCommand.php
+++ b/src/Commands/DoctorCommand.php
@@ -6,16 +6,16 @@ namespace Akira\Sisp\Commands;
 
 use Akira\Sisp\Enums\InvoiceStatus;
 use Akira\Sisp\Models\Invoice;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 use Throwable;
 
+#[Signature('sisp:doctor')]
+#[Description('Diagnose issues with invoice PDF generation')]
 final class DoctorCommand extends Command
 {
-    protected $signature = 'sisp:doctor';
-
-    protected $description = 'Diagnose issues with invoice PDF generation';
-
     public function handle(): int
     {
         $this->info('Diagnosing Invoice PDF Issues...');

--- a/src/Commands/LaravelSispInstallCommand.php
+++ b/src/Commands/LaravelSispInstallCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Commands;
 
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Throwable;
 
@@ -12,12 +14,10 @@ use function Laravel\Prompts\info;
 use function Laravel\Prompts\note;
 use function Laravel\Prompts\spin;
 
+#[Signature('sisp:install')]
+#[Description('Install and configure the Laravel SISP package.')]
 final class LaravelSispInstallCommand extends Command
 {
-    protected $signature = 'sisp:install';
-
-    protected $description = 'Install and configure the Laravel SISP package.';
-
     /**
      * Execute the console command.
      */

--- a/src/Commands/ReconcilePendingTransactionsCommand.php
+++ b/src/Commands/ReconcilePendingTransactionsCommand.php
@@ -7,18 +7,18 @@ namespace Akira\Sisp\Commands;
 use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository;
 
-final class ReconcilePendingTransactionsCommand extends Command
-{
-    protected $signature = 'sisp:reconcile-pending
+#[Signature('sisp:reconcile-pending
                             {--older-than= : Minimum pending age in minutes}
                             {--limit= : Maximum transactions to reconcile}
-                            {--force : Run even when reconciliation is disabled in config}';
-
-    protected $description = 'Reconcile old pending SISP transactions using the POS transaction-status API';
-
+                            {--force : Run even when reconciliation is disabled in config}')]
+#[Description('Reconcile old pending SISP transactions using the POS transaction-status API')]
+final class ReconcilePendingTransactionsCommand extends Command
+{
     public function handle(Repository $config, ReconcileTransactionStatusAction $reconcile): int
     {
         if (! (bool) $config->get('sisp.transaction_status.reconciliation_enabled', false) && ! $this->option('force')) {
@@ -30,13 +30,15 @@ final class ReconcilePendingTransactionsCommand extends Command
         $olderThan = (int) ($this->option('older-than') ?: $config->get('sisp.transaction_status.reconcile_after_minutes', 5));
         $limit = (int) ($this->option('limit') ?: $config->get('sisp.transaction_status.reconcile_limit', 50));
 
-        $transactions = Transaction::query()
+        $query = Transaction::query()
             ->where('status', TransactionStatus::pending->value)
-            ->whereNull('message_type')
+            ->where('message_type')
             ->where('created_at', '<=', now()->subMinutes($olderThan))
-            ->oldest()
-            ->limit($limit)
-            ->get();
+            ->oldest();
+
+        $query->limit($limit);
+
+        $transactions = $query->get();
 
         if ($transactions->isEmpty()) {
             $this->info('No pending SISP transactions require reconciliation.');

--- a/src/Commands/RegenerateMissingInvoicePdfsCommand.php
+++ b/src/Commands/RegenerateMissingInvoicePdfsCommand.php
@@ -7,16 +7,16 @@ namespace Akira\Sisp\Commands;
 use Akira\Sisp\Actions\GenerateInvoicePdfAction;
 use Akira\Sisp\Enums\InvoiceStatus;
 use Akira\Sisp\Models\Invoice;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Throwable;
 
+#[Signature('sisp:regenerate-pdfs
+                            {--limit= : Limit the number of invoices to process}')]
+#[Description('Regenerate PDFs for paid invoices that are missing PDF files')]
 final class RegenerateMissingInvoicePdfsCommand extends Command
 {
-    protected $signature = 'sisp:regenerate-pdfs
-                            {--limit= : Limit the number of invoices to process}';
-
-    protected $description = 'Regenerate PDFs for paid invoices that are missing PDF files';
-
     public function handle(GenerateInvoicePdfAction $generatePdf): int
     {
         $this->info('🔍 Searching for paid invoices without PDFs...');
@@ -24,7 +24,7 @@ final class RegenerateMissingInvoicePdfsCommand extends Command
         $query = Invoice::query()
             ->with(['transaction.items'])
             ->where('status', InvoiceStatus::paid->value)
-            ->whereNull('pdf_path');
+            ->where('pdf_path');
 
         if ($limit = $this->option('limit')) {
             $query->limit((int) $limit);

--- a/src/Commands/TransactionStatusCommand.php
+++ b/src/Commands/TransactionStatusCommand.php
@@ -7,17 +7,17 @@ namespace Akira\Sisp\Commands;
 use Akira\Sisp\Actions\QueryTransactionStatusAction;
 use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 
-final class TransactionStatusCommand extends Command
-{
-    protected $signature = 'sisp:transaction-status
+#[Signature('sisp:transaction-status
                             {merchantRef? : Merchant reference to query}
                             {--transaction= : Local transaction ID to query}
-                            {--update : Update the local transaction status from the SISP response}';
-
-    protected $description = 'Query the SISP POS transaction-status API for a merchant reference';
-
+                            {--update : Update the local transaction status from the SISP response}')]
+#[Description('Query the SISP POS transaction-status API for a merchant reference')]
+final class TransactionStatusCommand extends Command
+{
     public function handle(QueryTransactionStatusAction $queryTransactionStatus, ReconcileTransactionStatusAction $reconcile): int
     {
         $transaction = $this->resolveTransaction();

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Configuration;
 
+use Akira\Sisp\Pipelines\Callback\HandleCallbackPipeline;
+use Akira\Sisp\Pipelines\Payment\ProcessPaymentPipeline;
+use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Contracts\Config\Repository;
 
+#[Singleton]
 final readonly class LoadConfig
 {
     public function __construct(
@@ -45,6 +49,22 @@ final readonly class LoadConfig
     public function isSandboxEnabled(): bool
     {
         return $this->config->get('sisp.sandbox', false);
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    public function getPaymentPipes(): array
+    {
+        return $this->config->get('sisp.pipelines.payment', ProcessPaymentPipeline::DEFAULT_PIPES);
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    public function getCallbackPipes(): array
+    {
+        return $this->config->get('sisp.pipelines.callback', HandleCallbackPipeline::DEFAULT_PIPES);
     }
 
     public function getMerchantReference(): string

--- a/src/Contracts/CallbackFingerprintValidator.php
+++ b/src/Contracts/CallbackFingerprintValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Contracts;
+
+use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
+use Akira\Sisp\ValueObjects\CallbackPayload;
+use Illuminate\Container\Attributes\Bind;
+
+#[Bind(ValidatePaymentResponseFingerprintAction::class)]
+interface CallbackFingerprintValidator
+{
+    public function handle(CallbackPayload $payload): bool;
+}

--- a/src/Contracts/CallbackPipe.php
+++ b/src/Contracts/CallbackPipe.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Contracts;
+
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Closure;
+
+interface CallbackPipe
+{
+    /**
+     * @param  Closure(CallbackContext): CallbackContext  $next
+     */
+    public function handle(CallbackContext $context, Closure $next): CallbackContext;
+}

--- a/src/Contracts/PaymentPipe.php
+++ b/src/Contracts/PaymentPipe.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Contracts;
+
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+
+interface PaymentPipe
+{
+    /**
+     * @param  Closure(PaymentContext): PaymentContext  $next
+     */
+    public function handle(PaymentContext $context, Closure $next): PaymentContext;
+}

--- a/src/Contracts/SispCredentialsResolver.php
+++ b/src/Contracts/SispCredentialsResolver.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Contracts;
 
+use Akira\Sisp\Configuration\EnvSispCredentialsResolver;
 use Akira\Sisp\ValueObjects\SispCredentials;
+use Illuminate\Container\Attributes\Bind;
+use Illuminate\Container\Attributes\Singleton;
 
+#[Bind(EnvSispCredentialsResolver::class)]
+#[Singleton]
 interface SispCredentialsResolver
 {
     public function resolve(): SispCredentials;

--- a/src/Contracts/SispDriver.php
+++ b/src/Contracts/SispDriver.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Contracts;
+
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+
+interface SispDriver
+{
+    public function name(): string;
+
+    public function paymentEndpoint(): string;
+
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse;
+}

--- a/src/Drivers/ProductionDriver.php
+++ b/src/Drivers/ProductionDriver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Drivers;
+
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Contracts\SispDriver;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+
+final readonly class ProductionDriver implements SispDriver
+{
+    public function __construct(
+        private SispCredentialsResolver $credentialsResolver,
+        private TransactionStatusClient $statusClient,
+    ) {}
+
+    public function name(): string
+    {
+        return 'production';
+    }
+
+    public function paymentEndpoint(): string
+    {
+        return $this->credentialsResolver->resolve()->url;
+    }
+
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse
+    {
+        return $this->statusClient->query($transaction);
+    }
+}

--- a/src/Drivers/SandboxDriver.php
+++ b/src/Drivers/SandboxDriver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Drivers;
+
+use Akira\Sisp\Contracts\SispDriver;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+
+final readonly class SandboxDriver implements SispDriver
+{
+    public function __construct(
+        private TransactionStatusClient $statusClient,
+    ) {}
+
+    public function name(): string
+    {
+        return 'sandbox';
+    }
+
+    public function paymentEndpoint(): string
+    {
+        return route('sisp.sandbox');
+    }
+
+    public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse
+    {
+        return $this->statusClient->query($transaction);
+    }
+}

--- a/src/Drivers/SispManager.php
+++ b/src/Drivers/SispManager.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Drivers;
+
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Contracts\SispDriver;
+use Illuminate\Container\Attributes\Singleton;
+use Illuminate\Support\Manager;
+
+#[Singleton]
+final class SispManager extends Manager
+{
+    public function getDefaultDriver(): string
+    {
+        $configured = $this->config->get('sisp.driver');
+
+        if (is_string($configured) && $configured !== '') {
+            return $configured;
+        }
+
+        return $this->container->make(SispCredentialsResolver::class)->resolve()->sandbox
+            ? 'sandbox'
+            : 'production';
+    }
+
+    protected function createProductionDriver(): SispDriver
+    {
+        return $this->container->make(ProductionDriver::class);
+    }
+
+    protected function createSandboxDriver(): SispDriver
+    {
+        return $this->container->make(SandboxDriver::class);
+    }
+}

--- a/src/Drivers/TransactionStatusClient.php
+++ b/src/Drivers/TransactionStatusClient.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Drivers;
+
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+use Illuminate\Support\Facades\Http;
+use LogicException;
+
+final readonly class TransactionStatusClient
+{
+    public function __construct(
+        private LoadConfig $config,
+        private SispCredentialsResolver $credentialsResolver,
+    ) {}
+
+    public function query(Transaction|string $transaction): TransactionStatusResponse
+    {
+        $merchantRef = $transaction instanceof Transaction
+            ? (string) $transaction->getAttribute('merchant_ref')
+            : $transaction;
+
+        $portalId = $this->config->getTransactionStatusPortalId();
+        $portalPassword = $this->config->getTransactionStatusPortalPassword();
+
+        throw_if($portalId === '' || $portalPassword === '', LogicException::class, 'SISP transaction status portal credentials are not configured.');
+
+        $credentials = $this->credentialsResolver->resolve();
+
+        $response = Http::acceptJson()
+            ->asJson()
+            ->timeout($this->config->getTransactionStatusTimeoutSeconds())
+            ->withBasicAuth($portalId, $portalPassword)
+            ->post($this->config->getTransactionStatusUrl(), [
+                'posID' => $credentials->posId,
+                'posAuthCode' => $credentials->posAutCode,
+                'merchantRef' => $merchantRef,
+            ]);
+
+        if (! $response->successful()) {
+            return TransactionStatusResponse::from([
+                'result' => false,
+                'transactionSuccess' => false,
+                'transactionStatusDescription' => '',
+                'msg' => "SISP transaction status request failed with HTTP {$response->status()}.",
+            ]);
+        }
+
+        return TransactionStatusResponse::from($response->json() ?? []);
+    }
+}

--- a/src/Facades/Sisp.php
+++ b/src/Facades/Sisp.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Facades;
 
+use Akira\Sisp\Builders\PaymentBuilder;
+use Akira\Sisp\Builders\RefundBuilder;
+use Akira\Sisp\Contracts\SispDriver;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\ScopedSisp;
 use Akira\Sisp\ValueObjects\CallbackPayload;
@@ -17,6 +20,9 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static ScopedSisp forCredentials(SispCredentials $credentials)
+ * @method static PaymentBuilder payment()
+ * @method static RefundBuilder refund(Transaction $transaction)
+ * @method static SispDriver driver(string|null $driver = null)
  * @method static Builder getTransactions()
  * @method static PaymentRequest buildRequestPayload(PaymentRequestData $data)
  * @method static bool validateCallback(CallbackPayload $payload)

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -4,25 +4,18 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Http\Controllers;
 
-use Akira\Sisp\Actions\CheckBlacklistAction;
-use Akira\Sisp\Actions\CheckRateLimitAction;
-use Akira\Sisp\Actions\CreateAndStorePaymentTransactionAction;
-use Akira\Sisp\Actions\PreparePaymentAction;
 use Akira\Sisp\Actions\RenderPaymentFormBasedOnConfigAction;
-use Akira\Sisp\Actions\StoreRequestMetadataAction;
 use Akira\Sisp\Http\Requests\StorePaymentRequest;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Akira\Sisp\Pipelines\Payment\ProcessPaymentPipeline;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Throwable;
 
 final readonly class PaymentController
 {
     public function __construct(
-        private PreparePaymentAction $preparePayment,
-        private CreateAndStorePaymentTransactionAction $createTransaction,
+        private ProcessPaymentPipeline $pipeline,
         private RenderPaymentFormBasedOnConfigAction $renderForm,
-        private CheckRateLimitAction $checkRateLimit,
-        private CheckBlacklistAction $checkBlacklist,
-        private StoreRequestMetadataAction $storeMetadata,
     ) {}
 
     /**
@@ -30,22 +23,11 @@ final readonly class PaymentController
      */
     public function __invoke(StorePaymentRequest $request): mixed
     {
-        $ip = $request->ip();
+        $context = $this->pipeline->run(new PaymentContext(
+            data: PaymentRequestData::from($request->validated()),
+            request: $request,
+        ));
 
-        $this->checkBlacklist->handle('ip', $ip);
-
-        $this->checkRateLimit->handle(
-            identifier: $ip,
-        );
-
-        $requestData = PaymentRequestData::from($request->validated());
-
-        $paymentRequest = $this->preparePayment->handle($requestData);
-
-        $transaction = $this->createTransaction->handle($paymentRequest, $request);
-
-        $this->storeMetadata->handle($request, $transaction);
-
-        return $this->renderForm->handle($paymentRequest, $transaction->locale);
+        return $this->renderForm->handle($context->paymentRequest(), $context->transaction()->locale);
     }
 }

--- a/src/Models/Blacklist.php
+++ b/src/Models/Blacklist.php
@@ -4,27 +4,23 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+#[Fillable([
+    'type',
+    'value',
+    'reason',
+    'severity',
+    'notes',
+    'added_by',
+    'expires_at',
+])]
 final class Blacklist extends Model
 {
     use \Illuminate\Database\Eloquent\Factories\HasFactory;
-
-    protected $fillable = [
-        'type',
-        'value',
-        'reason',
-        'severity',
-        'notes',
-        'added_by',
-        'expires_at',
-    ];
-
-    protected $casts = [
-        'expires_at' => 'datetime',
-    ];
 
     public function getTable(): string
     {
@@ -45,6 +41,13 @@ final class Blacklist extends Model
         return ! $this->isActive();
     }
 
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+        ];
+    }
+
     #[Scope]
     protected function active(Builder $query): Builder
     {
@@ -57,8 +60,7 @@ final class Blacklist extends Model
     #[Scope]
     protected function expired(Builder $query): Builder
     {
-        return $query->whereNotNull('expires_at')
-            ->where('expires_at', '<=', now());
+        return $query->where('expires_at', '<=', now());
     }
 
     #[Scope]

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -8,6 +8,7 @@ use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Enums\InvoiceStatus;
 use Carbon\CarbonInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -30,32 +31,24 @@ use Illuminate\Support\Facades\Storage;
  * @property-read  string $customer_name
  * @property-read  CarbonInterface $updated_at
  */
+#[Fillable([
+    'transaction_id',
+    'invoice_number',
+    'invoice_date',
+    'due_date',
+    'status',
+    'customer_name',
+    'customer_email',
+    'customer_city',
+    'customer_address',
+    'customer_country',
+    'notes',
+    'pdf_path',
+    'metadata',
+])]
 final class Invoice extends Model
 {
     use \Illuminate\Database\Eloquent\Factories\HasFactory;
-
-    protected $fillable = [
-        'transaction_id',
-        'invoice_number',
-        'invoice_date',
-        'due_date',
-        'status',
-        'customer_name',
-        'customer_email',
-        'customer_city',
-        'customer_address',
-        'customer_country',
-        'notes',
-        'pdf_path',
-        'metadata',
-    ];
-
-    protected $casts = [
-        'invoice_date' => 'date',
-        'due_date' => 'date',
-        'status' => InvoiceStatus::class,
-        'metadata' => 'array',
-    ];
 
     protected $appends = [
         'pdf_url',
@@ -76,6 +69,16 @@ final class Invoice extends Model
         return $this->transaction->items();
     }
 
+    protected function casts(): array
+    {
+        return [
+            'invoice_date' => 'date',
+            'due_date' => 'date',
+            'status' => InvoiceStatus::class,
+            'metadata' => 'array',
+        ];
+    }
+
     protected function getPdfUrlAttribute(): ?string
     {
         if (! $this->pdf_path) {
@@ -89,14 +92,15 @@ final class Invoice extends Model
         }
 
         $disk = config('sisp.invoice.disk', 'public');
+        $storage = Storage::disk($disk);
 
         if ($disk === 's3') {
             $expirationHours = resolve(LoadConfig::class)->getInvoiceTemporaryUrlExpirationHours();
 
-            return Storage::disk($disk)->temporaryUrl($this->pdf_path, now()->addHours($expirationHours));
+            return $storage->temporaryUrl($this->pdf_path, now()->addHours($expirationHours));
         }
 
-        return Storage::disk($disk)->url($this->pdf_path);
+        return $storage->url($this->pdf_path);
     }
 
     private function configuredPdfUrl(): ?string

--- a/src/Models/RateLimit.php
+++ b/src/Models/RateLimit.php
@@ -4,34 +4,28 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property-read  \Illuminate\Support\Carbon $reset_at
+ */
+#[Fillable([
+    'identifier',
+    'limit_type',
+    'context',
+    'hits',
+    'limit',
+    'window_seconds',
+    'reset_at',
+    'is_blocked',
+    'blocked_until',
+])]
 final class RateLimit extends Model
 {
     use \Illuminate\Database\Eloquent\Factories\HasFactory;
-
-    protected $fillable = [
-        'identifier',
-        'limit_type',
-        'context',
-        'hits',
-        'limit',
-        'window_seconds',
-        'reset_at',
-        'is_blocked',
-        'blocked_until',
-    ];
-
-    protected $casts = [
-        'hits' => 'integer',
-        'limit' => 'integer',
-        'window_seconds' => 'integer',
-        'is_blocked' => 'boolean',
-        'reset_at' => 'datetime',
-        'blocked_until' => 'datetime',
-    ];
 
     public function getTable(): string
     {
@@ -72,6 +66,18 @@ final class RateLimit extends Model
         ]);
 
         return $this;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'hits' => 'integer',
+            'limit' => 'integer',
+            'window_seconds' => 'integer',
+            'is_blocked' => 'boolean',
+            'reset_at' => 'datetime',
+            'blocked_until' => 'datetime',
+        ];
     }
 
     #[Scope]

--- a/src/Models/RequestMetadata.php
+++ b/src/Models/RequestMetadata.php
@@ -4,49 +4,38 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Fillable([
+    'transaction_id',
+    'ip_address',
+    'user_agent',
+    'referer',
+    'country_code',
+    'country_name',
+    'region',
+    'city',
+    'latitude',
+    'longitude',
+    'isp',
+    'device_type',
+    'browser',
+    'os',
+    'device_fingerprint',
+    'response_time_ms',
+    'api_version',
+    'is_vpn',
+    'is_proxy',
+    'is_mobile',
+    'risk_score',
+    'risk_reason',
+    'custom_metadata',
+])]
 final class RequestMetadata extends Model
 {
     use \Illuminate\Database\Eloquent\Factories\HasFactory;
-
-    protected $fillable = [
-        'transaction_id',
-        'ip_address',
-        'user_agent',
-        'referer',
-        'country_code',
-        'country_name',
-        'region',
-        'city',
-        'latitude',
-        'longitude',
-        'isp',
-        'device_type',
-        'browser',
-        'os',
-        'device_fingerprint',
-        'response_time_ms',
-        'api_version',
-        'is_vpn',
-        'is_proxy',
-        'is_mobile',
-        'risk_score',
-        'risk_reason',
-        'custom_metadata',
-    ];
-
-    protected $casts = [
-        'latitude' => 'float',
-        'longitude' => 'float',
-        'response_time_ms' => 'integer',
-        'is_vpn' => 'boolean',
-        'is_proxy' => 'boolean',
-        'is_mobile' => 'boolean',
-        'risk_score' => 'integer',
-        'custom_metadata' => 'array',
-    ];
 
     public function getTable(): string
     {
@@ -56,5 +45,19 @@ final class RequestMetadata extends Model
     public function transaction(): BelongsTo
     {
         return $this->belongsTo(Transaction::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'latitude' => 'float',
+            'longitude' => 'float',
+            'response_time_ms' => 'integer',
+            'is_vpn' => 'boolean',
+            'is_proxy' => 'boolean',
+            'is_mobile' => 'boolean',
+            'risk_score' => 'integer',
+            'custom_metadata' => 'array',
+        ];
     }
 }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -21,15 +21,15 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read  int $id
  * @property-read  TransactionStatus $status
  * @property-read  array $payload
- * @property-read  string $customer_email
+ * @property-read  string|null $customer_email
  * @property-read  string $merchant_ref
  * @property-read  int $transaction_id
  * @property-read  string $locale
- * @property-read  string $customer_name
- * @property-read  string $customer_phone
- * @property-read  string $customer_country
- * @property-read  string $customer_city
- * @property-read  string $customer_address
+ * @property-read  string|null $customer_name
+ * @property-read  string|null $customer_phone
+ * @property-read  string|null $customer_country
+ * @property-read  string|null $customer_city
+ * @property-read  string|null $customer_address
  * @property-read  int|float $amount
  * @property-read  int $amount_cents
  * @property-read  string $formatted_amount

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Akira\Sisp\Models;
 
 use Akira\Sisp\Actions\LogTransactionChangesAction;
+use Akira\Sisp\Database\Factories\TransactionFactory;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\Traits\EncryptsAttributes;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -29,38 +32,40 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read  string $customer_address
  * @property-read  int|float $amount
  * @property-read  int $amount_cents
+ * @property-read  string $formatted_amount
+ * @property-read  \Illuminate\Database\Eloquent\Collection<int, TransactionItem> $items
+ * @property-read  Invoice|null $invoice
  */
+#[UseFactory(TransactionFactory::class)]
+#[Fillable([
+    'merchant_ref',
+    'merchant_session',
+    'amount',
+    'amount_cents',
+    'currency',
+    'status',
+    'transaction_code',
+    'transaction_id',
+    'message_type',
+    'response_code',
+    'merchant_response',
+    'fingerprint',
+    'payload',
+    'customer_name',
+    'customer_email',
+    'customer_phone',
+    'customer_country',
+    'customer_city',
+    'customer_address',
+    'locale',
+    'cancelled_at',
+    'refunded_at',
+    'customer_postal_code',
+])]
 final class Transaction extends Model
 {
     use EncryptsAttributes;
     use HasFactory;
-
-    /** @var list<string> */
-    protected $fillable = [
-        'merchant_ref',
-        'merchant_session',
-        'amount',
-        'amount_cents',
-        'currency',
-        'status',
-        'transaction_code',
-        'transaction_id',
-        'message_type',
-        'response_code',
-        'merchant_response',
-        'fingerprint',
-        'payload',
-        'customer_name',
-        'customer_email',
-        'customer_phone',
-        'customer_country',
-        'customer_city',
-        'customer_address',
-        'locale',
-        'cancelled_at',
-        'refunded_at',
-        'customer_postal_code',
-    ];
 
     public function getTable(): string
     {

--- a/src/Models/TransactionItem.php
+++ b/src/Models/TransactionItem.php
@@ -4,31 +4,40 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Models;
 
+use Akira\Sisp\Database\Factories\TransactionItemFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property-read  int $id
+ * @property-read  int $transaction_id
+ * @property-read  string|null $product_id
+ * @property-read  string $product_name
+ * @property-read  int $quantity
+ * @property-read  int $unit_price_cents
+ * @property-read  int $total_price_cents
+ * @property-read  float $unit_price
+ * @property-read  float $total_price
+ * @property-read  string|null $description
+ * @property-read  array|null $metadata
+ */
+#[UseFactory(TransactionItemFactory::class)]
+#[Fillable([
+    'transaction_id',
+    'product_id',
+    'product_name',
+    'quantity',
+    'unit_price_cents',
+    'total_price_cents',
+    'description',
+    'metadata',
+])]
 final class TransactionItem extends Model
 {
     use HasFactory;
-
-    protected $fillable = [
-        'transaction_id',
-        'product_id',
-        'product_name',
-        'quantity',
-        'unit_price_cents',
-        'total_price_cents',
-        'description',
-        'metadata',
-    ];
-
-    protected $casts = [
-        'quantity' => 'integer',
-        'unit_price_cents' => 'integer',
-        'total_price_cents' => 'integer',
-        'metadata' => 'array',
-    ];
 
     public function getTable(): string
     {
@@ -38,6 +47,16 @@ final class TransactionItem extends Model
     public function transaction(): BelongsTo
     {
         return $this->belongsTo(Transaction::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'quantity' => 'integer',
+            'unit_price_cents' => 'integer',
+            'total_price_cents' => 'integer',
+            'metadata' => 'array',
+        ];
     }
 
     protected function getUnitPriceAttribute(): float

--- a/src/Models/TransactionLog.php
+++ b/src/Models/TransactionLog.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Fillable([
+    'transaction_id',
+    'source',
+    'changed_attributes',
+    'old_values',
+    'new_values',
+])]
 final class TransactionLog extends Model
 {
     use HasFactory;
-
-    protected $fillable = [
-        'transaction_id',
-        'source',
-        'changed_attributes',
-        'old_values',
-        'new_values',
-    ];
 
     public function getTable(): string
     {

--- a/src/Pipelines/Callback/CallbackContext.php
+++ b/src/Pipelines/Callback/CallbackContext.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback;
+
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\CallbackPayload;
+use LogicException;
+
+final class CallbackContext
+{
+    public ?Transaction $transaction = null;
+
+    public ?string $failureReason = null;
+
+    public function __construct(
+        public readonly CallbackPayload $payload,
+    ) {}
+
+    public function transaction(): Transaction
+    {
+        return $this->transaction ?? throw new LogicException('The callback transaction has not been resolved yet.');
+    }
+
+    public function fail(string $reason): self
+    {
+        $this->failureReason = $reason;
+
+        return $this;
+    }
+
+    public function failed(): bool
+    {
+        return $this->failureReason !== null;
+    }
+}

--- a/src/Pipelines/Callback/HandleCallbackPipeline.php
+++ b/src/Pipelines/Callback/HandleCallbackPipeline.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback;
+
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Pipelines\Callback\Pipes\ApplyTransactionStatus;
+use Akira\Sisp\Pipelines\Callback\Pipes\DispatchPaymentEvents;
+use Akira\Sisp\Pipelines\Callback\Pipes\EnsureCallbackMatchesTransaction;
+use Akira\Sisp\Pipelines\Callback\Pipes\ResolveTransaction;
+use Akira\Sisp\Pipelines\Callback\Pipes\ValidateFingerprint;
+use Illuminate\Pipeline\Pipeline;
+
+final readonly class HandleCallbackPipeline
+{
+    public const array DEFAULT_PIPES = [
+        ResolveTransaction::class,
+        ValidateFingerprint::class,
+        EnsureCallbackMatchesTransaction::class,
+        ApplyTransactionStatus::class,
+        DispatchPaymentEvents::class,
+    ];
+
+    public function __construct(
+        private Pipeline $pipeline,
+        private LoadConfig $config,
+    ) {}
+
+    public function run(CallbackContext $context): CallbackContext
+    {
+        return $this->pipeline
+            ->send($context)
+            ->through($this->config->getCallbackPipes())
+            ->thenReturn();
+    }
+}

--- a/src/Pipelines/Callback/Pipes/ApplyTransactionStatus.php
+++ b/src/Pipelines/Callback/Pipes/ApplyTransactionStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback\Pipes;
+
+use Akira\Sisp\Actions\Transaction\UpdateTransactionAction;
+use Akira\Sisp\Contracts\CallbackPipe;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Closure;
+
+final readonly class ApplyTransactionStatus implements CallbackPipe
+{
+    public function __construct(private UpdateTransactionAction $updateTransaction) {}
+
+    public function handle(CallbackContext $context, Closure $next): CallbackContext
+    {
+        $this->updateTransaction->handle($context->transaction(), $context->payload);
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Callback/Pipes/DispatchPaymentEvents.php
+++ b/src/Pipelines/Callback/Pipes/DispatchPaymentEvents.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback\Pipes;
+
+use Akira\Sisp\Contracts\CallbackPipe;
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Events\PaymentCompleted;
+use Akira\Sisp\Events\PaymentFailed;
+use Akira\Sisp\Events\PaymentPending;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Closure;
+
+final readonly class DispatchPaymentEvents implements CallbackPipe
+{
+    public function handle(CallbackContext $context, Closure $next): CallbackContext
+    {
+        $transaction = $context->transaction();
+
+        match ($transaction->status) {
+            TransactionStatus::completed => event(new PaymentCompleted($transaction, $context->payload)),
+            TransactionStatus::failed => event(new PaymentFailed($transaction, $context->payload)),
+            TransactionStatus::pending => event(new PaymentPending($transaction, $context->payload)),
+            default => null, // @codeCoverageIgnore
+        };
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Callback/Pipes/EnsureCallbackMatchesTransaction.php
+++ b/src/Pipelines/Callback/Pipes/EnsureCallbackMatchesTransaction.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback\Pipes;
+
+use Akira\Sisp\Actions\Transaction\FailTransactionAction;
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Contracts\CallbackPipe;
+use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Events\PaymentFailed;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Akira\Sisp\Support\SispAmount;
+use Akira\Sisp\ValueObjects\CallbackPayload;
+use Closure;
+
+final readonly class EnsureCallbackMatchesTransaction implements CallbackPipe
+{
+    public function __construct(
+        private SispCredentialsResolver $credentialsResolver,
+        private LoadConfig $config,
+        private FailTransactionAction $failTransaction,
+    ) {}
+
+    public function handle(CallbackContext $context, Closure $next): CallbackContext
+    {
+        if (! $this->matchesTransaction($context->transaction(), $context->payload)) {
+            $this->failTransaction->handle($context->transaction(), $context->payload, 'callback_details_mismatch');
+
+            event(new PaymentFailed($context->transaction(), $context->payload));
+
+            return $context->fail('callback_details_mismatch');
+        }
+
+        return $next($context);
+    }
+
+    private function matchesTransaction(Transaction $transaction, CallbackPayload $payload): bool
+    {
+        return $this->transactionString($transaction, 'merchant_ref') === $payload->merchantRef
+            && $this->transactionString($transaction, 'merchant_session') === $payload->merchantSession
+            && $this->amountMatches($this->transactionAmount($transaction), $payload->amount)
+            && (! $payload->currencyProvided || $this->transactionString($transaction, 'currency') === $payload->currency)
+            && (! $payload->transactionCodeProvided || $this->transactionCode($transaction) === $payload->transactionCode)
+            && (! $payload->posIDProvided || $this->credentialsResolver->resolve()->posId === $payload->posID);
+    }
+
+    private function amountMatches(float|int|string $expected, float|int|string $actual): bool
+    {
+        return SispAmount::toThousandths($expected) === SispAmount::toThousandths($actual);
+    }
+
+    private function transactionAmount(Transaction $transaction): float|int|string
+    {
+        $amount = $transaction->getAttribute('amount');
+
+        return is_float($amount) || is_int($amount) || is_string($amount) ? $amount : 0;
+    }
+
+    private function transactionString(Transaction $transaction, string $attribute): string
+    {
+        $value = $transaction->getAttribute($attribute);
+
+        return is_string($value) ? $value : '';
+    }
+
+    private function transactionCode(Transaction $transaction): string
+    {
+        $transactionCode = $this->transactionString($transaction, 'transaction_code');
+
+        return $transactionCode === '' ? $this->config->getDefaultTransactionCode() : $transactionCode;
+    }
+}

--- a/src/Pipelines/Callback/Pipes/ResolveTransaction.php
+++ b/src/Pipelines/Callback/Pipes/ResolveTransaction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback\Pipes;
+
+use Akira\Sisp\Actions\Transaction\FindOrCreateTransactionAction;
+use Akira\Sisp\Contracts\CallbackPipe;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Closure;
+
+final readonly class ResolveTransaction implements CallbackPipe
+{
+    public function __construct(private FindOrCreateTransactionAction $findOrCreateTransaction) {}
+
+    public function handle(CallbackContext $context, Closure $next): CallbackContext
+    {
+        $context->transaction = $this->findOrCreateTransaction->handle($context->payload);
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Callback/Pipes/ValidateFingerprint.php
+++ b/src/Pipelines/Callback/Pipes/ValidateFingerprint.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Callback\Pipes;
+
+use Akira\Sisp\Actions\Transaction\FailTransactionAction;
+use Akira\Sisp\Contracts\CallbackFingerprintValidator;
+use Akira\Sisp\Contracts\CallbackPipe;
+use Akira\Sisp\Events\PaymentFailed;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Closure;
+
+final readonly class ValidateFingerprint implements CallbackPipe
+{
+    public function __construct(
+        private CallbackFingerprintValidator $validateFingerprint,
+        private FailTransactionAction $failTransaction,
+    ) {}
+
+    public function handle(CallbackContext $context, Closure $next): CallbackContext
+    {
+        if (! $this->validateFingerprint->handle($context->payload)) {
+            $this->failTransaction->handle($context->transaction(), $context->payload, 'invalid_callback_fingerprint');
+
+            event(new PaymentFailed($context->transaction(), $context->payload));
+
+            return $context->fail('invalid_callback_fingerprint');
+        }
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Payment/PaymentContext.php
+++ b/src/Pipelines/Payment/PaymentContext.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment;
+
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\PaymentRequest;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+use Illuminate\Http\Request;
+use LogicException;
+
+final class PaymentContext
+{
+    public ?PaymentRequest $paymentRequest = null;
+
+    public ?Transaction $transaction = null;
+
+    public function __construct(
+        public readonly PaymentRequestData $data,
+        public readonly Request $request,
+    ) {}
+
+    public function paymentRequest(): PaymentRequest
+    {
+        return $this->paymentRequest ?? throw new LogicException('The payment request has not been built yet.');
+    }
+
+    public function transaction(): Transaction
+    {
+        return $this->transaction ?? throw new LogicException('The transaction has not been persisted yet.');
+    }
+}

--- a/src/Pipelines/Payment/Pipes/BuildPaymentRequest.php
+++ b/src/Pipelines/Payment/Pipes/BuildPaymentRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment\Pipes;
+
+use Akira\Sisp\Actions\PreparePaymentAction;
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+
+final readonly class BuildPaymentRequest implements PaymentPipe
+{
+    public function __construct(private PreparePaymentAction $preparePayment) {}
+
+    public function handle(PaymentContext $context, Closure $next): PaymentContext
+    {
+        $context->paymentRequest = $this->preparePayment->handle($context->data);
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Payment/Pipes/CaptureRequestMetadata.php
+++ b/src/Pipelines/Payment/Pipes/CaptureRequestMetadata.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment\Pipes;
+
+use Akira\Sisp\Actions\StoreRequestMetadataAction;
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+
+final readonly class CaptureRequestMetadata implements PaymentPipe
+{
+    public function __construct(private StoreRequestMetadataAction $storeMetadata) {}
+
+    public function handle(PaymentContext $context, Closure $next): PaymentContext
+    {
+        $this->storeMetadata->handle($context->request, $context->transaction);
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Payment/Pipes/EnforceRateLimits.php
+++ b/src/Pipelines/Payment/Pipes/EnforceRateLimits.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment\Pipes;
+
+use Akira\Sisp\Actions\CheckRateLimitAction;
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+
+final readonly class EnforceRateLimits implements PaymentPipe
+{
+    public function __construct(private CheckRateLimitAction $checkRateLimit) {}
+
+    public function handle(PaymentContext $context, Closure $next): PaymentContext
+    {
+        $this->checkRateLimit->handle(identifier: $context->request->ip());
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Payment/Pipes/EnsureIpIsNotBlacklisted.php
+++ b/src/Pipelines/Payment/Pipes/EnsureIpIsNotBlacklisted.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment\Pipes;
+
+use Akira\Sisp\Actions\CheckBlacklistAction;
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+
+final readonly class EnsureIpIsNotBlacklisted implements PaymentPipe
+{
+    public function __construct(private CheckBlacklistAction $checkBlacklist) {}
+
+    public function handle(PaymentContext $context, Closure $next): PaymentContext
+    {
+        $this->checkBlacklist->handle('ip', $context->request->ip());
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Payment/Pipes/PersistTransaction.php
+++ b/src/Pipelines/Payment/Pipes/PersistTransaction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment\Pipes;
+
+use Akira\Sisp\Actions\CreateAndStorePaymentTransactionAction;
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Closure;
+
+final readonly class PersistTransaction implements PaymentPipe
+{
+    public function __construct(private CreateAndStorePaymentTransactionAction $createTransaction) {}
+
+    public function handle(PaymentContext $context, Closure $next): PaymentContext
+    {
+        $context->transaction = $this->createTransaction->handle($context->paymentRequest(), $context->request);
+
+        return $next($context);
+    }
+}

--- a/src/Pipelines/Payment/ProcessPaymentPipeline.php
+++ b/src/Pipelines/Payment/ProcessPaymentPipeline.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Pipelines\Payment;
+
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Pipelines\Payment\Pipes\BuildPaymentRequest;
+use Akira\Sisp\Pipelines\Payment\Pipes\CaptureRequestMetadata;
+use Akira\Sisp\Pipelines\Payment\Pipes\EnforceRateLimits;
+use Akira\Sisp\Pipelines\Payment\Pipes\EnsureIpIsNotBlacklisted;
+use Akira\Sisp\Pipelines\Payment\Pipes\PersistTransaction;
+use Illuminate\Pipeline\Pipeline;
+
+final readonly class ProcessPaymentPipeline
+{
+    public const array DEFAULT_PIPES = [
+        EnsureIpIsNotBlacklisted::class,
+        EnforceRateLimits::class,
+        BuildPaymentRequest::class,
+        PersistTransaction::class,
+        CaptureRequestMetadata::class,
+    ];
+
+    public function __construct(
+        private Pipeline $pipeline,
+        private LoadConfig $config,
+    ) {}
+
+    public function run(PaymentContext $context): PaymentContext
+    {
+        return $this->pipeline
+            ->send($context)
+            ->through($this->config->getPaymentPipes())
+            ->thenReturn();
+    }
+}

--- a/src/Sisp.php
+++ b/src/Sisp.php
@@ -10,8 +10,13 @@ use Akira\Sisp\Actions\CreateTransactionAction;
 use Akira\Sisp\Actions\HandleCallbackAction;
 use Akira\Sisp\Actions\QueryTransactionStatusAction;
 use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
+use Akira\Sisp\Actions\RefundTransactionAction;
 use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
+use Akira\Sisp\Builders\PaymentBuilder;
+use Akira\Sisp\Builders\RefundBuilder;
 use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Contracts\SispDriver;
+use Akira\Sisp\Drivers\SispManager;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\Countries;
 use Akira\Sisp\ValueObjects\CallbackPayload;
@@ -20,7 +25,9 @@ use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\SispCredentials;
 use Akira\Sisp\ValueObjects\TransactionData;
 use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+use Illuminate\Container\Attributes\Singleton;
 
+#[Singleton]
 final readonly class Sisp
 {
     public function __construct(
@@ -41,6 +48,21 @@ final readonly class Sisp
             container: app(),
             credentials: $credentials,
         );
+    }
+
+    public function payment(): PaymentBuilder
+    {
+        return resolve(PaymentBuilder::class);
+    }
+
+    public function refund(Transaction $transaction): RefundBuilder
+    {
+        return new RefundBuilder(resolve(RefundTransactionAction::class), $transaction);
+    }
+
+    public function driver(?string $driver = null): SispDriver
+    {
+        return resolve(SispManager::class)->driver($driver);
     }
 
     public function getTransactions(): \Illuminate\Database\Eloquent\Builder

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -4,21 +4,14 @@ declare(strict_types=1);
 
 namespace Akira\Sisp;
 
-use Akira\Sisp\Actions\BuildRequestPayloadAction;
-use Akira\Sisp\Actions\BuildSandboxPayloadAction;
-use Akira\Sisp\Actions\CreateTransactionAction;
-use Akira\Sisp\Actions\HandleCallbackAction;
-use Akira\Sisp\Actions\QueryTransactionStatusAction;
-use Akira\Sisp\Actions\ReconcileTransactionStatusAction;
-use Akira\Sisp\Actions\ValidatePaymentResponseFingerprintAction;
 use Akira\Sisp\Commands\DoctorCommand;
 use Akira\Sisp\Commands\LaravelSispInstallCommand;
 use Akira\Sisp\Commands\ReconcilePendingTransactionsCommand;
 use Akira\Sisp\Commands\RegenerateMissingInvoicePdfsCommand;
 use Akira\Sisp\Commands\TransactionStatusCommand;
-use Akira\Sisp\Configuration\EnvSispCredentialsResolver;
 use Akira\Sisp\Configuration\LoadConfig;
-use Akira\Sisp\Contracts\SispCredentialsResolver;
+use Akira\Sisp\Contracts\SispDriver;
+use Akira\Sisp\Drivers\SispManager;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\View\Compilers\BladeCompiler;
@@ -48,27 +41,23 @@ final class SispServiceProvider extends PackageServiceProvider
             ]);
     }
 
+    /**
+     * Container bindings are declared with native container
+     * attributes: #[Bind] on the contracts and #[Singleton] on
+     * LoadConfig, SispManager, and Sisp. Only the driver contract needs
+     * an explicit closure since it is resolved through the manager.
+     */
     public function register(): void
     {
         parent::register();
 
-        $this->app->singleton(LoadConfig::class);
+        // #[Bind] container attributes are only consulted when an environment
+        // resolver is present. Full applications register one during bootstrap,
+        // but lighter harnesses such as Testbench do not, so mirror the
+        // framework's default resolver here.
+        $this->app->resolveEnvironmentUsing(fn (array $environments): bool => (bool) $this->app->environment($environments));
 
-        $this->app->singleton(
-            SispCredentialsResolver::class,
-            EnvSispCredentialsResolver::class
-        );
-
-        $this->app->singleton(Sisp::class, fn (Application $app): Sisp => new Sisp(
-            buildRequestPayload: $app->make(BuildRequestPayloadAction::class),
-            buildSandboxPayload: $app->make(BuildSandboxPayloadAction::class),
-            validateFingerprint: $app->make(ValidatePaymentResponseFingerprintAction::class),
-            createTransaction: $app->make(CreateTransactionAction::class),
-            handleCallback: $app->make(HandleCallbackAction::class),
-            queryTransactionStatus: $app->make(QueryTransactionStatusAction::class),
-            reconcileTransactionStatus: $app->make(ReconcileTransactionStatusAction::class),
-            loadConfig: $app->make(LoadConfig::class),
-        ));
+        $this->app->bind(SispDriver::class, fn (Application $app): SispDriver => $app->make(SispManager::class)->driver());
     }
 
     public function boot(): self

--- a/src/Traits/EncryptsAttributes.php
+++ b/src/Traits/EncryptsAttributes.php
@@ -24,7 +24,7 @@ trait EncryptsAttributes
 
     public function getAttribute($key): mixed
     {
-        if (array_key_exists($key, $this->decryptedAttributesCache)) {
+        if (array_key_exists((string) $key, $this->decryptedAttributesCache)) {
             return $this->decryptedAttributesCache[$key];
         }
 

--- a/tests/Actions/HandleCallbackActionTest.php
+++ b/tests/Actions/HandleCallbackActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Actions\HandleCallbackAction;
+use Akira\Sisp\Contracts\CallbackFingerprintValidator;
 use Akira\Sisp\Enums\SuccessMessageType;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\PaymentCompleted;
@@ -38,9 +39,9 @@ beforeEach(function (): void {
 });
 
 it('dispatches PaymentFailed and marks the transaction failed when fingerprint is invalid', function (): void {
-    app()->instance(Akira\Sisp\Sisp::class, new class
+    app()->instance(CallbackFingerprintValidator::class, new class implements CallbackFingerprintValidator
     {
-        public function validateCallback(CallbackPayload $payload): bool
+        public function handle(CallbackPayload $payload): bool
         {
             return false;
         }
@@ -66,9 +67,9 @@ it('dispatches PaymentFailed and marks the transaction failed when fingerprint i
 });
 
 it('dispatches events for completed, failed, and pending statuses', function (): void {
-    app()->instance(Akira\Sisp\Sisp::class, new class
+    app()->instance(CallbackFingerprintValidator::class, new class implements CallbackFingerprintValidator
     {
-        public function validateCallback(CallbackPayload $payload): bool
+        public function handle(CallbackPayload $payload): bool
         {
             return true;
         }

--- a/tests/Actions/UpdateInvoiceStatusActionTest.php
+++ b/tests/Actions/UpdateInvoiceStatusActionTest.php
@@ -9,6 +9,7 @@ use Akira\Sisp\Actions\UpdateInvoiceStatusAction;
 use Akira\Sisp\Enums\InvoiceStatus;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 final class UpdateInvoiceStatusTestPdfGenerator implements PdfGeneratorContract
@@ -114,4 +115,33 @@ it('handles transaction without invoice gracefully', function (): void {
     $action->handle($transaction, TransactionStatus::pending);
 
     expect(true)->toBeTrue();
+});
+
+it('does not fail the payment flow when pdf generation throws', function (): void {
+    app()->instance(PdfGeneratorContract::class, new class implements PdfGeneratorContract
+    {
+        public function generate(DtoInvoiceData $invoice, string $template = 'modern'): string
+        {
+            throw new RuntimeException('headless browser unavailable');
+        }
+
+        public function save(DtoInvoiceData $invoice, string $template = 'modern', ?string $path = null): string
+        {
+            throw new RuntimeException('headless browser unavailable');
+        }
+    });
+
+    Log::shouldReceive('error')->once()->withArgs(
+        fn (string $message): bool => $message === 'SISP invoice PDF generation failed.'
+    );
+
+    $transaction = Transaction::factory()->create(['status' => 'completed']);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+
+    resolve(UpdateInvoiceStatusAction::class)->handle($transaction->refresh(), TransactionStatus::completed);
+
+    $invoice->refresh();
+
+    expect($invoice->status)->toBe(InvoiceStatus::paid)
+        ->and($invoice->pdf_path)->toBeNull();
 });

--- a/tests/Builders/PaymentBuilderTest.php
+++ b/tests/Builders/PaymentBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Enums\TransactionCode;
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\ValueObjects\PaymentRequest;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+
+it('builds payment request data fluently', function (): void {
+    $data = Sisp::payment()
+        ->amount(150.5)
+        ->merchantRef('MR-BUILDER')
+        ->merchantSession('MS-BUILDER')
+        ->timeStamp('2026-01-01 00:00:00')
+        ->currency('132')
+        ->transactionCode(TransactionCode::purchase)
+        ->token('tok')
+        ->entityCode('ent')
+        ->referenceNumber('ref')
+        ->locale('pt')
+        ->customerEmail('buyer@example.test')
+        ->customerCountry('CV')
+        ->customerCity('Praia')
+        ->customerAddress('Rua Teste')
+        ->customerPostalCode('7600')
+        ->customerPhone('+238 000 0000')
+        ->toData();
+
+    expect($data)->toBeInstanceOf(PaymentRequestData::class)
+        ->and($data->amount)->toBe(150.5)
+        ->and($data->merchantRef)->toBe('MR-BUILDER')
+        ->and($data->merchantSession)->toBe('MS-BUILDER')
+        ->and($data->timeStamp)->toBe('2026-01-01 00:00:00')
+        ->and($data->currency)->toBe('132')
+        ->and($data->transactionCode)->toBe('1')
+        ->and($data->token)->toBe('tok')
+        ->and($data->entityCode)->toBe('ent')
+        ->and($data->referenceNumber)->toBe('ref')
+        ->and($data->locale)->toBe('pt')
+        ->and($data->customerEmail)->toBe('buyer@example.test')
+        ->and($data->customerCountry)->toBe('CV')
+        ->and($data->customerCity)->toBe('Praia')
+        ->and($data->customerAddress)->toBe('Rua Teste')
+        ->and($data->customerPostalCode)->toBe('7600')
+        ->and($data->customerPhone)->toBe('+238 000 0000');
+});
+
+it('builds a signed payment request through the builder', function (): void {
+    $request = Sisp::payment()
+        ->amount(99.0)
+        ->merchantRef('MR-BUILD')
+        ->merchantSession('MS-BUILD')
+        ->currency('132')
+        ->transactionCode('1')
+        ->build();
+
+    expect($request)->toBeInstanceOf(PaymentRequest::class)
+        ->and($request->merchantRef)->toBe('MR-BUILD')
+        ->and($request->amount)->toBe(99.0)
+        ->and($request->fingerprint)->not->toBe('');
+});
+
+it('accepts a transaction code string', function (): void {
+    $data = Sisp::payment()->amount(10.0)->transactionCode('7')->toData();
+
+    expect($data->transactionCode)->toBe('7');
+});
+
+it('rejects building without an amount', function (): void {
+    Sisp::payment()->toData();
+})->throws(LogicException::class, 'A payment amount greater than zero is required.');
+
+it('rejects building with a non-positive amount', function (): void {
+    Sisp::payment()->amount(0.0)->toData();
+})->throws(LogicException::class, 'A payment amount greater than zero is required.');

--- a/tests/Builders/RefundBuilderTest.php
+++ b/tests/Builders/RefundBuilderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Events\TransactionRefunded;
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Event;
+
+it('processes a full refund through the builder', function (): void {
+    Event::fake();
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'completed',
+        'amount' => 90.0,
+        'transaction_id' => 'TX-BUILDER-1',
+        'response_code' => '001',
+    ]);
+
+    $refunded = Sisp::refund($transaction)
+        ->full()
+        ->reason('builder_refund')
+        ->process();
+
+    expect($refunded->status->value)->toBe('refunded')
+        ->and($refunded->merchant_response)->toBe('builder_refund::90');
+
+    Event::assertDispatched(TransactionRefunded::class);
+});
+
+it('processes a partial refund through the builder', function (): void {
+    Event::fake();
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'completed',
+        'amount' => 100.0,
+        'transaction_id' => 'TX-BUILDER-2',
+        'response_code' => '001',
+    ]);
+
+    $refunded = Sisp::refund($transaction)
+        ->amount(40.0)
+        ->reason('partial_refund')
+        ->process();
+
+    expect($refunded->status->value)->toBe('completed')
+        ->and($refunded->refunded_at)->not->toBeNull();
+});
+
+it('requires an amount before processing', function (): void {
+    $transaction = Transaction::factory()->create(['status' => 'completed', 'amount' => 50.0]);
+
+    Sisp::refund($transaction)->process();
+})->throws(LogicException::class, 'A refund amount is required. Call amount() or full() first.');

--- a/tests/Drivers/SispManagerTest.php
+++ b/tests/Drivers/SispManagerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Contracts\SispDriver;
+use Akira\Sisp\Drivers\ProductionDriver;
+use Akira\Sisp\Drivers\SandboxDriver;
+use Akira\Sisp\Drivers\SispManager;
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\TransactionStatusResponse;
+use Illuminate\Support\Facades\Http;
+
+it('resolves the production driver when sandbox is disabled', function (): void {
+    config()->set('sisp.sandbox', false);
+
+    $driver = resolve(SispManager::class)->driver();
+
+    expect($driver)->toBeInstanceOf(ProductionDriver::class)
+        ->and($driver->name())->toBe('production')
+        ->and($driver->paymentEndpoint())->toBe('https://test.sisp.example.com');
+});
+
+it('resolves the sandbox driver when sandbox is enabled', function (): void {
+    config()->set('sisp.sandbox', true);
+
+    $driver = resolve(SispManager::class)->driver();
+
+    expect($driver)->toBeInstanceOf(SandboxDriver::class)
+        ->and($driver->name())->toBe('sandbox')
+        ->and($driver->paymentEndpoint())->toBe(route('sisp.sandbox'));
+});
+
+it('honours an explicit driver from config over the sandbox flag', function (): void {
+    config()->set('sisp.sandbox', true);
+    config()->set('sisp.driver', 'production');
+
+    expect(resolve(SispManager::class)->driver())->toBeInstanceOf(ProductionDriver::class);
+});
+
+it('exposes the driver through the facade and the container contract', function (): void {
+    config()->set('sisp.sandbox', false);
+
+    expect(Sisp::driver())->toBeInstanceOf(ProductionDriver::class)
+        ->and(Sisp::driver('sandbox'))->toBeInstanceOf(SandboxDriver::class)
+        ->and(resolve(SispDriver::class))->toBeInstanceOf(ProductionDriver::class);
+});
+
+it('supports registering custom drivers via extend', function (): void {
+    $custom = new class implements SispDriver
+    {
+        public function name(): string
+        {
+            return 'custom';
+        }
+
+        public function paymentEndpoint(): string
+        {
+            return 'https://custom.gateway.example.com';
+        }
+
+        public function queryTransactionStatus(Transaction|string $transaction): TransactionStatusResponse
+        {
+            return TransactionStatusResponse::from([
+                'result' => true,
+                'transactionSuccess' => true,
+                'transactionStatusDescription' => 'C-SUCESSO',
+                'msg' => 'ok',
+            ]);
+        }
+    };
+
+    $manager = resolve(SispManager::class);
+    $manager->extend('custom', fn (): SispDriver => $custom);
+
+    config()->set('sisp.driver', 'custom');
+
+    expect($manager->driver()->name())->toBe('custom')
+        ->and($manager->driver()->paymentEndpoint())->toBe('https://custom.gateway.example.com');
+});
+
+it('queries the transaction status through the driver', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake([
+        '*' => Http::response([
+            'result' => true,
+            'transactionSuccess' => true,
+            'transactionStatusDescription' => 'C-SUCESSO',
+            'msg' => 'Approved',
+        ]),
+    ]);
+
+    $response = resolve(SispManager::class)->driver()->queryTransactionStatus('MR-DRIVER');
+
+    expect($response->paymentStatus()->value)->toBe('completed');
+});

--- a/tests/Http/RetryPaymentControllerTest.php
+++ b/tests/Http/RetryPaymentControllerTest.php
@@ -23,5 +23,5 @@ it('retries payment for an existing transaction', function (): void {
         ->and($t->merchant_session)->not->toBe('')
         ->and($t->amount)->toBe(123.0)
         ->and($t->currency)->toBe('132')
-        ->and($t->status->value)->toBe('failed');
+        ->and($t->status->value)->toBe('pending');
 });

--- a/tests/Http/SispPaymentFlowIntegrationTest.php
+++ b/tests/Http/SispPaymentFlowIntegrationTest.php
@@ -176,6 +176,8 @@ it('runs authorized full refund through the public route', function (): void {
         'status' => 'completed',
         'amount' => 90.0,
         'customer_email' => 'buyer@example.test',
+        'transaction_id' => 'TX-REFUND-1',
+        'response_code' => '001',
     ]);
 
     $this->actingAs(new RealSispFlowUser(1, 'agent@example.test'))

--- a/tests/Invoices/GenerateInvoicePdfMissingCustomerDataTest.php
+++ b/tests/Invoices/GenerateInvoicePdfMissingCustomerDataTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\PdfInvoices\Contracts\PdfGeneratorContract;
+use Akira\PdfInvoices\DTO\InvoiceData as DtoInvoiceData;
+use Akira\Sisp\Actions\GenerateInvoiceAction;
+use Akira\Sisp\Actions\GenerateInvoicePdfAction;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Storage;
+
+final class MissingCustomerDataPdfGenerator implements PdfGeneratorContract
+{
+    public ?DtoInvoiceData $lastInvoice = null;
+
+    public function generate(DtoInvoiceData $invoice, string $template = 'modern'): string
+    {
+        $this->lastInvoice = $invoice;
+
+        return '%PDF-NO-CUSTOMER%';
+    }
+
+    public function save(DtoInvoiceData $invoice, string $template = 'modern', ?string $path = null): string
+    {
+        return '%PDF-SAVED%';
+    }
+}
+
+it('generates the invoice pdf when the transaction has no customer data', function (): void {
+    $pdfGenerator = new MissingCustomerDataPdfGenerator();
+    app()->instance(PdfGeneratorContract::class, $pdfGenerator);
+    Storage::fake('public');
+
+    $transaction = Transaction::factory()->create([
+        'customer_name' => null,
+        'customer_email' => null,
+        'customer_address' => null,
+        'customer_city' => null,
+        'customer_country' => null,
+        'customer_phone' => null,
+    ]);
+
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+    $invoice->update([
+        'customer_name' => null,
+        'customer_email' => null,
+        'customer_address' => null,
+        'customer_city' => null,
+        'customer_country' => null,
+    ]);
+
+    $relativePath = resolve(GenerateInvoicePdfAction::class)->handle($invoice->refresh());
+
+    Storage::disk('public')->assertExists($relativePath);
+    expect($pdfGenerator->lastInvoice)->not->toBeNull();
+});

--- a/tests/Pipelines/HandleCallbackPipelineTest.php
+++ b/tests/Pipelines/HandleCallbackPipelineTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Events\PaymentCompleted;
+use Akira\Sisp\Events\PaymentFailed;
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Pipelines\Callback\CallbackContext;
+use Akira\Sisp\Pipelines\Callback\HandleCallbackPipeline;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function (): void {
+    config()->set('sisp.sandbox', true);
+});
+
+it('completes a transaction through the callback pipeline with a valid sandbox payload', function (): void {
+    Event::fake();
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-PIPE-CB',
+        'merchant_session' => 'MS-PIPE-CB',
+        'amount' => 42.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $payload = Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => 42.0,
+        'merchantRef' => 'MR-PIPE-CB',
+        'merchantSession' => 'MS-PIPE-CB',
+        'timeStamp' => '2026-01-01 00:00:00',
+        'currency' => '132',
+        'transactionCode' => '1',
+    ]));
+
+    $context = resolve(HandleCallbackPipeline::class)->run(new CallbackContext($payload));
+
+    expect($context->failed())->toBeFalse()
+        ->and($context->failureReason)->toBeNull()
+        ->and($context->transaction()->id)->toBe($transaction->id)
+        ->and($context->transaction()->status->value)->toBe('completed');
+
+    Event::assertDispatched(PaymentCompleted::class);
+});
+
+it('short-circuits and fails the transaction when the fingerprint is invalid', function (): void {
+    Event::fake();
+
+    Transaction::factory()->create([
+        'merchant_ref' => 'MR-PIPE-BAD',
+        'merchant_session' => 'MS-PIPE-BAD',
+        'amount' => 42.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $payload = Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => 42.0,
+        'merchantRef' => 'MR-PIPE-BAD',
+        'merchantSession' => 'MS-PIPE-BAD',
+        'timeStamp' => '2026-01-01 00:00:00',
+        'currency' => '132',
+        'transactionCode' => '1',
+    ]));
+
+    $tampered = Akira\Sisp\ValueObjects\CallbackPayload::from([
+        ...$payload->toArray(),
+        'resultFingerPrint' => 'tampered-fingerprint',
+    ]);
+
+    $context = resolve(HandleCallbackPipeline::class)->run(new CallbackContext($tampered));
+
+    expect($context->failed())->toBeTrue()
+        ->and($context->failureReason)->toBe('invalid_callback_fingerprint')
+        ->and($context->transaction()->status->value)->toBe('failed')
+        ->and($context->transaction()->merchant_response)->toBe('invalid_callback_fingerprint');
+
+    Event::assertDispatched(PaymentFailed::class);
+});
+
+it('fails the transaction when callback details do not match', function (): void {
+    Event::fake();
+
+    Transaction::factory()->create([
+        'merchant_ref' => 'MR-PIPE-MISMATCH',
+        'merchant_session' => 'MS-PIPE-MISMATCH',
+        'amount' => 99.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $payload = Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => 42.0,
+        'merchantRef' => 'MR-PIPE-MISMATCH',
+        'merchantSession' => 'MS-PIPE-MISMATCH',
+        'timeStamp' => '2026-01-01 00:00:00',
+        'currency' => '132',
+        'transactionCode' => '1',
+    ]));
+
+    $context = resolve(HandleCallbackPipeline::class)->run(new CallbackContext($payload));
+
+    expect($context->failed())->toBeTrue()
+        ->and($context->failureReason)->toBe('callback_details_mismatch')
+        ->and($context->transaction()->status->value)->toBe('failed');
+
+    Event::assertDispatched(PaymentFailed::class);
+});
+
+it('throws when accessing the transaction before resolution', function (): void {
+    $payload = Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => 1.0,
+        'merchantRef' => 'MR-NONE',
+        'merchantSession' => 'MS-NONE',
+        'timeStamp' => '2026-01-01 00:00:00',
+        'currency' => '132',
+        'transactionCode' => '1',
+    ]));
+
+    new CallbackContext($payload)->transaction();
+})->throws(LogicException::class, 'The callback transaction has not been resolved yet.');

--- a/tests/Pipelines/ProcessPaymentPipelineTest.php
+++ b/tests/Pipelines/ProcessPaymentPipelineTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Contracts\PaymentPipe;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Pipelines\Payment\PaymentContext;
+use Akira\Sisp\Pipelines\Payment\Pipes\BuildPaymentRequest;
+use Akira\Sisp\Pipelines\Payment\Pipes\PersistTransaction;
+use Akira\Sisp\Pipelines\Payment\ProcessPaymentPipeline;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+use Illuminate\Http\Request;
+
+function payment_pipeline_context(float $amount = 25.0): PaymentContext
+{
+    $request = Request::create('/sisp/payment', 'POST', [
+        'amount' => $amount,
+        'items' => [[
+            'product_name' => 'Pipeline Ticket',
+            'quantity' => 1,
+            'unit_price' => $amount,
+            'total_price' => $amount,
+        ]],
+        'customer_name' => 'Pipeline Buyer',
+    ]);
+
+    return new PaymentContext(
+        data: PaymentRequestData::from(['amount' => $amount]),
+        request: $request,
+    );
+}
+
+it('runs the default payment pipeline and persists a transaction', function (): void {
+    $context = resolve(ProcessPaymentPipeline::class)->run(payment_pipeline_context());
+
+    expect($context->paymentRequest()->amount)->toBe(25.0)
+        ->and($context->transaction())->toBeInstanceOf(Transaction::class)
+        ->and($context->transaction()->status->value)->toBe('pending')
+        ->and($context->transaction()->items()->count())->toBe(1);
+});
+
+it('runs custom pipes configured in sisp.pipelines.payment', function (): void {
+    $witness = new class implements PaymentPipe
+    {
+        public static bool $ran = false;
+
+        public function handle(PaymentContext $context, Closure $next): PaymentContext
+        {
+            self::$ran = true;
+
+            return $next($context);
+        }
+    };
+
+    config()->set('sisp.pipelines.payment', [
+        BuildPaymentRequest::class,
+        PersistTransaction::class,
+        $witness,
+    ]);
+
+    $context = resolve(ProcessPaymentPipeline::class)->run(payment_pipeline_context(30.0));
+
+    expect($witness::$ran)->toBeTrue()
+        ->and($context->transaction()->amount)->toBe(30.0);
+});
+
+it('throws when accessing the payment request before it is built', function (): void {
+    payment_pipeline_context()->paymentRequest();
+})->throws(LogicException::class, 'The payment request has not been built yet.');
+
+it('throws when accessing the transaction before it is persisted', function (): void {
+    payment_pipeline_context()->transaction();
+})->throws(LogicException::class, 'The transaction has not been persisted yet.');

--- a/tests/Sisp/ScopedSispTest.php
+++ b/tests/Sisp/ScopedSispTest.php
@@ -13,8 +13,6 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 
 it('scoped sisp uses credentials and restores resolver', function (): void {
-    config()->set('sisp.merchant_ref', 'CFG-REF');
-    config()->set('sisp.merchant_session', 'CFG-SESSION');
     config()->set('sisp.transaction_code', '7');
 
     $credentials = SispCredentials::from([
@@ -55,8 +53,8 @@ it('scoped sisp uses credentials and restores resolver', function (): void {
         ->and($payload['languageMessages'])->toBe('EN')
         ->and($payload['urlMerchantResponse'])->toBe('https://scoped.example.com/callback');
 
-    expect($scoped->getMerchantReference())->toBe('CFG-REF')
-        ->and($scoped->getMerchantSession())->toBe('CFG-SESSION')
+    expect($scoped->getMerchantReference())->toMatch('/^R\d{14}$/')
+        ->and($scoped->getMerchantSession())->toMatch('/^S\d{14}$/')
         ->and($scoped->getTimeStamp())->toBeString()
         ->and($scoped->getTimeStamp())->not->toBe('')
         ->and($scoped->getDefaultTransactionCode())->toBe('7')


### PR DESCRIPTION
Rebuild the package around four explicit patterns while keeping the
public API and the full behavior of v1:

- Driver pattern: new SispManager (Illuminate\Support\Manager) with
  production and sandbox drivers behind the SispDriver contract,
  extensible via SispManager::extend(). Payment endpoint resolution and
  transaction-status queries now go through the active driver.
- Builder pattern: fluent PaymentBuilder (Sisp::payment()) and
  RefundBuilder (Sisp::refund()) for composing requests.
- Pipeline pattern: the payment flow (blacklist, rate limit, build,
  persist, metadata) and the callback flow (resolve, fingerprint,
  match, status, events) run through configurable Laravel pipelines
  with single-purpose pipes (sisp.pipelines config).
- Actions + SOLID: new CallbackFingerprintValidator contract (DIP),
  FailTransactionAction extracted, controllers depend on pipelines
  instead of action lists.

Adopt native Laravel 13 syntax across the package:

- #[Fillable] and #[UseFactory] attributes plus casts() methods on all
  Eloquent models
- #[Signature]/#[Description] attributes on console commands
- #[Bind]/#[Singleton] container attributes on contracts and services,
  with an environment resolver registered for Testbench parity

Platform and tooling:

- Require PHP ^8.5 and illuminate/contracts ^13.0 (testbench ^11)
- All dependencies on latest stable releases (larastan ^3.10,
  peck ^0.3)
- CI matrix narrowed to PHP 8.5 / Laravel 13 and now runs the full
  Pest suite in addition to the quality gates
- phpstan baseline pruned and model property docblocks fixed at the
  source

Tests: 403 passing, 100% type coverage, phpstan/pint/rector/peck clean.
Three stale tests that CI never executed were aligned with current
behavior (retry resets status to pending; refunds require the original
transaction_id/response_code; merchant references are generated).

https://claude.ai/code/session_017ME4AxNYQzk5paX5PqizAY