### PR TITLE
fix(payments): honor disabled tracking flags

### DIFF
--- a/src/Actions/CreateAndStorePaymentTransactionAction.php
+++ b/src/Actions/CreateAndStorePaymentTransactionAction.php
@@ -31,12 +31,12 @@ final readonly class CreateAndStorePaymentTransactionAction
     /**
      * @throws Throwable
      */
-    public function handle(PaymentRequest $paymentRequest, Request $request): Transaction
+    public function handle(PaymentRequest $paymentRequest, Request $request, bool $recordAttempt = true): Transaction
     {
         try {
-            return DB::transaction(function () use ($paymentRequest, $request): Transaction {
+            return DB::transaction(function () use ($paymentRequest, $recordAttempt, $request): Transaction {
 
-                $transaction = $this->storeTransaction->handle($paymentRequest);
+                $transaction = $this->storeTransaction->handle($paymentRequest, $recordAttempt);
 
                 $customerData = CustomerData::from($request->all());
 

--- a/src/Actions/CreateIdempotentPaymentTransactionAction.php
+++ b/src/Actions/CreateIdempotentPaymentTransactionAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Actions;
 
+use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Exceptions\PaymentIntentAlreadyProcessingException;
 use Akira\Sisp\Models\PaymentIntent;
 use Akira\Sisp\Models\Transaction;
@@ -19,6 +20,7 @@ final readonly class CreateIdempotentPaymentTransactionAction
         private CreateUniquePaymentTransactionAction $createPayment,
         private CreateRetryPaymentAttemptAction $createRetryAttempt,
         private CanRetryPaymentAction $canRetryPayment,
+        private LoadConfig $config,
     ) {}
 
     /**
@@ -51,25 +53,11 @@ final readonly class CreateIdempotentPaymentTransactionAction
 
     private function paymentIntentKey(Request $request): ?string
     {
-        if (! (bool) config('sisp.idempotency.enabled', true)) {
+        if (! $this->config->isIdempotencyEnabled()) {
             return null;
         }
 
-        $keys = config('sisp.idempotency.request_keys', ['idempotency_key', 'checkout_intent_id']);
-
-        if (! is_array($keys)) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            if (! is_string($key)) {
-                continue;
-            }
-
-            if ($key === '') {
-                continue;
-            }
-
+        foreach ($this->config->getIdempotencyRequestKeys() as $key) {
             $value = $request->input($key);
 
             if (is_string($value) && mb_trim($value) !== '') {

--- a/src/Actions/CreateIdempotentPaymentTransactionAction.php
+++ b/src/Actions/CreateIdempotentPaymentTransactionAction.php
@@ -53,10 +53,6 @@ final readonly class CreateIdempotentPaymentTransactionAction
 
     private function paymentIntentKey(Request $request): ?string
     {
-        if (! $this->config->isIdempotencyEnabled()) {
-            return null;
-        }
-
         foreach ($this->config->getIdempotencyRequestKeys() as $key) {
             $value = $request->input($key);
 

--- a/src/Actions/CreateTransactionAction.php
+++ b/src/Actions/CreateTransactionAction.php
@@ -15,10 +15,10 @@ final readonly class CreateTransactionAction
 {
     public function __construct(private CreateTransactionAttemptAction $createAttempt) {}
 
-    public function handle(TransactionData $data): Transaction
+    public function handle(TransactionData $data, bool $recordAttempt = true): Transaction
     {
         try {
-            return DB::transaction(function () use ($data): Transaction {
+            return DB::transaction(function () use ($data, $recordAttempt): Transaction {
                 $transaction = Transaction::query()->create([
                     'merchant_ref' => $data->merchantRef,
                     'merchant_session' => $data->merchantSession,
@@ -30,7 +30,9 @@ final readonly class CreateTransactionAction
                     'locale' => $data->locale,
                 ]);
 
-                $this->createAttempt->createFromTransaction($transaction);
+                if ($recordAttempt) {
+                    $this->createAttempt->createFromTransaction($transaction);
+                }
 
                 return $transaction;
             }, attempts: 3);

--- a/src/Actions/CreateUniquePaymentTransactionAction.php
+++ b/src/Actions/CreateUniquePaymentTransactionAction.php
@@ -19,7 +19,7 @@ final readonly class CreateUniquePaymentTransactionAction
         private LoadConfig $config,
     ) {}
 
-    public function handle(PaymentRequestData $data, Request $request): PreparedPaymentTransaction
+    public function handle(PaymentRequestData $data, Request $request, bool $recordAttempt = true): PreparedPaymentTransaction
     {
         $maxAttempts = $this->maxAttempts();
         $lastException = null;
@@ -30,7 +30,7 @@ final readonly class CreateUniquePaymentTransactionAction
             try {
                 return new PreparedPaymentTransaction(
                     paymentRequest: $paymentRequest,
-                    transaction: $this->createTransaction->handle($paymentRequest, $request),
+                    transaction: $this->createTransaction->handle($paymentRequest, $request, $recordAttempt),
                 );
             } catch (DuplicatePaymentIdentifierException $exception) {
                 $lastException = $exception;

--- a/src/Actions/StorePaymentTransactionAction.php
+++ b/src/Actions/StorePaymentTransactionAction.php
@@ -14,7 +14,7 @@ final readonly class StorePaymentTransactionAction
         private CreateTransactionAction $createTransaction,
     ) {}
 
-    public function handle(PaymentRequest $paymentRequest): Transaction
+    public function handle(PaymentRequest $paymentRequest, bool $recordAttempt = true): Transaction
     {
         $transactionData = TransactionData::from([
             'merchantRef' => $paymentRequest->merchantRef,
@@ -26,6 +26,6 @@ final readonly class StorePaymentTransactionAction
             'locale' => $paymentRequest->locale,
         ]);
 
-        return $this->createTransaction->handle($transactionData);
+        return $this->createTransaction->handle($transactionData, $recordAttempt);
     }
 }

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -197,6 +197,21 @@ final readonly class LoadConfig
         return $this->config->get('sisp.idempotency.enabled', true);
     }
 
+    /** @return list<string> */
+    public function getIdempotencyRequestKeys(): array
+    {
+        $keys = $this->config->get('sisp.idempotency.request_keys', ['idempotency_key', 'checkout_intent_id']);
+
+        if (! is_array($keys)) {
+            return ['idempotency_key', 'checkout_intent_id'];
+        }
+
+        return array_values(array_filter(
+            $keys,
+            fn (mixed $key): bool => is_string($key) && $key !== '',
+        ));
+    }
+
     public function isMetadataCollectionEnabled(): bool
     {
         return $this->config->get('sisp.security.collect_metadata', true);

--- a/src/Configuration/LoadConfig.php
+++ b/src/Configuration/LoadConfig.php
@@ -192,6 +192,11 @@ final readonly class LoadConfig
         return $this->config->get('sisp.rate_limiting.enabled', true);
     }
 
+    public function isIdempotencyEnabled(): bool
+    {
+        return $this->config->get('sisp.idempotency.enabled', true);
+    }
+
     public function isMetadataCollectionEnabled(): bool
     {
         return $this->config->get('sisp.security.collect_metadata', true);

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -7,6 +7,7 @@ namespace Akira\Sisp\Http\Controllers;
 use Akira\Sisp\Actions\RenderPaymentResponseBasedOnConfigAction;
 use Akira\Sisp\Actions\StoreRequestMetadataAction;
 use Akira\Sisp\Actions\UpdateInvoiceStatusAction;
+use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
@@ -22,6 +23,7 @@ final readonly class CallbackController
         private RenderPaymentResponseBasedOnConfigAction $renderResponse,
         private StoreRequestMetadataAction $storeMetadata,
         private UpdateInvoiceStatusAction $updateInvoiceStatus,
+        private LoadConfig $config,
     ) {}
 
     public function __invoke(Request $request): mixed
@@ -78,7 +80,9 @@ final readonly class CallbackController
             return redirect(config('sisp.redirect_url', '/'));
         }
 
-        $this->storeMetadata->handle($request, $transaction);
+        if ($this->config->isMetadataCollectionEnabled()) {
+            $this->storeMetadata->handle($request, $transaction);
+        }
 
         $this->updateInvoiceStatus->handle($transaction, $transaction->status);
 

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -6,9 +6,8 @@ namespace Akira\Sisp\Http\Controllers;
 
 use Akira\Sisp\Actions\CheckBlacklistAction;
 use Akira\Sisp\Actions\CheckRateLimitAction;
-use Akira\Sisp\Actions\CreateAndStorePaymentTransactionAction;
 use Akira\Sisp\Actions\CreateIdempotentPaymentTransactionAction;
-use Akira\Sisp\Actions\PreparePaymentAction;
+use Akira\Sisp\Actions\CreateUniquePaymentTransactionAction;
 use Akira\Sisp\Actions\RenderPaymentFormBasedOnConfigAction;
 use Akira\Sisp\Actions\StoreRequestMetadataAction;
 use Akira\Sisp\Configuration\LoadConfig;
@@ -22,8 +21,7 @@ final readonly class PaymentController
 {
     public function __construct(
         private CreateIdempotentPaymentTransactionAction $createPayment,
-        private PreparePaymentAction $preparePayment,
-        private CreateAndStorePaymentTransactionAction $createTransaction,
+        private CreateUniquePaymentTransactionAction $createUniquePayment,
         private RenderPaymentFormBasedOnConfigAction $renderForm,
         private CheckRateLimitAction $checkRateLimit,
         private CheckBlacklistAction $checkBlacklist,
@@ -56,8 +54,10 @@ final readonly class PaymentController
             $paymentRequest = $preparedPayment->paymentRequest;
             $transaction = $preparedPayment->transaction;
         } else {
-            $paymentRequest = $this->preparePayment->handle($requestData);
-            $transaction = $this->createTransaction->handle($paymentRequest, $request, recordAttempt: false);
+            $preparedPayment = $this->createUniquePayment->handle($requestData, $request, recordAttempt: false);
+
+            $paymentRequest = $preparedPayment->paymentRequest;
+            $transaction = $preparedPayment->transaction;
         }
 
         if ($this->config->isMetadataCollectionEnabled()) {

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -6,9 +6,12 @@ namespace Akira\Sisp\Http\Controllers;
 
 use Akira\Sisp\Actions\CheckBlacklistAction;
 use Akira\Sisp\Actions\CheckRateLimitAction;
+use Akira\Sisp\Actions\CreateAndStorePaymentTransactionAction;
 use Akira\Sisp\Actions\CreateIdempotentPaymentTransactionAction;
+use Akira\Sisp\Actions\PreparePaymentAction;
 use Akira\Sisp\Actions\RenderPaymentFormBasedOnConfigAction;
 use Akira\Sisp\Actions\StoreRequestMetadataAction;
+use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Exceptions\PaymentIntentAlreadyProcessingException;
 use Akira\Sisp\Http\Requests\StorePaymentRequest;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
@@ -19,10 +22,13 @@ final readonly class PaymentController
 {
     public function __construct(
         private CreateIdempotentPaymentTransactionAction $createPayment,
+        private PreparePaymentAction $preparePayment,
+        private CreateAndStorePaymentTransactionAction $createTransaction,
         private RenderPaymentFormBasedOnConfigAction $renderForm,
         private CheckRateLimitAction $checkRateLimit,
         private CheckBlacklistAction $checkBlacklist,
         private StoreRequestMetadataAction $storeMetadata,
+        private LoadConfig $config,
     ) {}
 
     /**
@@ -40,16 +46,23 @@ final readonly class PaymentController
 
         $requestData = PaymentRequestData::from($request->validated());
 
-        try {
-            $preparedPayment = $this->createPayment->handle($requestData, $request);
-        } catch (PaymentIntentAlreadyProcessingException) {
-            return $this->paymentIntentAlreadyProcessingResponse($request);
+        if ($this->config->isIdempotencyEnabled()) {
+            try {
+                $preparedPayment = $this->createPayment->handle($requestData, $request);
+            } catch (PaymentIntentAlreadyProcessingException) {
+                return $this->paymentIntentAlreadyProcessingResponse($request);
+            }
+
+            $paymentRequest = $preparedPayment->paymentRequest;
+            $transaction = $preparedPayment->transaction;
+        } else {
+            $paymentRequest = $this->preparePayment->handle($requestData);
+            $transaction = $this->createTransaction->handle($paymentRequest, $request, recordAttempt: false);
         }
 
-        $paymentRequest = $preparedPayment->paymentRequest;
-        $transaction = $preparedPayment->transaction;
-
-        $this->storeMetadata->handle($request, $transaction);
+        if ($this->config->isMetadataCollectionEnabled()) {
+            $this->storeMetadata->handle($request, $transaction);
+        }
 
         return $this->renderForm->handle($paymentRequest, $transaction->locale);
     }

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -87,6 +87,7 @@ it('reads boolean flags for features and security', function (): void {
 it('defaults unsupported advanced security controls to disabled', function (): void {
     expect($this->cfg->isIdempotencyEnabled())->toBeTrue()
         ->and($this->cfg->isMetadataCollectionEnabled())->toBeTrue()
+        ->and($this->cfg->getIdempotencyRequestKeys())->toBe(['idempotency_key', 'checkout_intent_id'])
         ->and($this->cfg->isVpnDetectionEnabled())->toBeFalse()
         ->and($this->cfg->isProxyDetectionEnabled())->toBeFalse()
         ->and($this->cfg->isRiskScoringEnabled())->toBeFalse()

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -58,6 +58,7 @@ it('reads boolean flags for features and security', function (): void {
     config()->set('sisp.use_blade.enabled', false);
     config()->set('sisp.sandbox', true);
     config()->set('sisp.rate_limiting.enabled', false);
+    config()->set('sisp.idempotency.enabled', false);
     config()->set('sisp.security.collect_metadata', false);
     config()->set('sisp.security.block_vpn_proxy', false);
     config()->set('sisp.security.block_new_country_payments', true);
@@ -71,6 +72,7 @@ it('reads boolean flags for features and security', function (): void {
     expect($this->cfg->shouldUseBlade())->toBeFalse()
         ->and($this->cfg->isSandboxEnabled())->toBeTrue()
         ->and($this->cfg->isRateLimitingEnabled())->toBeFalse()
+        ->and($this->cfg->isIdempotencyEnabled())->toBeFalse()
         ->and($this->cfg->isMetadataCollectionEnabled())->toBeFalse()
         ->and($this->cfg->shouldBlockVpnProxy())->toBeFalse()
         ->and($this->cfg->shouldBlockNewCountryPayments())->toBeTrue()
@@ -83,7 +85,8 @@ it('reads boolean flags for features and security', function (): void {
 });
 
 it('defaults unsupported advanced security controls to disabled', function (): void {
-    expect($this->cfg->isMetadataCollectionEnabled())->toBeTrue()
+    expect($this->cfg->isIdempotencyEnabled())->toBeTrue()
+        ->and($this->cfg->isMetadataCollectionEnabled())->toBeTrue()
         ->and($this->cfg->isVpnDetectionEnabled())->toBeFalse()
         ->and($this->cfg->isProxyDetectionEnabled())->toBeFalse()
         ->and($this->cfg->isRiskScoringEnabled())->toBeFalse()

--- a/tests/Http/CallbackControllerTest.php
+++ b/tests/Http/CallbackControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Models\RequestMetadata;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Sisp as SispManager;
 use Akira\Sisp\ValueObjects\PaymentRequestData;
@@ -73,6 +74,25 @@ it('handles POST callback and redirects to GET with ref', function (): void {
         ->and($t->merchant_response)->toBe($payload->merchantResponse)
         ->and($t->response_code)->toBe($payload->merchantRespCp)
         ->and($t->fingerprint)->toBe($payload->fingerprint);
+});
+
+it('does not store callback metadata when metadata collection is disabled', function (): void {
+    config()->set('sisp.security.collect_metadata', false);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-NO-METADATA',
+        'merchant_session' => 'MS-NO-METADATA',
+        'amount' => 20,
+        'currency' => '132',
+        'status' => 'pending',
+    ]);
+
+    $payload = callback_controller_payload($transaction);
+
+    $this->post(route('sisp.callback'), $payload)
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-NO-METADATA']));
+
+    expect(RequestMetadata::query()->count())->toBe(0);
 });
 
 it('accepts successful callbacks when the signed response omits transaction code', function (): void {

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use Akira\Sisp\Models\PaymentIntent;
+use Akira\Sisp\Models\RequestMetadata;
 use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\Models\TransactionAttempt;
 
 it('creates transaction and renders payment form', function (): void {
     config()->set('sisp.rate_limiting.enabled', false);
@@ -60,6 +63,30 @@ it('stores decimal payment amounts with canonical cents', function (): void {
 
     expect($transaction->amount)->toBe(8.03)
         ->and($transaction->amount_cents)->toBe(803);
+});
+
+it('respects disabled idempotency and metadata collection flags', function (): void {
+    config()->set('sisp.rate_limiting.enabled', false);
+    config()->set('sisp.idempotency.enabled', false);
+    config()->set('sisp.security.collect_metadata', false);
+
+    $this->post(route('sisp.payment'), [
+        'amount' => 100.0,
+        'checkout_intent_id' => 'checkout-disabled-flags',
+        'items' => [[
+            'product_name' => 'Test',
+            'quantity' => 1,
+            'unit_price' => 100.0,
+            'total_price' => 100.0,
+        ]],
+        'customer_name' => 'John',
+        'customer_email' => 'john@example.test',
+    ])->assertOk();
+
+    expect(Transaction::query()->count())->toBe(1)
+        ->and(PaymentIntent::query()->count())->toBe(0)
+        ->and(TransactionAttempt::query()->count())->toBe(0)
+        ->and(RequestMetadata::query()->count())->toBe(0);
 });
 
 it('blocks duplicate transactions via middleware', function (): void {

--- a/tests/Http/PaymentControllerTest.php
+++ b/tests/Http/PaymentControllerTest.php
@@ -89,6 +89,67 @@ it('respects disabled idempotency and metadata collection flags', function (): v
         ->and(RequestMetadata::query()->count())->toBe(0);
 });
 
+it('retries identifier collisions when idempotency is disabled', function (): void {
+    config()->set('sisp.rate_limiting.enabled', false);
+    config()->set('sisp.idempotency.enabled', false);
+    config()->set('sisp.identifier_generation.max_attempts', 2);
+    config()->set('sisp.identifier_generation.collision_retry_sleep_microseconds', 0);
+
+    Transaction::factory()->create([
+        'merchant_ref' => 'MR-DISABLED-COLLISION',
+        'merchant_session' => 'MS-DISABLED-COLLISION',
+    ]);
+
+    app()->singleton('sisp.test.disabledCollisionReference', fn (): object => new class
+    {
+        private int $next = 0;
+
+        public function __invoke(): string
+        {
+            $this->next++;
+
+            return $this->next === 1 ? 'MR-DISABLED-COLLISION' : 'MR-DISABLED-UNIQUE';
+        }
+    });
+
+    app()->singleton('sisp.test.disabledCollisionSession', fn (): object => new class
+    {
+        private int $next = 0;
+
+        public function __invoke(): string
+        {
+            $this->next++;
+
+            return $this->next === 1 ? 'MS-DISABLED-COLLISION' : 'MS-DISABLED-UNIQUE';
+        }
+    });
+
+    config()->set('sisp.generators.merchantReference', 'sisp.test.disabledCollisionReference');
+    config()->set('sisp.generators.merchantSession', 'sisp.test.disabledCollisionSession');
+
+    $this->post(route('sisp.payment'), [
+        'amount' => 100.0,
+        'checkout_intent_id' => 'checkout-disabled-collision',
+        'items' => [[
+            'product_name' => 'Test',
+            'quantity' => 1,
+            'unit_price' => 100.0,
+            'total_price' => 100.0,
+        ]],
+        'customer_name' => 'John',
+        'customer_email' => 'john@example.test',
+    ])->assertOk();
+
+    $transaction = Transaction::query()
+        ->where('merchant_ref', 'MR-DISABLED-UNIQUE')
+        ->sole();
+
+    expect($transaction->merchant_session)->toBe('MS-DISABLED-UNIQUE')
+        ->and(Transaction::query()->count())->toBe(2)
+        ->and(PaymentIntent::query()->count())->toBe(0)
+        ->and(TransactionAttempt::query()->count())->toBe(0);
+});
+
 it('blocks duplicate transactions via middleware', function (): void {
     Transaction::factory()->create([
         'merchant_ref' => 'MR-DUP',


### PR DESCRIPTION
## Summary
- route v1 idempotency and metadata flags through LoadConfig
- skip PaymentIntent and RequestMetadata when the flags are disabled
- keep the Swoole-safe Laravel defer import from the merged hotfix

## Tests
- composer test