### PR TITLE
fix(payments): prevent duplicate SISP submissions

### DIFF
--- a/database/factories/TransactionAttemptFactory.php
+++ b/database/factories/TransactionAttemptFactory.php
@@ -22,6 +22,7 @@ final class TransactionAttemptFactory extends Factory
             'attempt_number' => 1,
             'merchant_ref' => $this->faker->uuid(),
             'merchant_session' => $this->faker->uuid(),
+            'attempt_session' => $this->faker->uuid(),
             'status' => 'pending',
             'payload' => [],
             'submitted_at' => now(),

--- a/database/migrations/create_sisp_transaction_attempts_table.php
+++ b/database/migrations/create_sisp_transaction_attempts_table.php
@@ -30,6 +30,7 @@ return new class extends Migration
             $table->unsignedInteger('attempt_number');
             $table->string('merchant_ref');
             $table->string('merchant_session');
+            $table->string('attempt_session')->nullable();
             $table->string('status')->default('pending');
             $table->string('gateway_transaction_id')->nullable();
             $table->string('message_type')->nullable();
@@ -44,9 +45,9 @@ return new class extends Migration
             $table->timestamp('superseded_at')->nullable();
             $table->timestamps();
 
-            $table->unique('merchant_session');
-            $table->unique(['merchant_ref', 'merchant_session']);
             $table->unique(['transaction_id', 'attempt_number']);
+            $table->index(['merchant_ref', 'merchant_session']);
+            $table->index('attempt_session');
             $table->index(['transaction_id', 'status']);
             $table->index('gateway_transaction_id');
         });
@@ -103,7 +104,7 @@ return new class extends Migration
 
     private function backfillAttempts(string $transactionsTable, string $attemptsTable): void
     {
-        $usedMerchantSessions = [];
+        $usedAttemptSessions = [];
 
         DB::table($transactionsTable)
             ->orderBy('id')
@@ -121,20 +122,21 @@ return new class extends Migration
                 'created_at',
                 'updated_at',
             ])
