### PR TITLE
fix(payments): avoid Swoole defer collision

### DIFF
--- a/src/Actions/CreateAndStorePaymentTransactionAction.php
+++ b/src/Actions/CreateAndStorePaymentTransactionAction.php
@@ -17,6 +17,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Throwable;
 
+use function Illuminate\Support\defer;
+
 final readonly class CreateAndStorePaymentTransactionAction
 {
     public function __construct(

--- a/tests/Actions/CreateAndStorePaymentTransactionActionTest.php
+++ b/tests/Actions/CreateAndStorePaymentTransactionActionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\CreateAndStorePaymentTransactionAction;
+
+it('uses Laravel defer helper explicitly when scheduling invoice generation', function (): void {
+    $reflection = new ReflectionClass(CreateAndStorePaymentTransactionAction::class);
+    $fileName = $reflection->getFileName();
+
+    expect($fileName)->toBeString();
+
+    $source = file_get_contents((string) $fileName);
+
+    expect($source)->toBeString()
+        ->and($source)->toContain('use function Illuminate\Support\defer;')
+        ->and($source)->toContain('defer(');
+});


### PR DESCRIPTION
## Summary
- call Laravel's namespaced defer helper when scheduling invoice generation
- add regression coverage so the payment flow does not fall back to a global defer function

## Validation
- composer test with PHP 8.4