-            ->chunkById(100, function ($transactions) use ($attemptsTable, &$usedMerchantSessions): void {
+            ->chunkById(100, function ($transactions) use ($attemptsTable, &$usedAttemptSessions): void {
                 foreach ($transactions as $transaction) {
-                    $merchantSession = $this->uniqueLegacyMerchantSession(
+                    $attemptSession = $this->uniqueLegacyMerchantSession(
                         (string) $transaction->merchant_session,
                         (int) $transaction->id,
-                        $usedMerchantSessions,
+                        $usedAttemptSessions,
                     );
-                    $hasDuplicateSession = $merchantSession !== (string) $transaction->merchant_session;
+                    $hasDuplicateAttemptSession = $attemptSession !== (string) $transaction->merchant_session;
 
                     DB::table($attemptsTable)->insert([
                         'transaction_id' => $transaction->id,
                         'attempt_number' => 1,
                         'merchant_ref' => $transaction->merchant_ref,
-                        'merchant_session' => $merchantSession,
+                        'merchant_session' => $transaction->merchant_session,
+                        'attempt_session' => $attemptSession,
                         'status' => $transaction->status,
                         'gateway_transaction_id' => $transaction->transaction_id,
                         'message_type' => $transaction->message_type,
@@ -143,10 +145,10 @@ return new class extends Migration
                         'fingerprint' => $transaction->fingerprint,
                         'payload' => $transaction->payload,
                         'callback_payload' => null,
-                        'failure_reason' => $hasDuplicateSession ? 'Legacy duplicate merchant_session; original value remains on the transaction.' : null,
+                        'failure_reason' => $hasDuplicateAttemptSession ? 'Legacy duplicate local attempt_session; original SISP merchant_session remains on the attempt.' : null,
                         'submitted_at' => $transaction->created_at,
                         'callback_received_at' => $transaction->transaction_id !== null ? $transaction->updated_at : null,
-                        'superseded_at' => $hasDuplicateSession ? ($transaction->updated_at ?? now()) : null,
+                        'superseded_at' => $hasDuplicateAttemptSession ? ($transaction->updated_at ?? now()) : null,
                         'created_at' => $transaction->created_at,
                         'updated_at' => $transaction->updated_at,
                     ]);

--- a/database/migrations/update_sisp_transaction_attempts_for_local_sessions.php
+++ b/database/migrations/update_sisp_transaction_attempts_for_local_sessions.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $attemptsTable = config('sisp.tables.transaction_attempts', 'sisp_transaction_attempts');
+
+        if (! Schema::hasTable($attemptsTable)) {
+            return;
+        }
+
+        if (! Schema::hasColumn($attemptsTable, 'attempt_session')) {
+            Schema::table($attemptsTable, function (Blueprint $table): void {
+                $table->string('attempt_session')->nullable()->after('merchant_session');
+            });
+        }
+
+        if (Schema::hasIndex($attemptsTable, ['merchant_session'], 'unique')) {
+            Schema::table($attemptsTable, function (Blueprint $table): void {
+                $table->dropUnique(['merchant_session']);
+            });
+        }
+
+        if (Schema::hasIndex($attemptsTable, ['merchant_ref', 'merchant_session'], 'unique')) {
+            Schema::table($attemptsTable, function (Blueprint $table): void {
+                $table->dropUnique(['merchant_ref', 'merchant_session']);
+            });
+        }
+
+        if (! Schema::hasIndex($attemptsTable, ['merchant_ref', 'merchant_session'])) {
+            Schema::table($attemptsTable, function (Blueprint $table): void {
+                $table->index(['merchant_ref', 'merchant_session']);
+            });
+        }
+
+        if (! Schema::hasIndex($attemptsTable, ['attempt_session'])) {
+            Schema::table($attemptsTable, function (Blueprint $table): void {
+                $table->index('attempt_session');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $attemptsTable = config('sisp.tables.transaction_attempts', 'sisp_transaction_attempts');
+
+        if (! Schema::hasTable($attemptsTable) || ! Schema::hasColumn($attemptsTable, 'attempt_session')) {
+            return;
+        }
+
+        if (Schema::hasIndex($attemptsTable, ['attempt_session'])) {
+            Schema::table($attemptsTable, function (Blueprint $table): void {
+                $table->dropIndex(['attempt_session']);
+            });
+        }
+
+        Schema::table($attemptsTable, function (Blueprint $table): void {
+            $table->dropColumn('attempt_session');
+        });
+    }
+};

--- a/src/Actions/CreateIdempotentPaymentTransactionAction.php
+++ b/src/Actions/CreateIdempotentPaymentTransactionAction.php
@@ -7,8 +7,6 @@ namespace Akira\Sisp\Actions;
 use Akira\Sisp\Exceptions\PaymentIntentAlreadyProcessingException;
 use Akira\Sisp\Models\PaymentIntent;
 use Akira\Sisp\Models\Transaction;
-use Akira\Sisp\Models\TransactionAttempt;
-use Akira\Sisp\ValueObjects\PaymentRequest;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
 use Akira\Sisp\ValueObjects\PreparedPaymentTransaction;
 use Illuminate\Http\Request;
@@ -128,27 +126,7 @@ final readonly class CreateIdempotentPaymentTransactionAction
             );
         }
 
-        return new PreparedPaymentTransaction(
-            paymentRequest: $this->paymentRequestFrom($transaction, $paymentIntentKey),
-            transaction: $transaction,
-        );
-    }
-
-    private function paymentRequestFrom(Transaction $transaction, string $paymentIntentKey): PaymentRequest
-    {
-        $attempt = $transaction->currentAttempt()->first()
-            ?? $transaction->attempts()->latest('attempt_number')->first();
-
-        $payload = $attempt instanceof TransactionAttempt ? $attempt->payload : null;
-
-        if ($payload === null || $payload === []) {
-            $transactionPayload = $transaction->getAttribute('payload');
-            $payload = is_array($transactionPayload) ? $transactionPayload : null;
-        }
-
-        throw_if($payload === null || $payload === [], PaymentIntentAlreadyProcessingException::class, $paymentIntentKey);
-
-        return PaymentRequest::from($payload);
+        throw new PaymentIntentAlreadyProcessingException($paymentIntentKey);
     }
 
     private function submit(string $paymentIntentKey, Transaction $transaction): void

--- a/src/Actions/CreateRetryPaymentAttemptAction.php
+++ b/src/Actions/CreateRetryPaymentAttemptAction.php
@@ -34,7 +34,7 @@ final readonly class CreateRetryPaymentAttemptAction
                         ->lockForUpdate()
                         ->findOrFail($transaction->id);
 
-                    $paymentRequest = $this->retryPayment->handle($lockedTransaction, rotateMerchantSession: false);
+                    $paymentRequest = $this->retryPayment->handle($lockedTransaction);
                     $attemptSession = $this->nextLocalAttemptSession($lockedTransaction);
 
                     TransactionLogContext::run(

--- a/src/Actions/CreateRetryPaymentAttemptAction.php
+++ b/src/Actions/CreateRetryPaymentAttemptAction.php
@@ -4,14 +4,8 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
-use Akira\Sisp\Configuration\LoadConfig;
-use Akira\Sisp\Enums\TransactionStatus;
-use Akira\Sisp\Exceptions\UnableToGenerateUniquePaymentIdentifiersException;
 use Akira\Sisp\Models\Transaction;
-use Akira\Sisp\Support\TransactionLogContext;
-use Akira\Sisp\Support\UniqueConstraintViolation;
 use Akira\Sisp\ValueObjects\PaymentRequest;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 final readonly class CreateRetryPaymentAttemptAction
@@ -19,63 +13,36 @@ final readonly class CreateRetryPaymentAttemptAction
     public function __construct(
         private RetryPaymentAction $retryPayment,
         private CreateTransactionAttemptAction $createAttempt,
-        private LoadConfig $config,
     ) {}
 
     public function handle(Transaction $transaction): PaymentRequest
     {
-        $maxAttempts = $this->config->getIdentifierGenerationMaxAttempts();
-        $lastException = null;
+        /** @var Transaction $lockedTransaction */
+        $lockedTransaction = DB::transaction(function () use ($transaction): Transaction {
+            /** @var Transaction $lockedTransaction */
+            $lockedTransaction = Transaction::query()
+                ->lockForUpdate()
+                ->findOrFail($transaction->id);
 
-        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-            $paymentRequest = $this->retryPayment->handle($transaction->refresh());
+            $this->ensureCurrentAttemptExists($lockedTransaction);
 
-            try {
-                DB::transaction(function () use ($paymentRequest, $transaction): void {
-                    /** @var Transaction $lockedTransaction */
-                    $lockedTransaction = Transaction::query()
-                        ->lockForUpdate()
-                        ->findOrFail($transaction->id);
+            return $lockedTransaction;
+        }, attempts: 3);
 
-                    TransactionLogContext::run(
-                        'retry',
-                        function () use ($lockedTransaction, $paymentRequest): void {
-                            $this->createAttempt->handle($lockedTransaction, $paymentRequest, supersedeCurrent: true);
-
-                            $lockedTransaction->update([
-                                'merchant_session' => $paymentRequest->merchantSession,
-                                'transaction_id' => null,
-                                'message_type' => null,
-                                'merchant_response' => null,
-                                'response_code' => null,
-                                'fingerprint' => null,
-                                'status' => TransactionStatus::pending,
-                            ]);
-                        }
-                    );
-                }, attempts: 3);
-
-                return $paymentRequest;
-            } catch (QueryException $exception) {
-                throw_unless(UniqueConstraintViolation::causedBy($exception), $exception);
-
-                $lastException = $exception;
-
-                if ($attempt < $maxAttempts) {
-                    $this->waitForNextCandidate();
-                }
-            }
-        }
-
-        throw new UnableToGenerateUniquePaymentIdentifiersException($maxAttempts, $lastException);
+        return $this->retryPayment->handle($lockedTransaction, rotateMerchantSession: false);
     }
 
-    private function waitForNextCandidate(): void
+    private function ensureCurrentAttemptExists(Transaction $transaction): void
     {
-        $microseconds = $this->config->getIdentifierGenerationCollisionRetrySleepMicroseconds();
+        $exists = $transaction->attempts()
+            ->where('merchant_ref', $transaction->merchant_ref)
+            ->where('merchant_session', $transaction->merchant_session)
+            ->exists();
 
-        if ($microseconds > 0) {
-            \Illuminate\Support\Sleep::usleep($microseconds);
+        if ($exists) {
+            return;
         }
+
+        $this->createAttempt->createFromTransaction($transaction);
     }
 }

--- a/src/Actions/CreateRetryPaymentAttemptAction.php
+++ b/src/Actions/CreateRetryPaymentAttemptAction.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
+use Akira\Sisp\Configuration\LoadConfig;
+use Akira\Sisp\Exceptions\UnableToGenerateUniquePaymentIdentifiersException;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Support\TransactionLogContext;
+use Akira\Sisp\Support\UniqueConstraintViolation;
 use Akira\Sisp\ValueObjects\PaymentRequest;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 final readonly class CreateRetryPaymentAttemptAction
@@ -13,36 +18,78 @@ final readonly class CreateRetryPaymentAttemptAction
     public function __construct(
         private RetryPaymentAction $retryPayment,
         private CreateTransactionAttemptAction $createAttempt,
+        private LoadConfig $config,
     ) {}
 
     public function handle(Transaction $transaction): PaymentRequest
     {
-        /** @var Transaction $lockedTransaction */
-        $lockedTransaction = DB::transaction(function () use ($transaction): Transaction {
-            /** @var Transaction $lockedTransaction */
-            $lockedTransaction = Transaction::query()
-                ->lockForUpdate()
-                ->findOrFail($transaction->id);
+        $maxAttempts = $this->config->getIdentifierGenerationMaxAttempts();
+        $lastException = null;
 
-            $this->ensureCurrentAttemptExists($lockedTransaction);
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            try {
+                return DB::transaction(function () use ($transaction): PaymentRequest {
+                    /** @var Transaction $lockedTransaction */
+                    $lockedTransaction = Transaction::query()
+                        ->lockForUpdate()
+                        ->findOrFail($transaction->id);
 
-            return $lockedTransaction;
-        }, attempts: 3);
+                    $paymentRequest = $this->retryPayment->handle($lockedTransaction, rotateMerchantSession: false);
+                    $attemptSession = $this->nextLocalAttemptSession($lockedTransaction);
 
-        return $this->retryPayment->handle($lockedTransaction, rotateMerchantSession: false);
-    }
+                    TransactionLogContext::run(
+                        'retry',
+                        fn (): \Akira\Sisp\Models\TransactionAttempt => $this->createAttempt->handle(
+                            $lockedTransaction,
+                            $paymentRequest,
+                            supersedeCurrent: true,
+                            attemptSession: $attemptSession,
+                        )
+                    );
 
-    private function ensureCurrentAttemptExists(Transaction $transaction): void
-    {
-        $exists = $transaction->attempts()
-            ->where('merchant_ref', $transaction->merchant_ref)
-            ->where('merchant_session', $transaction->merchant_session)
-            ->exists();
+                    return $paymentRequest;
+                }, attempts: 3);
+            } catch (QueryException $exception) {
+                throw_unless(UniqueConstraintViolation::causedBy($exception), $exception);
 
-        if ($exists) {
-            return;
+                $lastException = $exception;
+
+                if ($attempt < $maxAttempts) {
+                    $this->waitForNextCandidate();
+                }
+            }
         }
 
-        $this->createAttempt->createFromTransaction($transaction);
+        throw new UnableToGenerateUniquePaymentIdentifiersException($maxAttempts, $lastException);
+    }
+
+    private function nextLocalAttemptSession(Transaction $transaction): string
+    {
+        $base = $this->config->getMerchantSession();
+        $candidate = $base;
+        $counter = 1;
+
+        while ($transaction->attempts()->where('attempt_session', $candidate)->exists()) {
+            $candidate = $this->suffixedAttemptSession($base, $transaction, $counter);
+            $counter++;
+        }
+
+        return $candidate;
+    }
+
+    private function suffixedAttemptSession(string $base, Transaction $transaction, int $counter): string
+    {
+        $suffix = '-try-'.$transaction->id.'-'.$counter;
+
+        return mb_substr($base, 0, 255 - mb_strlen($suffix)).$suffix;
+    }
+
+    private function waitForNextCandidate(): void
+    {
+        $microseconds = $this->config->getIdentifierGenerationCollisionRetrySleepMicroseconds();
+
+        if ($microseconds > 0) {
+            \Illuminate\Support\Sleep::usleep($microseconds);
+        }
     }
 }

--- a/src/Actions/CreateTransactionAttemptAction.php
+++ b/src/Actions/CreateTransactionAttemptAction.php
@@ -10,8 +10,12 @@ use Akira\Sisp\ValueObjects\PaymentRequest;
 
 final readonly class CreateTransactionAttemptAction
 {
-    public function handle(Transaction $transaction, PaymentRequest $paymentRequest, bool $supersedeCurrent = false): TransactionAttempt
-    {
+    public function handle(
+        Transaction $transaction,
+        PaymentRequest $paymentRequest,
+        bool $supersedeCurrent = false,
+        ?string $attemptSession = null,
+    ): TransactionAttempt {
         if ($supersedeCurrent) {
             $this->ensureCurrentAttemptExists($transaction);
 
@@ -24,6 +28,7 @@ final readonly class CreateTransactionAttemptAction
             'attempt_number' => $this->nextAttemptNumber($transaction),
             'merchant_ref' => $paymentRequest->merchantRef,
             'merchant_session' => $paymentRequest->merchantSession,
+            'attempt_session' => $attemptSession ?? $paymentRequest->merchantSession,
             'status' => 'pending',
             'payload' => $paymentRequest->toArray(),
             'submitted_at' => now(),
@@ -36,6 +41,7 @@ final readonly class CreateTransactionAttemptAction
             'attempt_number' => $this->nextAttemptNumber($transaction),
             'merchant_ref' => $transaction->merchant_ref,
             'merchant_session' => $transaction->merchant_session,
+            'attempt_session' => $transaction->merchant_session,
             'status' => $transaction->status->value,
             'gateway_transaction_id' => $transaction->transaction_id,
             'message_type' => $transaction->message_type,

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -14,10 +14,9 @@ final readonly class RetryPaymentAction
 
     public function __construct(private BuildRequestPayloadAction $buildRequestPayload) {}
 
-    public function handle(Transaction $transaction, bool $rotateMerchantSession = true): PaymentRequest
+    public function handle(Transaction $transaction): PaymentRequest
     {
-        $retryTransaction = $rotateMerchantSession ? $transaction->refresh() : $transaction;
-        $paymentRequestData = $this->extractFromTransaction($retryTransaction);
+        $paymentRequestData = $this->extractFromTransaction($transaction);
 
         return $this->buildRequestPayload->handle($paymentRequestData);
     }

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -28,7 +28,6 @@ final readonly class RetryPaymentAction
             amount: $transaction->amount,
             merchantRef: $transaction->merchant_ref,
             merchantSession: $this->merchantSession($transaction),
-            timeStamp: null,
             currency: $transaction->currency,
             transactionCode: $transaction->transaction_code,
             token: '',

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -16,17 +16,18 @@ final readonly class RetryPaymentAction
 
     public function handle(Transaction $transaction, bool $rotateMerchantSession = true): PaymentRequest
     {
-        $paymentRequestData = $this->extractFromTransaction($transaction, $rotateMerchantSession);
+        $retryTransaction = $rotateMerchantSession ? $transaction->refresh() : $transaction;
+        $paymentRequestData = $this->extractFromTransaction($retryTransaction);
 
         return $this->buildRequestPayload->handle($paymentRequestData);
     }
 
-    private function extractFromTransaction(Transaction $transaction, bool $rotateMerchantSession): PaymentRequestData
+    private function extractFromTransaction(Transaction $transaction): PaymentRequestData
     {
         return new PaymentRequestData(
             amount: $transaction->amount,
             merchantRef: $transaction->merchant_ref,
-            merchantSession: $rotateMerchantSession ? null : $this->merchantSession($transaction),
+            merchantSession: $this->merchantSession($transaction),
             timeStamp: null,
             currency: $transaction->currency,
             transactionCode: $transaction->transaction_code,

--- a/src/Actions/Transaction/FindTransactionAttemptAction.php
+++ b/src/Actions/Transaction/FindTransactionAttemptAction.php
@@ -54,7 +54,9 @@ final readonly class FindTransactionAttemptAction
     {
         $query = TransactionAttempt::query()
             ->where('merchant_ref', $payload->merchantRef)
-            ->where('merchant_session', $payload->merchantSession);
+            ->where('merchant_session', $payload->merchantSession)
+            ->orderByRaw('callback_received_at is not null')
+            ->orderByDesc('attempt_number');
 
         if ($lockForUpdate) {
             $query->lockForUpdate();

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -90,6 +90,7 @@ final readonly class CallbackController
         $attempt = TransactionAttempt::query()
             ->where('merchant_ref', $payload->merchantRef)
             ->where('merchant_session', $payload->merchantSession)
+            ->where('status', TransactionStatus::completed)
             ->first();
 
         if ($attempt instanceof TransactionAttempt) {

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Http\Controllers;
 use Akira\Sisp\Actions\RenderPaymentResponseBasedOnConfigAction;
 use Akira\Sisp\Actions\StoreRequestMetadataAction;
 use Akira\Sisp\Actions\UpdateInvoiceStatusAction;
+use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Models\TransactionAttempt;
@@ -92,7 +93,7 @@ final readonly class CallbackController
             ->first();
 
         if ($attempt instanceof TransactionAttempt) {
-            return $attempt->getAttribute('gateway_transaction_id') !== null;
+            return $attempt->status === TransactionStatus::completed;
         }
 
         $transaction = Transaction::query()
@@ -100,6 +101,6 @@ final readonly class CallbackController
             ->where('merchant_session', $payload->merchantSession)
             ->first();
 
-        return $transaction !== null && $transaction->getAttribute('transaction_id') !== null;
+        return $transaction instanceof Transaction && $transaction->status === TransactionStatus::completed;
     }
 }

--- a/src/Http/Controllers/RetryPaymentController.php
+++ b/src/Http/Controllers/RetryPaymentController.php
@@ -24,7 +24,7 @@ final readonly class RetryPaymentController
 
         if ($request->isMethod('get')) {
             return $this->renderForm->handle(
-                $this->retryPayment->handle($transaction, rotateMerchantSession: false),
+                $this->retryPayment->handle($transaction),
                 $transaction->locale,
             );
         }

--- a/src/Http/Middleware/EnforceSispRateLimits.php
+++ b/src/Http/Middleware/EnforceSispRateLimits.php
@@ -30,7 +30,6 @@ final readonly class EnforceSispRateLimits
                 $this->checkRateLimit->handle(
                     $ip,
                     'ip',
-                    context: null,
                     limit: (int) config('sisp.rate_limiting.per_ip.limit'),
                     windowSeconds: (int) config('sisp.rate_limiting.per_ip.window_seconds')
                 );

--- a/src/Models/TransactionAttempt.php
+++ b/src/Models/TransactionAttempt.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Carbon;
  * @property-read int $attempt_number
  * @property-read string $merchant_ref
  * @property-read string $merchant_session
+ * @property-read string|null $attempt_session
  * @property-read TransactionStatus $status
  * @property-read string|null $gateway_transaction_id
  * @property-read array<string, mixed>|null $payload
@@ -35,6 +36,7 @@ final class TransactionAttempt extends Model
         'attempt_number',
         'merchant_ref',
         'merchant_session',
+        'attempt_session',
         'status',
         'gateway_transaction_id',
         'message_type',

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -37,6 +37,7 @@ final class SispServiceProvider extends PackageServiceProvider
                 'update_laravel_sisp_transactions_add_amount_cents',
                 'create_sisp_transaction_logs_table',
                 'create_sisp_transaction_attempts_table',
+                'update_sisp_transaction_attempts_for_local_sessions',
                 'create_sisp_payment_intents_table',
             ])
             ->hasTranslations()

--- a/tests/Actions/FindTransactionAttemptActionTest.php
+++ b/tests/Actions/FindTransactionAttemptActionTest.php
@@ -42,3 +42,54 @@ it('reuses a backfilled legacy callback attempt', function (): void {
         ->and($firstAttempt->merchant_ref)->toBe('MR-LEGACY-CALLBACK')
         ->and($firstAttempt->merchant_session)->toBe('MS-LEGACY-CALLBACK');
 });
+
+it('uses the latest pending local attempt for callbacks on the same SISP transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-RETRIED-CALLBACK',
+        'merchant_session' => 'MS-SISP-CALLBACK',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'failed',
+    ]);
+
+    TransactionAttempt::factory()->create([
+        'transaction_id' => $transaction->id,
+        'attempt_number' => 1,
+        'merchant_ref' => 'MR-RETRIED-CALLBACK',
+        'merchant_session' => 'MS-SISP-CALLBACK',
+        'attempt_session' => 'MS-LOCAL-1',
+        'status' => 'failed',
+        'callback_received_at' => now(),
+        'superseded_at' => now(),
+    ]);
+
+    $latestAttempt = TransactionAttempt::factory()->create([
+        'transaction_id' => $transaction->id,
+        'attempt_number' => 2,
+        'merchant_ref' => 'MR-RETRIED-CALLBACK',
+        'merchant_session' => 'MS-SISP-CALLBACK',
+        'attempt_session' => 'MS-LOCAL-2',
+        'status' => 'pending',
+        'callback_received_at' => null,
+    ]);
+
+    $payload = new CallbackPayload(
+        merchantRef: 'MR-RETRIED-CALLBACK',
+        merchantSession: 'MS-SISP-CALLBACK',
+        timeStamp: '20240101010101',
+        amount: '30.00',
+        currency: '132',
+        transactionCode: '1',
+        transactionID: 'TID-RETRIED-CALLBACK',
+        messageType: '8',
+        merchantResponse: 'OK',
+        responseCode: '00',
+        fingerprint: 'fingerprint',
+        posID: 'POS1',
+    );
+
+    $attempt = resolve(FindTransactionAttemptAction::class)->handle($payload);
+
+    expect($attempt->is($latestAttempt))->toBeTrue();
+});

--- a/tests/Actions/RetryPaymentActionTest.php
+++ b/tests/Actions/RetryPaymentActionTest.php
@@ -37,9 +37,23 @@ it('includes all transaction details', function (): void {
     $paymentRequest = $this->action->handle($transaction);
 
     expect($paymentRequest->merchantRef)->toBe('CUSTOM-REF-123')
-        ->and($paymentRequest->merchantSession)->not->toBe('CUSTOM-SESS-456')
-        ->and($paymentRequest->merchantSession)->not->toBe('')
+        ->and($paymentRequest->merchantSession)->toBe('CUSTOM-SESS-456')
         ->and($paymentRequest->currency)->toBe('CVE');
+});
+
+it('keeps SISP identifiers when the legacy rotate flag is enabled', function (): void {
+    $transaction = Transaction::factory()->create([
+        'amount' => 25000.0,
+        'merchant_ref' => 'CUSTOM-REF-123',
+        'merchant_session' => 'CUSTOM-SESS-456',
+        'currency' => 'CVE',
+        'transaction_code' => '1',
+    ]);
+
+    $paymentRequest = $this->action->handle($transaction, rotateMerchantSession: true);
+
+    expect($paymentRequest->merchantRef)->toBe('CUSTOM-REF-123')
+        ->and($paymentRequest->merchantSession)->toBe('CUSTOM-SESS-456');
 });
 
 it('creates valid payment request with data from transaction', function (): void {

--- a/tests/Actions/RetryPaymentActionTest.php
+++ b/tests/Actions/RetryPaymentActionTest.php
@@ -41,21 +41,6 @@ it('includes all transaction details', function (): void {
         ->and($paymentRequest->currency)->toBe('CVE');
 });
 
-it('keeps SISP identifiers when the legacy rotate flag is enabled', function (): void {
-    $transaction = Transaction::factory()->create([
-        'amount' => 25000.0,
-        'merchant_ref' => 'CUSTOM-REF-123',
-        'merchant_session' => 'CUSTOM-SESS-456',
-        'currency' => 'CVE',
-        'transaction_code' => '1',
-    ]);
-
-    $paymentRequest = $this->action->handle($transaction, rotateMerchantSession: true);
-
-    expect($paymentRequest->merchantRef)->toBe('CUSTOM-REF-123')
-        ->and($paymentRequest->merchantSession)->toBe('CUSTOM-SESS-456');
-});
-
 it('creates valid payment request with data from transaction', function (): void {
     $transaction = Transaction::factory()->create([
         'amount' => 50000.0,

--- a/tests/Controllers/RetryPaymentControllerTest.php
+++ b/tests/Controllers/RetryPaymentControllerTest.php
@@ -46,7 +46,7 @@ it('opens signed retry links with get requests without mutating transactions', f
         ->and($t->fingerprint)->toBe('old-fingerprint');
 });
 
-it('updates merchant_session on transaction so callback can find it', function (): void {
+it('keeps the same SISP identifiers on retry so the gateway sees the same transaction', function (): void {
     $t = Transaction::factory()->create([
         'status' => 'failed',
         'merchant_ref' => 'MR-R2',
@@ -65,15 +65,14 @@ it('updates merchant_session on transaction so callback can find it', function (
 
     $t->refresh();
 
-    expect($t->merchant_session)
-        ->not->toBe('MS-OLD')
-        ->not->toBeEmpty()
-        ->and($t->status->value)->toBe('pending')
-        ->and($t->transaction_id)->toBeNull()
-        ->and($t->message_type)->toBeNull()
-        ->and($t->merchant_response)->toBeNull()
-        ->and($t->response_code)->toBeNull()
-        ->and($t->fingerprint)->toBeNull();
+    expect($t->merchant_ref)->toBe('MR-R2')
+        ->and($t->merchant_session)->toBe('MS-OLD')
+        ->and($t->status->value)->toBe('failed')
+        ->and($t->transaction_id)->toBe('OLD-TID')
+        ->and($t->message_type)->toBe('13')
+        ->and($t->merchant_response)->toBe('old failure')
+        ->and($t->response_code)->toBe('13')
+        ->and($t->fingerprint)->toBe('old-fingerprint');
 });
 
 it('does not reset completed transactions through signed retry links', function (): void {

--- a/tests/Http/Middleware/PreventDuplicateCallbackTest.php
+++ b/tests/Http/Middleware/PreventDuplicateCallbackTest.php
@@ -12,6 +12,7 @@ it('redirects duplicate callback requests after validation', function (): void {
     Transaction::factory()->create([
         'merchant_ref' => 'MR-CB-DUP',
         'merchant_session' => 'MS-CB-DUP',
+        'status' => 'completed',
         'transaction_id' => 'T-EXISTS',
     ]);
 

--- a/tests/Http/RetryPaymentControllerTest.php
+++ b/tests/Http/RetryPaymentControllerTest.php
@@ -10,6 +10,7 @@ it('retries payment for an existing transaction', function (): void {
         'amount' => 123.0,
         'currency' => '132',
         'status' => 'failed',
+        'merchant_ref' => 'retry-reference',
         'merchant_session' => 'old-session',
         'transaction_code' => '1',
     ]);
@@ -19,8 +20,8 @@ it('retries payment for an existing transaction', function (): void {
 
     $t->refresh();
 
-    expect($t->merchant_session)->not->toBe('old-session')
-        ->and($t->merchant_session)->not->toBe('')
+    expect($t->merchant_ref)->toBe('retry-reference')
+        ->and($t->merchant_session)->toBe('old-session')
         ->and($t->amount)->toBe(123.0)
         ->and($t->currency)->toBe('132')
         ->and($t->status->value)->toBe('failed');

--- a/tests/Http/SispPaymentFlowIntegrationTest.php
+++ b/tests/Http/SispPaymentFlowIntegrationTest.php
@@ -144,11 +144,12 @@ it('runs a failed payment flow and exposes signed retry without paying the invoi
         ->assertSee('/sisp/retry-payment', false);
 });
 
-it('runs retry through the signed public route and refreshes payment identifiers', function (): void {
+it('runs retry through the signed public route with the same SISP identifiers', function (): void {
     $transaction = Transaction::factory()->create([
         'amount' => 123.0,
         'currency' => '132',
         'status' => 'failed',
+        'merchant_ref' => 'retry-reference',
         'merchant_session' => 'old-session',
         'transaction_code' => '1',
         'locale' => 'pt',
@@ -165,8 +166,8 @@ it('runs retry through the signed public route and refreshes payment identifiers
 
     $transaction->refresh();
 
-    expect($transaction->merchant_session)->not->toBe('old-session')
-        ->and($transaction->merchant_session)->not->toBe('');
+    expect($transaction->merchant_ref)->toBe('retry-reference')
+        ->and($transaction->merchant_session)->toBe('old-session');
 });
 
 it('runs authorized full refund through the public route', function (): void {
@@ -175,6 +176,8 @@ it('runs authorized full refund through the public route', function (): void {
     $transaction = Transaction::factory()->create([
         'status' => 'completed',
         'amount' => 90.0,
+        'transaction_id' => 'PAID-TID',
+        'response_code' => '5',
         'customer_email' => 'buyer@example.test',
     ]);
 

--- a/tests/Http/TransactionAttemptsTest.php
+++ b/tests/Http/TransactionAttemptsTest.php
@@ -26,18 +26,6 @@ final class ConstantMerchantSessionGenerator
     }
 }
 
-final class IncrementingMerchantSessionGenerator
-{
-    private static int $count = 0;
-
-    public function __invoke(): string
-    {
-        self::$count++;
-
-        return 'MS-INCREMENTING-'.self::$count;
-    }
-}
-
 final class ReferenceCollisionMerchantSessionGenerator
 {
     private static int $count = 0;
@@ -76,7 +64,7 @@ it('creates an auditable first attempt when a payment transaction is created', f
         ->and($attempt->payload)->toBeArray();
 });
 
-it('reuses an existing pending transaction when the checkout intent is posted twice', function (): void {
+it('rejects an existing pending transaction when the checkout intent is posted twice', function (): void {
     $payload = transaction_attempt_payment_payload([
         'checkout_intent_id' => 'checkout-intent-duplicate',
     ]);
@@ -86,9 +74,11 @@ it('reuses an existing pending transaction when the checkout intent is posted tw
 
     $transaction = Transaction::query()->sole();
 
-    $this->post(route('sisp.payment'), $payload)
-        ->assertOk()
-        ->assertSee($transaction->merchant_ref);
+    $this->postJson(route('sisp.payment'), $payload)
+        ->assertConflict()
+        ->assertJson([
+            'message' => __('sisp::messages.validation.payment_in_progress'),
+        ]);
 
     expect(Transaction::query()->count())->toBe(1)
         ->and(TransactionAttempt::query()->count())->toBe(1)
@@ -96,11 +86,7 @@ it('reuses an existing pending transaction when the checkout intent is posted tw
         ->and(PaymentIntent::query()->sole()->transaction_id)->toBe($transaction->id);
 });
 
-it('creates a retry attempt for the same transaction when a failed checkout intent is posted again', function (): void {
-    config([
-        'sisp.generators.merchantSession' => IncrementingMerchantSessionGenerator::class,
-    ]);
-
+it('reuses the same SISP identifiers when a failed checkout intent is posted again', function (): void {
     $payload = transaction_attempt_payment_payload([
         'idempotency_key' => 'checkout-intent-retry',
     ]);
@@ -109,6 +95,7 @@ it('creates a retry attempt for the same transaction when a failed checkout inte
         ->assertOk();
 
     $transaction = Transaction::query()->sole();
+    $oldRef = $transaction->merchant_ref;
     $oldSession = $transaction->merchant_session;
 
     $transaction->update([
@@ -121,20 +108,22 @@ it('creates a retry attempt for the same transaction when a failed checkout inte
     ]);
 
     $this->post(route('sisp.payment'), $payload)
-        ->assertOk();
+        ->assertOk()
+        ->assertSee($oldRef);
 
     $transaction->refresh();
     $attempts = $transaction->attempts()->orderBy('attempt_number')->get();
 
     expect(Transaction::query()->count())->toBe(1)
         ->and(PaymentIntent::query()->sole()->transaction_id)->toBe($transaction->id)
-        ->and($attempts)->toHaveCount(2)
+        ->and($attempts)->toHaveCount(1)
+        ->and($attempts[0]->merchant_ref)->toBe($oldRef)
         ->and($attempts[0]->merchant_session)->toBe($oldSession)
-        ->and($attempts[0]->superseded_at)->not->toBeNull()
-        ->and($attempts[1]->merchant_ref)->toBe($transaction->merchant_ref)
-        ->and($attempts[1]->merchant_session)->toBe($transaction->merchant_session)
-        ->and($transaction->status->value)->toBe('pending')
-        ->and($transaction->transaction_id)->toBeNull();
+        ->and($attempts[0]->superseded_at)->toBeNull()
+        ->and($transaction->merchant_ref)->toBe($oldRef)
+        ->and($transaction->merchant_session)->toBe($oldSession)
+        ->and($transaction->status->value)->toBe('failed')
+        ->and($transaction->transaction_id)->toBe('FAILED-GATEWAY-ID');
 });
 
 it('rejects a duplicate checkout intent while the first request is still being reserved', function (): void {
@@ -222,7 +211,7 @@ it('fails without persisting a duplicate when only the merchant reference keeps 
         ->and(TransactionAttempt::query()->count())->toBe(1);
 });
 
-it('creates a new attempt on retry while preserving the old session for audit', function (): void {
+it('renders retry with the same SISP identifiers', function (): void {
     $transaction = Transaction::factory()->create([
         'status' => 'failed',
         'merchant_ref' => 'MR-RETRY-ATTEMPT',
@@ -237,68 +226,43 @@ it('creates a new attempt on retry while preserving the old session for audit', 
     $transaction->refresh();
     $attempts = $transaction->attempts()->orderBy('attempt_number')->get();
 
-    expect($attempts)->toHaveCount(2)
+    expect($attempts)->toHaveCount(1)
+        ->and($transaction->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
+        ->and($transaction->merchant_session)->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[0]->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
         ->and($attempts[0]->merchant_session)->toBe('MS-OLD-ATTEMPT')
-        ->and($attempts[0]->superseded_at)->not->toBeNull()
-        ->and($attempts[1]->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
-        ->and($attempts[1]->merchant_session)->toBe($transaction->merchant_session)
-        ->and($attempts[1]->superseded_at)->toBeNull();
+        ->and($attempts[0]->superseded_at)->toBeNull();
 });
 
-it('records a late failed callback for an old attempt without overwriting the current retry attempt', function (): void {
+it('allows a later successful callback for the same SISP transaction after a failed callback', function (): void {
+    config()->set('sisp.sandbox', true);
+
     $transaction = Transaction::factory()->create([
         'status' => 'failed',
-        'merchant_ref' => 'MR-LATE-FAILED',
-        'merchant_session' => 'MS-LATE-OLD',
+        'merchant_ref' => 'MR-SAME-SISP-RETRY',
+        'merchant_session' => 'MS-SAME-SISP-RETRY',
         'amount' => 30.0,
         'currency' => '132',
         'transaction_code' => '1',
+        'transaction_id' => 'FAILED-GATEWAY-ID',
+        'message_type' => '13',
     ]);
 
     $this->post(signed_attempt_retry_url($transaction))->assertOk();
 
-    $transaction->refresh();
-    $currentSession = $transaction->merchant_session;
-
-    $payload = transaction_attempt_callback_payload($transaction, 'MS-LATE-OLD', 'failed');
+    $payload = transaction_attempt_callback_payload($transaction->refresh(), 'MS-SAME-SISP-RETRY', 'success');
 
     $this->post(route('sisp.callback'), $payload)
-        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-LATE-FAILED']));
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-SAME-SISP-RETRY']));
 
     $transaction->refresh();
-    $oldAttempt = $transaction->attempts()->where('merchant_session', 'MS-LATE-OLD')->firstOrFail();
+    $attempt = $transaction->attempts()->where('merchant_session', 'MS-SAME-SISP-RETRY')->firstOrFail();
 
-    expect($oldAttempt->status->value)->toBe('failed')
-        ->and($oldAttempt->gateway_transaction_id)->not->toBeNull()
-        ->and($transaction->status->value)->toBe('pending')
-        ->and($transaction->merchant_session)->toBe($currentSession)
-        ->and($transaction->transaction_id)->toBeNull();
-});
-
-it('promotes a late successful callback for an old attempt to the transaction', function (): void {
-    $transaction = Transaction::factory()->create([
-        'status' => 'failed',
-        'merchant_ref' => 'MR-LATE-SUCCESS',
-        'merchant_session' => 'MS-LATE-SUCCESS-OLD',
-        'amount' => 30.0,
-        'currency' => '132',
-        'transaction_code' => '1',
-    ]);
-
-    $this->post(signed_attempt_retry_url($transaction))->assertOk();
-
-    $payload = transaction_attempt_callback_payload($transaction, 'MS-LATE-SUCCESS-OLD', 'success');
-
-    $this->post(route('sisp.callback'), $payload)
-        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-LATE-SUCCESS']));
-
-    $transaction->refresh();
-    $oldAttempt = $transaction->attempts()->where('merchant_session', 'MS-LATE-SUCCESS-OLD')->firstOrFail();
-
-    expect($oldAttempt->status->value)->toBe('completed')
+    expect($attempt->status->value)->toBe('completed')
         ->and($transaction->status->value)->toBe('completed')
-        ->and($transaction->merchant_session)->toBe('MS-LATE-SUCCESS-OLD')
-        ->and($transaction->transaction_id)->toBe($oldAttempt->gateway_transaction_id);
+        ->and($transaction->merchant_ref)->toBe('MR-SAME-SISP-RETRY')
+        ->and($transaction->merchant_session)->toBe('MS-SAME-SISP-RETRY')
+        ->and($transaction->transaction_id)->toBe($attempt->gateway_transaction_id);
 });
 
 function transaction_attempt_payment_payload(array $overrides = []): array

--- a/tests/Http/TransactionAttemptsTest.php
+++ b/tests/Http/TransactionAttemptsTest.php
@@ -3,12 +3,9 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Exceptions\UnableToGenerateUniquePaymentIdentifiersException;
-use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\PaymentIntent;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Models\TransactionAttempt;
-use Akira\Sisp\ValueObjects\PaymentRequestData;
-use Illuminate\Support\Facades\URL;
 
 final class ConstantMerchantReferenceGenerator
 {
@@ -60,6 +57,7 @@ it('creates an auditable first attempt when a payment transaction is created', f
         ->and($attempt->attempt_number)->toBe(1)
         ->and($attempt->merchant_ref)->toBe($transaction->merchant_ref)
         ->and($attempt->merchant_session)->toBe($transaction->merchant_session)
+        ->and($attempt->attempt_session)->toBe($transaction->merchant_session)
         ->and($attempt->status->value)->toBe('pending')
         ->and($attempt->payload)->toBeArray();
 });
@@ -116,10 +114,16 @@ it('reuses the same SISP identifiers when a failed checkout intent is posted aga
 
     expect(Transaction::query()->count())->toBe(1)
         ->and(PaymentIntent::query()->sole()->transaction_id)->toBe($transaction->id)
-        ->and($attempts)->toHaveCount(1)
+        ->and($attempts)->toHaveCount(2)
         ->and($attempts[0]->merchant_ref)->toBe($oldRef)
         ->and($attempts[0]->merchant_session)->toBe($oldSession)
-        ->and($attempts[0]->superseded_at)->toBeNull()
+        ->and($attempts[0]->attempt_session)->toBe($oldSession)
+        ->and($attempts[0]->superseded_at)->not->toBeNull()
+        ->and($attempts[1]->merchant_ref)->toBe($oldRef)
+        ->and($attempts[1]->merchant_session)->toBe($oldSession)
+        ->and($attempts[1]->attempt_session)->not->toBe($oldSession)
+        ->and($attempts[1]->payload['merchantSession'])->toBe($oldSession)
+        ->and($attempts[1]->superseded_at)->toBeNull()
         ->and($transaction->merchant_ref)->toBe($oldRef)
         ->and($transaction->merchant_session)->toBe($oldSession)
         ->and($transaction->status->value)->toBe('failed')
@@ -211,60 +215,6 @@ it('fails without persisting a duplicate when only the merchant reference keeps 
         ->and(TransactionAttempt::query()->count())->toBe(1);
 });
 
-it('renders retry with the same SISP identifiers', function (): void {
-    $transaction = Transaction::factory()->create([
-        'status' => 'failed',
-        'merchant_ref' => 'MR-RETRY-ATTEMPT',
-        'merchant_session' => 'MS-OLD-ATTEMPT',
-        'amount' => 30.0,
-        'currency' => '132',
-    ]);
-
-    $this->post(signed_attempt_retry_url($transaction))
-        ->assertOk();
-
-    $transaction->refresh();
-    $attempts = $transaction->attempts()->orderBy('attempt_number')->get();
-
-    expect($attempts)->toHaveCount(1)
-        ->and($transaction->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
-        ->and($transaction->merchant_session)->toBe('MS-OLD-ATTEMPT')
-        ->and($attempts[0]->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
-        ->and($attempts[0]->merchant_session)->toBe('MS-OLD-ATTEMPT')
-        ->and($attempts[0]->superseded_at)->toBeNull();
-});
-
-it('allows a later successful callback for the same SISP transaction after a failed callback', function (): void {
-    config()->set('sisp.sandbox', true);
-
-    $transaction = Transaction::factory()->create([
-        'status' => 'failed',
-        'merchant_ref' => 'MR-SAME-SISP-RETRY',
-        'merchant_session' => 'MS-SAME-SISP-RETRY',
-        'amount' => 30.0,
-        'currency' => '132',
-        'transaction_code' => '1',
-        'transaction_id' => 'FAILED-GATEWAY-ID',
-        'message_type' => '13',
-    ]);
-
-    $this->post(signed_attempt_retry_url($transaction))->assertOk();
-
-    $payload = transaction_attempt_callback_payload($transaction->refresh(), 'MS-SAME-SISP-RETRY', 'success');
-
-    $this->post(route('sisp.callback'), $payload)
-        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-SAME-SISP-RETRY']));
-
-    $transaction->refresh();
-    $attempt = $transaction->attempts()->where('merchant_session', 'MS-SAME-SISP-RETRY')->firstOrFail();
-
-    expect($attempt->status->value)->toBe('completed')
-        ->and($transaction->status->value)->toBe('completed')
-        ->and($transaction->merchant_ref)->toBe('MR-SAME-SISP-RETRY')
-        ->and($transaction->merchant_session)->toBe('MS-SAME-SISP-RETRY')
-        ->and($transaction->transaction_id)->toBe($attempt->gateway_transaction_id);
-});
-
 function transaction_attempt_payment_payload(array $overrides = []): array
 {
     return array_replace_recursive([
@@ -278,25 +228,4 @@ function transaction_attempt_payment_payload(array $overrides = []): array
         'customer_name' => 'Buyer',
         'customer_email' => 'buyer@example.test',
     ], $overrides);
-}
-
-function signed_attempt_retry_url(Transaction $transaction): string
-{
-    return URL::temporarySignedRoute(
-        'sisp.retry-payment',
-        now()->addMinutes(30),
-        ['transaction' => $transaction->id],
-    );
-}
-
-function transaction_attempt_callback_payload(Transaction $transaction, string $merchantSession, string $status): array
-{
-    return Sisp::generateSandboxPayload(PaymentRequestData::from([
-        'amount' => $transaction->amount,
-        'merchantRef' => $transaction->merchant_ref,
-        'merchantSession' => $merchantSession,
-        'timeStamp' => '2024-01-01 00:00:00',
-        'currency' => $transaction->currency,
-        'transactionCode' => $transaction->transaction_code ?? '1',
-    ]), $status)->toArray();
 }

--- a/tests/Http/TransactionRetryAttemptsTest.php
+++ b/tests/Http/TransactionRetryAttemptsTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Models\TransactionAttempt;
+use Akira\Sisp\ValueObjects\PaymentRequestData;
+use Illuminate\Support\Facades\URL;
+
+it('renders retry with the same SISP identifiers', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_ref' => 'MR-RETRY-ATTEMPT',
+        'merchant_session' => 'MS-OLD-ATTEMPT',
+        'amount' => 30.0,
+        'currency' => '132',
+    ]);
+
+    $this->post(signed_transaction_retry_url($transaction))
+        ->assertOk();
+
+    $transaction->refresh();
+    $attempts = $transaction->attempts()->orderBy('attempt_number')->get();
+
+    expect($attempts)->toHaveCount(2)
+        ->and($transaction->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
+        ->and($transaction->merchant_session)->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[0]->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
+        ->and($attempts[0]->merchant_session)->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[0]->attempt_session)->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[0]->superseded_at)->not->toBeNull()
+        ->and($attempts[1]->merchant_ref)->toBe('MR-RETRY-ATTEMPT')
+        ->and($attempts[1]->merchant_session)->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[1]->attempt_session)->not->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[1]->payload['merchantSession'])->toBe('MS-OLD-ATTEMPT')
+        ->and($attempts[1]->superseded_at)->toBeNull();
+});
+
+it('persists every local retry while sending the original SISP transaction identity', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_ref' => 'MR-FIVE-RETRIES',
+        'merchant_session' => 'MS-SISP-ORIGINAL',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_id' => 'FAILED-GATEWAY-ID',
+        'message_type' => '13',
+    ]);
+
+    TransactionAttempt::factory()->create([
+        'transaction_id' => $transaction->id,
+        'attempt_number' => 1,
+        'merchant_ref' => 'MR-FIVE-RETRIES',
+        'merchant_session' => 'MS-SISP-ORIGINAL',
+        'attempt_session' => 'MS-SISP-ORIGINAL',
+        'status' => 'failed',
+        'gateway_transaction_id' => 'FAILED-GATEWAY-ID',
+        'callback_received_at' => now(),
+    ]);
+
+    for ($retry = 0; $retry < 5; $retry++) {
+        $this->post(signed_transaction_retry_url($transaction))->assertOk();
+    }
+
+    $transaction->refresh();
+    $attempts = $transaction->attempts()->orderBy('attempt_number')->get();
+    $attemptSessions = $attempts->pluck('attempt_session')->all();
+
+    expect($attempts)->toHaveCount(6)
+        ->and($attempts->pluck('merchant_ref')->unique()->values()->all())->toBe(['MR-FIVE-RETRIES'])
+        ->and($attempts->pluck('merchant_session')->unique()->values()->all())->toBe(['MS-SISP-ORIGINAL'])
+        ->and(array_unique($attemptSessions))->toHaveCount(6)
+        ->and($attempts->skip(1)->pluck('payload')->pluck('merchantSession')->unique()->values()->all())->toBe(['MS-SISP-ORIGINAL'])
+        ->and($attempts->last()->superseded_at)->toBeNull()
+        ->and($transaction->merchant_ref)->toBe('MR-FIVE-RETRIES')
+        ->and($transaction->merchant_session)->toBe('MS-SISP-ORIGINAL')
+        ->and($transaction->status->value)->toBe('failed')
+        ->and($transaction->transaction_id)->toBe('FAILED-GATEWAY-ID');
+});
+
+it('allows a later successful callback for the same SISP transaction after a failed callback', function (): void {
+    config()->set('sisp.sandbox', true);
+
+    $transaction = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_ref' => 'MR-SAME-SISP-RETRY',
+        'merchant_session' => 'MS-SAME-SISP-RETRY',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'transaction_id' => 'FAILED-GATEWAY-ID',
+        'message_type' => '13',
+    ]);
+
+    $this->post(signed_transaction_retry_url($transaction))->assertOk();
+
+    $payload = transaction_retry_callback_payload($transaction->refresh(), 'MS-SAME-SISP-RETRY', 'success');
+
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-SAME-SISP-RETRY']));
+
+    $transaction->refresh();
+    $attempt = $transaction->attempts()
+        ->where('merchant_session', 'MS-SAME-SISP-RETRY')
+        ->orderByDesc('attempt_number')
+        ->firstOrFail();
+
+    expect($attempt->status->value)->toBe('completed')
+        ->and($transaction->status->value)->toBe('completed')
+        ->and($transaction->merchant_ref)->toBe('MR-SAME-SISP-RETRY')
+        ->and($transaction->merchant_session)->toBe('MS-SAME-SISP-RETRY')
+        ->and($transaction->transaction_id)->toBe($attempt->gateway_transaction_id);
+});
+
+function signed_transaction_retry_url(Transaction $transaction): string
+{
+    return URL::temporarySignedRoute(
+        'sisp.retry-payment',
+        now()->addMinutes(30),
+        ['transaction' => $transaction->id],
+    );
+}
+
+function transaction_retry_callback_payload(Transaction $transaction, string $merchantSession, string $status): array
+{
+    return Sisp::generateSandboxPayload(PaymentRequestData::from([
+        'amount' => $transaction->amount,
+        'merchantRef' => $transaction->merchant_ref,
+        'merchantSession' => $merchantSession,
+        'timeStamp' => '2024-01-01 00:00:00',
+        'currency' => $transaction->currency,
+        'transactionCode' => $transaction->transaction_code ?? '1',
+    ]), $status)->toArray();
+}

--- a/tests/Migrations/TransactionAttemptsMigrationTest.php
+++ b/tests/Migrations/TransactionAttemptsMigrationTest.php
@@ -50,8 +50,10 @@ it('backfills legacy duplicate identifiers without blocking the attempts migrati
         ->and($attempts)->toHaveCount(2)
         ->and($attempts[0]->merchant_ref)->toBe('MR-LEGACY-DUPLICATE')
         ->and($attempts[0]->merchant_session)->toBe('MS-LEGACY-DUPLICATE')
+        ->and($attempts[0]->attempt_session)->toBe('MS-LEGACY-DUPLICATE')
         ->and($attempts[0]->superseded_at)->toBeNull()
         ->and($attempts[1]->merchant_ref)->toBe('MR-LEGACY-DUPLICATE')
-        ->and($attempts[1]->merchant_session)->toContain('MS-LEGACY-DUPLICATE-legacy-')
+        ->and($attempts[1]->merchant_session)->toBe('MS-LEGACY-DUPLICATE')
+        ->and($attempts[1]->attempt_session)->toContain('MS-LEGACY-DUPLICATE-legacy-')
         ->and($attempts[1]->superseded_at)->not->toBeNull();
 });

--- a/tests/ValueObjects/PaymentRequestDataTest.php
+++ b/tests/ValueObjects/PaymentRequestDataTest.php
@@ -169,10 +169,7 @@ it('reports missing three d secure fields', function (): void {
     $data = new PaymentRequestData(
         amount: 120.00,
         customerEmail: 'customer@example.com',
-        customerCountry: null,
         customerCity: 'Lisbon',
-        customerAddress: null,
-        customerPostalCode: null,
     );
 
     expect($data->hasThreeDSecureData())->toBeFalse()
@@ -186,9 +183,7 @@ it('reports missing three d secure fields', function (): void {
 it('reports missing email and city for three d secure data', function (): void {
     $data = new PaymentRequestData(
         amount: 120.00,
-        customerEmail: null,
         customerCountry: 'PT',
-        customerCity: null,
         customerAddress: 'Rua Augusta',
         customerPostalCode: '1100-048',
     );


### PR DESCRIPTION
Summary: blocks repeated submitted idempotency keys from re-rendering the SISP form; keeps retry on the same merchant reference and merchant session so SISP sees the same transaction; allows later callbacks for the same SISP identity to correct failed payments. Tests: composer test.