### PR TITLE
feat(mcp): Laravel MCP server for AI integration and operation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "php": "^8.5",
     "akira/laravel-pdf-invoices": "^1.8",
     "illuminate/contracts": "^13.0",
+    "laravel/mcp": "^0.8",
     "pinkary-project/type-guard": "^0.1.0",
     "spatie/laravel-package-tools": "^1.16",
     "stevebauman/location": "^7.6"

--- a/config/sisp.php
+++ b/config/sisp.php
@@ -499,4 +499,28 @@ return [
         'refund' => ['web', 'auth'],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | MCP Server
+    |--------------------------------------------------------------------------
+    |
+    | Exposes the package to AI agents through the Model Context Protocol.
+    | Disabled by default so host applications opt in explicitly. The local
+    | transport serves coding agents on the developer machine; the web
+    | transport serves remote clients behind authentication. Destructive
+    | payment tools stay off the web transport unless expose_destructive is on.
+    |
+    */
+    'mcp' => [
+        'enabled' => env('SISP_MCP_ENABLED', false),
+        'local' => env('SISP_MCP_LOCAL', true),
+        'web' => [
+            'enabled' => env('SISP_MCP_WEB_ENABLED', false),
+            'path' => env('SISP_MCP_WEB_PATH', '/sisp/mcp'),
+            'middleware' => ['auth:sanctum'],
+            'ability' => null,
+            'expose_destructive' => env('SISP_MCP_WEB_DESTRUCTIVE', false),
+        ],
+    ],
+
 ];

--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -82,6 +82,7 @@ The existing security metadata collection and risk scoring can be extended with:
 - React and Vue component libraries
 - Webhook signature verification middleware
 - Payment status polling utilities
+- [MCP server](15-mcp.md) for AI-assisted integration and operation
 
 **Events and Webhooks**
 

--- a/docs/15-mcp.md
+++ b/docs/15-mcp.md
@@ -1,0 +1,115 @@
+# 15. MCP Server
+
+laravel-sisp ships an [official Laravel MCP](https://github.com/laravel/mcp) server so AI
+agents can both integrate the package and operate the gateway. It is split into two servers by
+risk profile and is disabled by default.
+
+| Server | Handle | Transport | Surface |
+| --- | --- | --- | --- |
+| `SispDevServer` | `sisp-dev` | local | Read-only developer assistance: docs, config, enums, countries, sandbox |
+| `SispOpsServer` | `sisp-ops` | local | Runtime payment operations, including refund and cancel |
+| `SispWebOpsServer` | `sisp-ops` | web | Runtime operations over HTTP; destructive tools gated behind a flag |
+
+## Enabling
+
+The server is opt-in. Set the environment variables in the host application:
+
+```dotenv
+SISP_MCP_ENABLED=true
+SISP_MCP_LOCAL=true
+
+# Web transport (remote AI clients)
+SISP_MCP_WEB_ENABLED=false
+SISP_MCP_WEB_PATH=/sisp/mcp
+SISP_MCP_WEB_DESTRUCTIVE=false
+```
+
+The matching config lives in `config/sisp.php` under the `mcp` key:
+
+```php
+'mcp' => [
+    'enabled' => env('SISP_MCP_ENABLED', false),
+    'local'   => env('SISP_MCP_LOCAL', true),
+    'web' => [
+        'enabled'    => env('SISP_MCP_WEB_ENABLED', false),
+        'path'       => env('SISP_MCP_WEB_PATH', '/sisp/mcp'),
+        'middleware' => ['auth:sanctum'],
+        'ability'    => null,
+        'expose_destructive' => env('SISP_MCP_WEB_DESTRUCTIVE', false),
+    ],
+],
+```
+
+When `mcp.enabled` is false the package never loads its `routes/ai.php`, so no MCP routes or
+commands are registered.
+
+## Local usage
+
+Local servers run as Artisan commands and connect to coding agents on the developer machine:
+
+```bash
+php artisan mcp:start sisp-dev
+php artisan mcp:start sisp-ops
+```
+
+Inspect a server interactively with the MCP Inspector:
+
+```bash
+php artisan mcp:inspector sisp-dev
+```
+
+## Web usage
+
+With `mcp.web.enabled` true, the ops server is exposed at `mcp.web.path` behind the configured
+middleware (default `auth:sanctum`). Clients send `Authorization: Bearer <token>`.
+
+- `mcp.web.middleware` - guard(s) protecting the route. Override for Passport/OAuth or a custom guard.
+- `mcp.web.ability` - optional Gate ability checked inside refund and cancel. When set, the
+  authenticated user must pass `Gate::allows($ability, $transaction)`.
+- `mcp.web.expose_destructive` - when false (default), refund and cancel are NOT registered on the
+  web transport. The dev server is never exposed over the web.
+
+## Tools
+
+### Developer (sisp-dev, all read-only)
+
+| Tool | Purpose |
+| --- | --- |
+| `search-docs-tool` | Search the package docs by keyword. |
+| `get-doc-tool` | Return one documentation page by slug. |
+| `config-reference-tool` | Explain `config/sisp.php` keys (secrets redacted). |
+| `env-scaffold-tool` | Produce the `.env` variables to set, per environment. |
+| `enum-reference-tool` | List cases and labels for a SISP enum. |
+| `error-code-lookup-tool` | Resolve a SISP error code to label, category, and action. |
+| `country-reference-tool` | Resolve or list supported countries. |
+| `simulate-sandbox-callback-tool` | Build a sandbox callback payload for local testing (no writes). |
+| `doctor-tool` | Invoice storage and configuration diagnostics. |
+
+### Operations (sisp-ops)
+
+| Tool | Annotation | Purpose |
+| --- | --- | --- |
+| `build-payment-request-tool` | read-only | Build the signed payment payload. Does not charge. |
+| `query-transaction-status-tool` | read-only, idempotent | Query live status at SISP. |
+| `get-transaction-tool` | read-only | Fetch one stored transaction. |
+| `list-transactions-tool` | read-only | List/filter stored transactions. |
+| `reconcile-transaction-tool` | idempotent | Re-sync and persist a transaction's status. |
+| `refund-transaction-tool` | destructive | Refund a completed transaction. |
+| `cancel-transaction-tool` | destructive | Cancel a pending transaction. |
+
+## Resources and prompts
+
+The dev server also exposes reference resources - `sisp://docs`, `sisp://enums`,
+`sisp://countries`, `sisp://error-codes` - and two prompts: an integration walkthrough and a
+payment-failure diagnosis.
+
+## Security
+
+Refund and cancel move money. They are annotated destructive, require authentication on the web
+transport, support an optional Gate ability, and are hidden from the web transport unless
+`expose_destructive` is enabled. Prefer keeping the web transport read-only and running destructive
+operations through the local transport or your own audited application code.
+
+---
+
+[Previous: Idempotency](14-idempotency.md)

--- a/docs/audit/v2-audit-report.md
+++ b/docs/audit/v2-audit-report.md
@@ -1,0 +1,124 @@
+# laravel-sisp v2 Audit Report
+
+Static read-only audit of the v2 codebase across five dimensions: idempotency/concurrency,
+security, payment correctness, architecture, and test/docs coverage. Findings are sorted by
+severity. Line numbers are indicative; verify against the current source before acting. This is
+an analysis pass only - no code was changed by this report.
+
+## Executive summary
+
+| Severity | Count |
+| --- | --- |
+| Critical | 3 |
+| High | 9 |
+| Medium | 11 |
+| Low / informational | 3 |
+
+The highest-risk areas are the idempotency reservation path (a TOCTOU window in payment-intent
+reservation) and authorization on the money-moving HTTP endpoints (retry, refund, cancel), which
+default to weak or empty middleware and rely on a host-defined policy that may be absent. Payment
+correctness is mostly sound; the main concern is float round-tripping in partial refunds.
+
+## Critical
+
+### C1 - TOCTOU race in payment-intent reservation
+`src/Pipelines/Payment/Pipes/ApplyPaymentIntent.php` (reserve path). The reclaim-then-insert
+sequence is not wrapped in a single atomic step, so two concurrent requests with the same
+idempotency key can both miss the reclaim and then race on `insertOrIgnore`. The loser can land on
+a `processing` intent with no `transaction_id` and throw `PaymentIntentAlreadyProcessingException`.
+Fix: perform the reclaim/insert inside one `DB::transaction` with `lockForUpdate`, or rely on a
+single upsert and branch on the resulting row.
+
+### C2 - Missing authorization on retry / refund / cancel (IDOR)
+`routes/web.php` plus `RetryPaymentController`, `RefundTransactionController`,
+`CancelTransactionController`. Retry default middleware is empty (`sisp.middleware.retry => []`);
+refund depends on a host `refund` policy that, if undefined, may not deny; cancel is protected only
+by a signed URL, which validates URL integrity, not the actor. A user who knows a transaction id or
+merchant reference may act on transactions that are not theirs. Fix: require authentication by
+default, add an ownership/policy check in each controller, and document the expected policy.
+
+### C3 - Partial-refund float round-trip
+`src/Actions/RefundTransactionAction.php` (refund amount handling). The refund amount is converted
+to thousandths and then divided back to a float before being handed to the refund request builder,
+re-introducing float imprecision on values such as `8.03`. Fix: keep the canonical integer
+(thousandths/cents) and pass it through without the float round-trip.
+
+## High
+
+- H1 - Retry attempt creation locks the transaction row but reads `max(attempt_number)` from the
+  attempts relation in a way that can interleave under concurrency.
+  `src/Actions/CreateRetryPaymentAttemptAction.php` / `CreateTransactionAttemptAction.php`. Lock the
+  attempts in the same transaction before computing the next number.
+- H2 - `superseded_at` marking and new-attempt insertion are separate writes; a callback can resolve
+  a just-superseded attempt. `src/Actions/CreateTransactionAttemptAction.php`. Wrap both in one
+  transaction and have the callback path assert the attempt is current.
+- H3 - Legacy attempt lookup runs unlocked before falling back to a locked path.
+  `src/Actions/Transaction/FindTransactionAttemptAction.php`. Lock on the first resolving query when
+  idempotency matters.
+- H4 - Idempotency key accepted with minimal validation (trim only); very short keys risk
+  collisions. `src/Pipelines/Payment/Pipes/ApplyPaymentIntent.php`. Enforce a minimum length and a
+  character allow-list.
+- H5 - `PaymentContext` / `CallbackContext` expose public mutable state mutated in place across
+  pipes. `src/Pipelines/*/`. Prefer private state with explicit setters or immutable `with*()`.
+- H6 - `RefundBuilder` is `final` with mutable internal state; intent (mutable builder vs immutable)
+  is undocumented. `src/Builders/RefundBuilder.php`.
+- H7 - Refund replay/idempotency is untested; a retried refund callback could double-process.
+  `tests/Actions/RefundTransactionActionTest.php`.
+- H8 - `CancelTransactionAction` has no dedicated test for the non-cancellable transitions.
+  `src/Actions/CancelTransactionAction.php`.
+- H9 - Fingerprint validation tests cover only a narrow set of vectors (no missing/malformed/empty
+  fingerprint). `tests/Actions/ValidateFingerprintActionTest.php`.
+
+## Medium
+
+- M1 - Callback route bypasses the `web` middleware group (`withoutMiddleware('web')`), so CSRF is
+  off and replays are possible if fingerprint validation is ever reordered. `routes/web.php`. This
+  is standard for gateway callbacks; keep fingerprint validation first and add replay/rate guards.
+- M2 - Card PAN is persisted inside `callback_payload`. It is encrypted at rest via
+  `EncryptsAttributes`, but is not masked. `src/Actions/Transaction/UpdateTransactionAttemptAction.php`.
+  Consider masking before storage.
+- M3 - Rate limiting keys on IP only; no merchant- or user-scoped limiting.
+  `src/Pipelines/Payment/Pipes/EnforceRateLimits.php`.
+- M4 - `PaymentIntent` submit (status -> submitted, set `transaction_id`) runs after the pipeline
+  without failure handling; a failed update strands the intent in `processing`.
+  `src/Pipelines/Payment/Pipes/ApplyPaymentIntent.php`.
+- M5 - No explicit deadlock retry around the callback pipeline's nested transactions.
+  `src/Pipelines/Callback/HandleCallbackPipeline.php`.
+- M6 - Pre-pipeline `isAlreadyProcessed` check on the callback can let two identical callbacks both
+  enter the pipeline (last write wins). `src/Http/Controllers/CallbackController.php`. Move the
+  idempotency check inside the locked section.
+- M7 - `MapTransactionStatusAction` treats a hardcoded `'10'` as success without an enum case.
+  `src/Actions/Transaction/MapTransactionStatusAction.php`.
+- M8 - `ThreeDSecureData` does not validate that country-code conversion succeeded.
+  `src/ValueObjects/ThreeDSecureData.php`.
+- M9 - Reconciliation lacks edge-case tests (already-completed no-op, conflicting result flags,
+  repeated calls). `tests/Actions/ReconcileTransactionStatusActionTest.php`.
+- M10 - `docs/05-transaction-management.md` carries a stale "before 1.0.0" note and lacks a
+  cancellation-rules section.
+- M11 - Type-coverage requirement (100%) and how to run it are undocumented.
+  `docs/12-architecture.md`.
+
+## Low / informational
+
+- L1 - Fingerprint comparison correctly uses `hash_equals` (timing-safe).
+  `src/Actions/ValidatePaymentResponseFingerprintAction.php`. No action.
+- L2 - Retry loop already filters non-unique-constraint `QueryException`s correctly.
+  `src/Actions/CreateRetryPaymentAttemptAction.php`. No action.
+- L3 - Several narrative comments remain (`SispServiceProvider`, `EncryptsAttributes`,
+  `ProtectPaymentRoute`); house style discourages explanatory comments.
+
+## Prioritized backlog
+
+1. C2 - Lock down authorization on retry/refund/cancel (highest real-world risk).
+2. C1 / H1 / H2 / H3 - Make the intent and attempt lifecycle atomic under concurrency.
+3. C3 - Remove the partial-refund float round-trip.
+4. H7 / H8 / H9 / M9 - Close the refund/cancel/reconcile/fingerprint test gaps.
+5. M-series - Hardening (PAN masking, rate-limit scope, deadlock retry, callback idempotency).
+
+## Method and caveats
+
+Findings come from two parallel static read passes (security/concurrency and
+correctness/architecture/tests). Some line references are approximate and a few recommended fixes
+are debatable design choices rather than defects; confirm each against the current source and the
+test suite before changing behavior. The security-sensitive items (C1, C2, C3, H1-H3) should be
+reproduced with a focused test before remediation.

--- a/peck.json
+++ b/peck.json
@@ -22,7 +22,8 @@
             "addr",
             "pdfs",
             "decrypted",
-            "testbench"
+            "testbench",
+            "mcp"
         ],
         "paths": []
     }

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Mcp\Servers\SispDevServer;
+use Akira\Sisp\Mcp\Servers\SispOpsServer;
+use Akira\Sisp\Mcp\Servers\SispWebOpsServer;
+use Laravel\Mcp\Facades\Mcp;
+
+if (config('sisp.mcp.local', true)) {
+    Mcp::local('sisp-dev', SispDevServer::class);
+    Mcp::local('sisp-ops', SispOpsServer::class);
+}
+
+if (config('sisp.mcp.web.enabled', false)) {
+    Mcp::web(config('sisp.mcp.web.path', '/sisp/mcp'), SispWebOpsServer::class)
+        ->middleware(config('sisp.mcp.web.middleware', ['auth:sanctum']));
+}

--- a/src/Actions/RetryPaymentAction.php
+++ b/src/Actions/RetryPaymentAction.php
@@ -27,7 +27,6 @@ final readonly class RetryPaymentAction
             amount: $transaction->amount,
             merchantRef: $transaction->merchant_ref,
             merchantSession: $rotateMerchantSession ? null : $this->merchantSession($transaction),
-            timeStamp: null,
             currency: $transaction->currency,
             transactionCode: $transaction->transaction_code,
             token: '',

--- a/src/Http/Middleware/EnforceSispRateLimits.php
+++ b/src/Http/Middleware/EnforceSispRateLimits.php
@@ -30,7 +30,6 @@ final readonly class EnforceSispRateLimits
                 $this->checkRateLimit->handle(
                     $ip,
                     'ip',
-                    context: null,
                     limit: (int) config('sisp.rate_limiting.per_ip.limit'),
                     windowSeconds: (int) config('sisp.rate_limiting.per_ip.window_seconds')
                 );

--- a/src/Mcp/Concerns/AuthorizesTransactionOps.php
+++ b/src/Mcp/Concerns/AuthorizesTransactionOps.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Concerns;
+
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Mcp\Request;
+
+trait AuthorizesTransactionOps
+{
+    private function isAuthorized(Request $request, Transaction $transaction): bool
+    {
+        $ability = config('sisp.mcp.web.ability');
+
+        if ($ability === null) {
+            return true;
+        }
+
+        $user = $request->user();
+
+        if (! $user instanceof \Illuminate\Contracts\Auth\Authenticatable) {
+            return true;
+        }
+
+        return Gate::forUser($user)->allows((string) $ability, $transaction);
+    }
+}

--- a/src/Mcp/Concerns/ResolvesTransaction.php
+++ b/src/Mcp/Concerns/ResolvesTransaction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Concerns;
+
+use Akira\Sisp\Models\Transaction;
+use Carbon\CarbonInterface;
+
+trait ResolvesTransaction
+{
+    private function resolveTransaction(string $identifier): ?Transaction
+    {
+        $query = Transaction::query();
+
+        if (ctype_digit($identifier)) {
+            return $query->where('id', (int) $identifier)
+                ->orWhere('merchant_ref', $identifier)
+                ->first();
+        }
+
+        return $query->where('merchant_ref', $identifier)->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function transactionSummary(Transaction $transaction): array
+    {
+        $createdAt = $transaction->getAttributeValue('created_at');
+
+        return [
+            'id' => $transaction->id,
+            'merchant_ref' => $transaction->merchant_ref,
+            'merchant_session' => $transaction->merchant_session,
+            'status' => $transaction->status->value,
+            'amount' => $transaction->amount,
+            'amount_cents' => $transaction->amount_cents,
+            'transaction_id' => $transaction->transaction_id,
+            'message_type' => $transaction->message_type,
+            'response_code' => $transaction->response_code,
+            'customer_email' => $transaction->customer_email,
+            'locale' => $transaction->locale,
+            'created_at' => $createdAt instanceof CarbonInterface ? $createdAt->toIso8601String() : null,
+        ];
+    }
+}

--- a/src/Mcp/Prompts/DiagnosePaymentFailurePrompt.php
+++ b/src/Mcp/Prompts/DiagnosePaymentFailurePrompt.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Prompts;
+
+use Akira\Sisp\Enums\ErrorMessageType;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Prompts\Argument;
+
+#[Description('Explain a failed SISP payment from its error code and propose a remediation path.')]
+final class DiagnosePaymentFailurePrompt extends Prompt
+{
+    public function handle(Request $request): Response
+    {
+        $code = mb_trim((string) $request->get('code'));
+        $error = ErrorMessageType::tryFrom($code);
+
+        if (! $error instanceof ErrorMessageType) {
+            return Response::text("Resolve SISP error code \"{$code}\" with the error_code_lookup tool, then explain the cause and the next step for the customer.");
+        }
+
+        $message = <<<MARKDOWN
+            A SISP payment failed with code {$error->value} ({$error->name}).
+
+            - Meaning: {$error->label()}
+            - Category: {$error->category()}
+            - Recommended action: {$error->action()}
+
+            Explain to the customer in plain language what went wrong, whether retrying will help, and the concrete next step. If the category is "system" or "issuer", advise retrying or reconciling the transaction with the sisp-ops reconcile tool. If it is "funds" or "card", advise using a different card or contacting the issuer.
+            MARKDOWN;
+
+        return Response::text($message);
+    }
+
+    /**
+     * @return array<int, Argument>
+     */
+    public function arguments(): array
+    {
+        return [
+            new Argument(
+                name: 'code',
+                description: 'The SISP response/error code returned with the failed payment.',
+                required: true,
+            ),
+        ];
+    }
+}

--- a/src/Mcp/Prompts/IntegrateSispPrompt.php
+++ b/src/Mcp/Prompts/IntegrateSispPrompt.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Prompts;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Prompts\Argument;
+
+#[Description('Guided walkthrough for integrating laravel-sisp into a Laravel application end to end.')]
+final class IntegrateSispPrompt extends Prompt
+{
+    public function handle(Request $request): Response
+    {
+        $stack = (string) ($request->get('stack') ?? 'blade');
+
+        $message = <<<MARKDOWN
+            Integrate the akira/laravel-sisp payment gateway into this Laravel application for a {$stack} frontend. Work through these steps and use the sisp-dev tools/resources to ground every detail:
+
+            1. Install: `composer require akira/laravel-sisp`, then run `php artisan sisp:install` to publish config, migrations, and the {$stack} components. Run the migrations.
+            2. Configure: call the `config_reference` tool to review every sisp config key. Then call the `env_scaffold` tool for the target environment and add the variables to .env.
+            3. Callback route: ensure SISP_URL_MERCHANT_RESPONSE points at the package /sisp/callback route and is publicly reachable over HTTPS.
+            4. Build a payment: use the sisp-ops `build_payment_request` tool to produce the form payload, and render it for the customer.
+            5. Test without live credentials: enable sandbox mode, then use the dev `simulate_sandbox_callback` tool to generate a callback payload and POST it to /sisp/callback.
+            6. Handle results: read docs 04-payment-flow and 05-transaction-management (via `get_doc`) to wire the PaymentCompleted/PaymentFailed events.
+
+            For any SISP error code you encounter, use the `error_code_lookup` tool to get the recommended action. Confirm the final wiring against the docs index resource (sisp://docs).
+            MARKDOWN;
+
+        return Response::text($message);
+    }
+
+    /**
+     * @return array<int, Argument>
+     */
+    public function arguments(): array
+    {
+        return [
+            new Argument(
+                name: 'stack',
+                description: 'Frontend stack to target: blade, inertia-react, or inertia-vue.',
+                required: false,
+            ),
+        ];
+    }
+}

--- a/src/Mcp/Resources/CountryCatalogResource.php
+++ b/src/Mcp/Resources/CountryCatalogResource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Resources;
+
+use Akira\Sisp\Support\Countries;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Resource;
+
+#[Uri('sisp://countries')]
+#[Description('Every country laravel-sisp supports with its ISO alpha-2, SISP numeric code, name, and flag URL.')]
+final class CountryCatalogResource extends Resource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::json(['countries' => Countries::all()]);
+    }
+}

--- a/src/Mcp/Resources/DocsIndexResource.php
+++ b/src/Mcp/Resources/DocsIndexResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Resources;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Resource;
+
+#[Uri('sisp://docs')]
+#[Description('Index of the laravel-sisp documentation pages with their titles and slugs.')]
+final class DocsIndexResource extends Resource
+{
+    public function handle(Request $request): Response
+    {
+        $index = [];
+
+        foreach (glob(dirname(__DIR__, 3).'/docs/*.md') ?: [] as $file) {
+            $first = (string) (preg_split('/\n/', (string) file_get_contents($file))[0] ?? '');
+
+            $index[] = [
+                'slug' => basename($file, '.md'),
+                'title' => mb_trim(mb_ltrim($first, '# ')),
+            ];
+        }
+
+        return Response::json(['docs' => $index]);
+    }
+}

--- a/src/Mcp/Resources/EnumCatalogResource.php
+++ b/src/Mcp/Resources/EnumCatalogResource.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Resources;
+
+use Akira\Sisp\Enums\ErrorMessageType;
+use Akira\Sisp\Enums\InvoiceStatus;
+use Akira\Sisp\Enums\SuccessMessageType;
+use Akira\Sisp\Enums\TransactionCode;
+use Akira\Sisp\Enums\TransactionStatus;
+use BackedEnum;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Resource;
+
+#[Uri('sisp://enums')]
+#[Description('Catalog of every laravel-sisp enum with its cases, values, and labels.')]
+final class EnumCatalogResource extends Resource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::json([
+            'transaction_status' => $this->cases(TransactionStatus::cases()),
+            'transaction_code' => $this->cases(TransactionCode::cases()),
+            'invoice_status' => $this->cases(InvoiceStatus::cases()),
+            'success_message' => $this->cases(SuccessMessageType::cases()),
+            'error_message' => $this->cases(ErrorMessageType::cases()),
+        ]);
+    }
+
+    /**
+     * @param  array<int, BackedEnum>  $cases
+     * @return array<int, array<string, mixed>>
+     */
+    private function cases(array $cases): array
+    {
+        return array_map(static function (BackedEnum $case): array {
+            $entry = ['name' => $case->name, 'value' => $case->value];
+
+            if (method_exists($case, 'label')) {
+                $entry['label'] = $case->label();
+            }
+
+            return $entry;
+        }, $cases);
+    }
+}

--- a/src/Mcp/Resources/ErrorCodeCatalogResource.php
+++ b/src/Mcp/Resources/ErrorCodeCatalogResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Resources;
+
+use Akira\Sisp\Enums\ErrorMessageType;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Resource;
+
+#[Uri('sisp://error-codes')]
+#[Description('Every SISP response/error code mapped to its label, category, and recommended action.')]
+final class ErrorCodeCatalogResource extends Resource
+{
+    public function handle(Request $request): Response
+    {
+        $codes = array_map(static fn (ErrorMessageType $error): array => [
+            'code' => $error->value,
+            'name' => $error->name,
+            'label' => $error->label(),
+            'category' => $error->category(),
+            'action' => $error->action(),
+        ], ErrorMessageType::cases());
+
+        return Response::json(['error_codes' => $codes]);
+    }
+}

--- a/src/Mcp/Servers/SispDevServer.php
+++ b/src/Mcp/Servers/SispDevServer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Servers;
+
+use Akira\Sisp\Mcp\Prompts\DiagnosePaymentFailurePrompt;
+use Akira\Sisp\Mcp\Prompts\IntegrateSispPrompt;
+use Akira\Sisp\Mcp\Resources\CountryCatalogResource;
+use Akira\Sisp\Mcp\Resources\DocsIndexResource;
+use Akira\Sisp\Mcp\Resources\EnumCatalogResource;
+use Akira\Sisp\Mcp\Resources\ErrorCodeCatalogResource;
+use Akira\Sisp\Mcp\Tools\Dev\ConfigReferenceTool;
+use Akira\Sisp\Mcp\Tools\Dev\CountryReferenceTool;
+use Akira\Sisp\Mcp\Tools\Dev\DoctorTool;
+use Akira\Sisp\Mcp\Tools\Dev\EnumReferenceTool;
+use Akira\Sisp\Mcp\Tools\Dev\EnvScaffoldTool;
+use Akira\Sisp\Mcp\Tools\Dev\ErrorCodeLookupTool;
+use Akira\Sisp\Mcp\Tools\Dev\GetDocTool;
+use Akira\Sisp\Mcp\Tools\Dev\SearchDocsTool;
+use Akira\Sisp\Mcp\Tools\Dev\SimulateSandboxCallbackTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+use Override;
+
+#[Name('sisp-dev')]
+#[Version('1.0.0')]
+#[Instructions(<<<'MARKDOWN'
+    Developer assistant for the akira/laravel-sisp payment gateway package.
+
+    Use this server to integrate laravel-sisp into a Laravel application: search
+    the package documentation, look up configuration keys and required .env
+    variables, resolve SISP error codes to recommended actions, inspect enums and
+    supported countries, and simulate sandbox callback payloads for local testing.
+
+    Every tool here is read-only. It never touches a live gateway, never writes to
+    the database, and never moves money. For runtime payment operations use the
+    sisp-ops server instead.
+    MARKDOWN)]
+final class SispDevServer extends Server
+{
+    #[Override]
+    protected array $tools = [
+        SearchDocsTool::class,
+        GetDocTool::class,
+        ConfigReferenceTool::class,
+        EnvScaffoldTool::class,
+        EnumReferenceTool::class,
+        ErrorCodeLookupTool::class,
+        CountryReferenceTool::class,
+        SimulateSandboxCallbackTool::class,
+        DoctorTool::class,
+    ];
+
+    #[Override]
+    protected array $resources = [
+        DocsIndexResource::class,
+        EnumCatalogResource::class,
+        CountryCatalogResource::class,
+        ErrorCodeCatalogResource::class,
+    ];
+
+    #[Override]
+    protected array $prompts = [
+        IntegrateSispPrompt::class,
+        DiagnosePaymentFailurePrompt::class,
+    ];
+}

--- a/src/Mcp/Servers/SispOpsServer.php
+++ b/src/Mcp/Servers/SispOpsServer.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Servers;
+
+use Akira\Sisp\Mcp\Tools\Ops\BuildPaymentRequestTool;
+use Akira\Sisp\Mcp\Tools\Ops\CancelTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\GetTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\ListTransactionsTool;
+use Akira\Sisp\Mcp\Tools\Ops\QueryTransactionStatusTool;
+use Akira\Sisp\Mcp\Tools\Ops\ReconcileTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\RefundTransactionTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+use Override;
+
+#[Name('sisp-ops')]
+#[Version('1.0.0')]
+#[Instructions(<<<'MARKDOWN'
+    Runtime operations for the akira/laravel-sisp payment gateway.
+
+    Use this server to build payment request payloads, query and reconcile
+    transaction status against the live SISP gateway, list and inspect stored
+    transactions, and refund or cancel transactions.
+
+    Refund and cancel move money and change state: they are irreversible. Confirm
+    the transaction identifier and amount with a human before calling them. Over
+    the web transport these destructive tools are hidden unless the host
+    application explicitly opts in.
+    MARKDOWN)]
+final class SispOpsServer extends Server
+{
+    #[Override]
+    protected array $tools = [
+        BuildPaymentRequestTool::class,
+        QueryTransactionStatusTool::class,
+        GetTransactionTool::class,
+        ListTransactionsTool::class,
+        ReconcileTransactionTool::class,
+        RefundTransactionTool::class,
+        CancelTransactionTool::class,
+    ];
+}

--- a/src/Mcp/Servers/SispWebOpsServer.php
+++ b/src/Mcp/Servers/SispWebOpsServer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Servers;
+
+use Akira\Sisp\Mcp\Tools\Ops\BuildPaymentRequestTool;
+use Akira\Sisp\Mcp\Tools\Ops\CancelTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\GetTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\ListTransactionsTool;
+use Akira\Sisp\Mcp\Tools\Ops\QueryTransactionStatusTool;
+use Akira\Sisp\Mcp\Tools\Ops\ReconcileTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\RefundTransactionTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+use Laravel\Mcp\Server\Contracts\Transport;
+use Override;
+
+#[Name('sisp-ops')]
+#[Version('1.0.0')]
+#[Instructions(<<<'MARKDOWN'
+    Runtime operations for the akira/laravel-sisp payment gateway, exposed over an
+    authenticated web transport.
+
+    Build payment request payloads, query and reconcile transaction status, and
+    list or inspect stored transactions. Refund and cancel are destructive and are
+    only available when the host application opts in via sisp.mcp.web.expose_destructive.
+    MARKDOWN)]
+final class SispWebOpsServer extends Server
+{
+    #[Override]
+    protected array $tools = [
+        BuildPaymentRequestTool::class,
+        QueryTransactionStatusTool::class,
+        GetTransactionTool::class,
+        ListTransactionsTool::class,
+        ReconcileTransactionTool::class,
+    ];
+
+    public function __construct(Transport $transport)
+    {
+        parent::__construct($transport);
+
+        if (config('sisp.mcp.web.expose_destructive', false)) {
+            $this->tools = [
+                ...$this->tools,
+                RefundTransactionTool::class,
+                CancelTransactionTool::class,
+            ];
+        }
+    }
+}

--- a/src/Mcp/Tools/Dev/ConfigReferenceTool.php
+++ b/src/Mcp/Tools/Dev/ConfigReferenceTool.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Explain the config/sisp.php keys: their purpose and current value. Secrets are redacted.')]
+final class ConfigReferenceTool extends Tool
+{
+    private const array DESCRIPTIONS = [
+        'url' => 'SISP gateway endpoint the payment form posts to.',
+        'driver' => 'Active driver: null (auto), "production", or "sandbox".',
+        'pipelines' => 'Ordered payment and callback pipe classes. Reorder or extend to customise the flow.',
+        'generators' => 'Classes that generate the merchant reference, session, and timestamp.',
+        'posID' => 'Merchant POS identifier issued by SISP.',
+        'posAutCode' => 'Merchant POS authorisation code used to sign requests (secret).',
+        'currency' => 'ISO 4217 numeric currency code. Default 132 (CVE).',
+        'language_messages' => 'Gateway message language: EN or PT.',
+        'fingerprint_version' => 'SISP fingerprint algorithm version.',
+        'url_merchant_response' => 'Callback URL SISP posts the payment result to.',
+        'is_3dsec' => '3D Secure indicator (0 or 1). When 1, customer data is required.',
+        'transaction_code' => 'Default SISP transaction code. 1 = purchase.',
+        'merchantId' => 'Merchant identifier.',
+        'tables' => 'Database table name overrides.',
+        'idempotency' => 'Idempotency toggle and the request field names treated as idempotency keys.',
+        'identifier_generation' => 'Retry budget and backoff when generating unique identifiers.',
+        'redirect_url' => 'Where to send the customer after the payment result is rendered.',
+        'sandbox' => 'Force sandbox mode regardless of driver.',
+        'transaction_status' => 'POS status API URL, credentials, and reconciliation thresholds.',
+        'use_blade' => 'Render the payment form and result with Blade views.',
+        'use_inertia' => 'Render the payment form and result with Inertia components.',
+        'invoice' => 'Invoice numbering, storage disk/path, template, and company details.',
+        'allow_retry' => 'Allow failed payments to be retried.',
+        'rate_limiting' => 'Per-IP, per-merchant, and per-user rate limits.',
+        'security' => 'Metadata collection, VPN/proxy detection, risk scoring, and spend caps.',
+        'geolocation' => 'Geolocation provider and API keys for request metadata.',
+        'middleware' => 'Route middleware for the payment, retry, and refund endpoints.',
+        'mcp' => 'MCP server toggles for the local and web transports.',
+    ];
+
+    private const array SECRET_KEYS = ['posAutCode', 'transaction_status'];
+
+    public function handle(Request $request): Response
+    {
+        $key = $request->get('key');
+
+        if ($key !== null) {
+            $key = (string) $key;
+
+            if (! array_key_exists($key, self::DESCRIPTIONS)) {
+                return Response::error("Unknown config key \"{$key}\". Known keys: ".implode(', ', array_keys(self::DESCRIPTIONS)));
+            }
+
+            return Response::json([
+                'key' => "sisp.{$key}",
+                'description' => self::DESCRIPTIONS[$key],
+                'value' => $this->valueFor($key),
+            ]);
+        }
+
+        $reference = [];
+
+        foreach (self::DESCRIPTIONS as $name => $description) {
+            $reference[$name] = [
+                'key' => "sisp.{$name}",
+                'description' => $description,
+                'value' => $this->valueFor($name),
+            ];
+        }
+
+        return Response::json($reference);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('A single top-level sisp config key to explain. Omit to list every key.')
+                ->enum(array_keys(self::DESCRIPTIONS)),
+        ];
+    }
+
+    private function valueFor(string $key): mixed
+    {
+        if (in_array($key, self::SECRET_KEYS, true)) {
+            return '[redacted]';
+        }
+
+        return config("sisp.{$key}");
+    }
+}

--- a/src/Mcp/Tools/Dev/CountryReferenceTool.php
+++ b/src/Mcp/Tools/Dev/CountryReferenceTool.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Akira\Sisp\Support\Countries;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Look up the SISP numeric code, name, and flag for a country, or list every supported country.')]
+final class CountryReferenceTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $alpha2 = $request->get('alpha2');
+
+        if ($alpha2 === null) {
+            return Response::json(['countries' => Countries::all()]);
+        }
+
+        $alpha2 = mb_strtolower(mb_trim((string) $alpha2));
+        $name = Countries::getName($alpha2);
+
+        if ($name === null) {
+            return Response::error("Unknown country code \"{$alpha2}\". Use an ISO 3166-1 alpha-2 code such as \"cv\".");
+        }
+
+        return Response::json([
+            'alpha2' => mb_strtoupper($alpha2),
+            'name' => $name,
+            'numeric' => Countries::getNumericCode($alpha2),
+            'flag' => Countries::getFlag($alpha2),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'alpha2' => $schema->string()
+                ->description('ISO 3166-1 alpha-2 country code, e.g. "cv". Omit to list all countries.')
+                ->min(2)
+                ->max(2),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Dev/DoctorTool.php
+++ b/src/Mcp/Tools/Dev/DoctorTool.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Akira\Sisp\Support\Diagnostics;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Run laravel-sisp diagnostics: invoice storage configuration, disk accessibility, and invoice/PDF counts.')]
+final class DoctorTool extends Tool
+{
+    public function handle(Request $request, Diagnostics $diagnostics): Response
+    {
+        return Response::json($diagnostics->all());
+    }
+}

--- a/src/Mcp/Tools/Dev/EnumReferenceTool.php
+++ b/src/Mcp/Tools/Dev/EnumReferenceTool.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Akira\Sisp\Enums\ErrorMessageType;
+use Akira\Sisp\Enums\InvoiceStatus;
+use Akira\Sisp\Enums\SuccessMessageType;
+use Akira\Sisp\Enums\TransactionCode;
+use Akira\Sisp\Enums\TransactionStatus;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('List the cases of a laravel-sisp enum with their values and labels.')]
+final class EnumReferenceTool extends Tool
+{
+    private const array ENUMS = [
+        'transaction_status' => TransactionStatus::class,
+        'transaction_code' => TransactionCode::class,
+        'error_message' => ErrorMessageType::class,
+        'invoice_status' => InvoiceStatus::class,
+        'success_message' => SuccessMessageType::class,
+    ];
+
+    public function handle(Request $request): Response
+    {
+        $name = (string) $request->get('enum');
+        $enumClass = self::ENUMS[$name] ?? null;
+
+        if ($enumClass === null) {
+            return Response::error("Unknown enum \"{$name}\". Available: ".implode(', ', array_keys(self::ENUMS)));
+        }
+
+        $cases = [];
+
+        foreach ($enumClass::cases() as $case) {
+            $entry = ['name' => $case->name, 'value' => $case->value];
+
+            if (method_exists($case, 'label')) {
+                $entry['label'] = $case->label();
+            }
+
+            if (method_exists($case, 'category')) {
+                $entry['category'] = $case->category();
+                $entry['action'] = $case->action();
+            }
+
+            $cases[] = $entry;
+        }
+
+        return Response::json(['enum' => $name, 'cases' => $cases]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'enum' => $schema->string()
+                ->description('Which enum to describe.')
+                ->enum(array_keys(self::ENUMS))
+                ->required(),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Dev/EnvScaffoldTool.php
+++ b/src/Mcp/Tools/Dev/EnvScaffoldTool.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Produce the .env variables a host application must set to use laravel-sisp, tailored to sandbox or production.')]
+final class EnvScaffoldTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $mode = $request->get('mode') === 'production' ? 'production' : 'sandbox';
+
+        $lines = [
+            '# laravel-sisp configuration ('.$mode.')',
+            'SISP_URL='.($mode === 'production'
+                ? 'https://mc.vinti4net.cv/biz_vbv_clientdata/biz_vbv_clientdata.jsp'
+                : 'https://mc.vinti4net.cv/BizMPIOnUs_PP/CardPayment'),
+            'SISP_POS_ID=your-pos-id',
+            'SISP_POS_AUT_CODE=your-pos-authorisation-code',
+            'SISP_MERCHANT_ID=your-merchant-id',
+            'SISP_CURRENCY=132',
+            'SISP_LANGUAGE_MESSAGES=PT',
+            'SISP_IS_3DSEC='.($mode === 'production' ? '1' : '0'),
+            'SISP_URL_MERCHANT_RESPONSE=https://your-app.test/sisp/callback',
+        ];
+
+        if ($mode === 'sandbox') {
+            $lines[] = 'SISP_SANDBOX=true';
+        }
+
+        $guidance = [
+            'POS credentials (SISP_POS_ID, SISP_POS_AUT_CODE, SISP_MERCHANT_ID) are issued by SISP.',
+            'SISP_URL_MERCHANT_RESPONSE must be a publicly reachable HTTPS URL hitting the /sisp/callback route.',
+            $mode === 'production'
+                ? '3D Secure is enabled: collect customer email, country, city, address, and phone.'
+                : 'Use the sisp-ops "build_payment_request" and the dev "simulate_sandbox_callback" tools to test without live credentials.',
+        ];
+
+        return Response::json([
+            'mode' => $mode,
+            'env' => implode("\n", $lines),
+            'guidance' => $guidance,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'mode' => $schema->string()
+                ->description('Target environment for the generated variables.')
+                ->enum(['sandbox', 'production'])
+                ->default('sandbox'),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Dev/ErrorCodeLookupTool.php
+++ b/src/Mcp/Tools/Dev/ErrorCodeLookupTool.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Akira\Sisp\Enums\ErrorMessageType;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Resolve a SISP error/response code to its label, category, and recommended remediation action.')]
+final class ErrorCodeLookupTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $code = mb_trim((string) $request->get('code'));
+        $error = ErrorMessageType::tryFrom($code);
+
+        if (! $error instanceof ErrorMessageType) {
+            return Response::error("Unknown SISP error code \"{$code}\". Codes range from 1 to 99; 99 is the generic error.");
+        }
+
+        return Response::json([
+            'code' => $error->value,
+            'name' => $error->name,
+            'label' => $error->label(),
+            'category' => $error->category(),
+            'category_label' => $error->categoryLabel(),
+            'action' => $error->action(),
+            'action_label' => $error->actionLabel(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'code' => $schema->string()
+                ->description('The numeric SISP response/error code, e.g. "51" for insufficient funds.')
+                ->required(),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Dev/GetDocTool.php
+++ b/src/Mcp/Tools/Dev/GetDocTool.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Return the full markdown content of a single laravel-sisp documentation page by its slug.')]
+final class GetDocTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $slug = basename((string) $request->get('doc'), '.md');
+        $file = dirname(__DIR__, 4)."/docs/{$slug}.md";
+
+        if (! is_file($file)) {
+            return Response::error("Unknown doc \"{$slug}\". Use one of: ".implode(', ', $this->slugs()));
+        }
+
+        return Response::text((string) file_get_contents($file));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'doc' => $schema->string()
+                ->description('Documentation slug, e.g. "01-installation" or "14-idempotency".')
+                ->enum($this->slugs())
+                ->required(),
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function slugs(): array
+    {
+        return array_map(
+            static fn (string $file): string => basename($file, '.md'),
+            glob(dirname(__DIR__, 4).'/docs/*.md') ?: [],
+        );
+    }
+}

--- a/src/Mcp/Tools/Dev/SearchDocsTool.php
+++ b/src/Mcp/Tools/Dev/SearchDocsTool.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Search the laravel-sisp documentation for a keyword and return matching sections with their source file.')]
+final class SearchDocsTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $query = mb_strtolower(mb_trim((string) $request->get('query')));
+
+        if ($query === '') {
+            return Response::error('Provide a non-empty "query" to search the documentation.');
+        }
+
+        $limit = max(1, min(20, (int) ($request->get('limit') ?? 10)));
+
+        $matches = [];
+
+        foreach (glob(dirname(__DIR__, 4).'/docs/*.md') ?: [] as $file) {
+            $contents = (string) file_get_contents($file);
+
+            foreach (preg_split('/\n(?=#{1,6}\s)/', $contents) ?: [] as $section) {
+                if (str_contains(mb_strtolower($section), $query)) {
+                    $heading = mb_trim((string) (preg_split('/\n/', $section)[0] ?? ''));
+
+                    $matches[] = [
+                        'doc' => basename($file, '.md'),
+                        'heading' => $heading,
+                        'excerpt' => mb_substr(mb_trim($section), 0, 600),
+                    ];
+
+                    if (count($matches) >= $limit) {
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        if ($matches === []) {
+            return Response::text("No documentation sections matched \"{$query}\".");
+        }
+
+        return Response::json(['query' => $query, 'matches' => $matches]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()
+                ->description('Keyword or phrase to search for across the docs/ folder.')
+                ->required(),
+            'limit' => $schema->integer()
+                ->description('Maximum number of matching sections to return (1-20).')
+                ->default(10),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Dev/SimulateSandboxCallbackTool.php
+++ b/src/Mcp/Tools/Dev/SimulateSandboxCallbackTool.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Dev;
+
+use Akira\Sisp\Builders\PaymentBuilder;
+use Akira\Sisp\Facades\Sisp;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Throwable;
+
+#[IsReadOnly]
+#[Description('Build a sandbox SISP callback payload for a given payment shape so a callback can be tested locally. Does not persist anything or contact the gateway.')]
+final class SimulateSandboxCallbackTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'amount' => ['required', 'numeric', 'gt:0'],
+            'status' => ['nullable', 'in:success,failed'],
+        ]);
+
+        $builder = resolve(PaymentBuilder::class)->amount((float) $request->get('amount'));
+
+        foreach (['currency', 'locale', 'customerEmail'] as $field) {
+            $value = $request->get($field);
+
+            if ($value !== null && method_exists($builder, $field)) {
+                $builder->{$field}((string) $value);
+            }
+        }
+
+        try {
+            $payload = Sisp::generateSandboxPayload($builder->toData(), (string) ($request->get('status') ?? 'success'));
+        } catch (Throwable $e) {
+            return Response::error('Could not build sandbox payload: '.$e->getMessage());
+        }
+
+        return Response::json([
+            'status' => $request->get('status') ?? 'success',
+            'callback' => $payload->toArray(),
+            'note' => 'POST these fields to the /sisp/callback route to exercise the callback pipeline.',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'amount' => $schema->number()
+                ->description('Payment amount in major currency units, e.g. 1500.00.')
+                ->required(),
+            'status' => $schema->string()
+                ->description('Outcome to simulate.')
+                ->enum(['success', 'failed'])
+                ->default('success'),
+            'currency' => $schema->string()
+                ->description('ISO 4217 numeric currency code. Defaults to the configured currency.'),
+            'locale' => $schema->string()
+                ->description('Locale for the payment, e.g. "pt".'),
+            'customerEmail' => $schema->string()
+                ->description('Customer email to embed in the payload.'),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/BuildPaymentRequestTool.php
+++ b/src/Mcp/Tools/Ops/BuildPaymentRequestTool.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Builders\PaymentBuilder;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Throwable;
+
+#[IsReadOnly]
+#[Description('Build a signed SISP payment request payload from the given inputs. Returns the form fields to post to the gateway; it does not persist a transaction or charge anything.')]
+final class BuildPaymentRequestTool extends Tool
+{
+    private const array STRING_FIELDS = [
+        'currency', 'transactionCode', 'token', 'entityCode', 'referenceNumber',
+        'locale', 'customerEmail', 'customerCountry', 'customerCity',
+        'customerAddress', 'customerPostalCode', 'customerPhone',
+        'merchantRef', 'merchantSession',
+    ];
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'amount' => ['required', 'numeric', 'gt:0'],
+        ]);
+
+        $builder = resolve(PaymentBuilder::class)->amount((float) $request->get('amount'));
+
+        foreach (self::STRING_FIELDS as $field) {
+            $value = $request->get($field);
+
+            if ($value !== null && $value !== '') {
+                $builder->{$field}((string) $value);
+            }
+        }
+
+        try {
+            $payload = $builder->build();
+        } catch (Throwable $e) {
+            return Response::error('Could not build payment request: '.$e->getMessage());
+        }
+
+        return Response::json([
+            'payment_request' => $payload->toArray(),
+            'note' => 'Post these fields as a form to the SISP gateway URL to start the hosted payment.',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'amount' => $schema->number()
+                ->description('Payment amount in major currency units, e.g. 1500.00.')
+                ->required(),
+            'currency' => $schema->string()->description('ISO 4217 numeric code. Defaults to the configured currency.'),
+            'transactionCode' => $schema->string()->description('SISP transaction code. Defaults to the configured code (1 = purchase).'),
+            'locale' => $schema->string()->description('Locale for the payment form, e.g. "pt".'),
+            'customerEmail' => $schema->string()->description('Customer email. Required when 3D Secure is enabled.'),
+            'customerCountry' => $schema->string()->description('Customer country (ISO alpha-2). Required when 3D Secure is enabled.'),
+            'customerCity' => $schema->string()->description('Customer city. Required when 3D Secure is enabled.'),
+            'customerAddress' => $schema->string()->description('Customer address. Required when 3D Secure is enabled.'),
+            'customerPostalCode' => $schema->string()->description('Customer postal code.'),
+            'customerPhone' => $schema->string()->description('Customer phone number.'),
+            'token' => $schema->string()->description('Stored card token for token payments.'),
+            'entityCode' => $schema->string()->description('Entity code for service payments.'),
+            'referenceNumber' => $schema->string()->description('Reference number for service payments.'),
+            'merchantRef' => $schema->string()->description('Override the generated merchant reference.'),
+            'merchantSession' => $schema->string()->description('Override the generated merchant session.'),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/CancelTransactionTool.php
+++ b/src/Mcp/Tools/Ops/CancelTransactionTool.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Actions\CancelTransactionAction;
+use Akira\Sisp\Mcp\Concerns\AuthorizesTransactionOps;
+use Akira\Sisp\Mcp\Concerns\ResolvesTransaction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Throwable;
+
+#[IsDestructive]
+#[Description('Cancel a pending SISP transaction. Completed or already-cancelled transactions cannot be cancelled.')]
+final class CancelTransactionTool extends Tool
+{
+    use AuthorizesTransactionOps;
+    use ResolvesTransaction;
+
+    public function handle(Request $request, CancelTransactionAction $cancel): Response
+    {
+        $request->validate([
+            'transaction' => ['required', 'string'],
+            'reason' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $transaction = $this->resolveTransaction((string) $request->get('transaction'));
+
+        if (! $transaction instanceof \Akira\Sisp\Models\Transaction) {
+            return Response::error('No transaction found for "'.$request->get('transaction').'".');
+        }
+
+        if (! $this->isAuthorized($request, $transaction)) {
+            return Response::error('Not authorized to cancel this transaction.');
+        }
+
+        try {
+            $transaction = $cancel->handle($transaction, (string) ($request->get('reason') ?? 'user_cancelled'));
+        } catch (Throwable $e) {
+            return Response::error('Cancel failed: '.$e->getMessage());
+        }
+
+        return Response::json($this->transactionSummary($transaction));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'transaction' => $schema->string()
+                ->description('Transaction id (numeric) or merchant reference to cancel.')
+                ->required(),
+            'reason' => $schema->string()
+                ->description('Reason recorded with the cancellation.'),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/GetTransactionTool.php
+++ b/src/Mcp/Tools/Ops/GetTransactionTool.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Mcp\Concerns\ResolvesTransaction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('Fetch a stored SISP transaction by its id or merchant reference.')]
+final class GetTransactionTool extends Tool
+{
+    use ResolvesTransaction;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['transaction' => ['required', 'string']]);
+
+        $transaction = $this->resolveTransaction((string) $request->get('transaction'));
+
+        if (! $transaction instanceof \Akira\Sisp\Models\Transaction) {
+            return Response::error('No transaction found for "'.$request->get('transaction').'".');
+        }
+
+        return Response::json($this->transactionSummary($transaction));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'transaction' => $schema->string()
+                ->description('Transaction id (numeric) or merchant reference.')
+                ->required(),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/ListTransactionsTool.php
+++ b/src/Mcp/Tools/Ops/ListTransactionsTool.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Mcp\Concerns\ResolvesTransaction;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('List stored SISP transactions with optional status and date filters.')]
+final class ListTransactionsTool extends Tool
+{
+    use ResolvesTransaction;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'status' => ['nullable', 'string'],
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $status = $request->get('status');
+
+        if ($status !== null && TransactionStatus::tryFrom((string) $status) === null) {
+            return Response::error('Invalid status. Use one of: '.implode(', ', array_column(TransactionStatus::cases(), 'value')));
+        }
+
+        $limit = max(1, min(100, (int) ($request->get('limit') ?? 25)));
+
+        $transactions = Transaction::query()
+            ->when($status !== null, fn (Builder $query) => $query->where('status', $status))
+            ->when($request->get('from') !== null, fn (Builder $query) => $query->where('created_at', '>=', $request->get('from')))
+            ->when($request->get('to') !== null, fn (Builder $query) => $query->where('created_at', '<=', $request->get('to')))
+            ->latest()
+            ->limit($limit)
+            ->get()
+            ->map(fn (Transaction $transaction): array => $this->transactionSummary($transaction))
+            ->all();
+
+        return Response::json([
+            'count' => count($transactions),
+            'transactions' => $transactions,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'status' => $schema->string()
+                ->description('Filter by transaction status.')
+                ->enum(array_column(TransactionStatus::cases(), 'value')),
+            'from' => $schema->string()->description('Only transactions created on or after this date (ISO 8601).'),
+            'to' => $schema->string()->description('Only transactions created on or before this date (ISO 8601).'),
+            'limit' => $schema->integer()->description('Maximum rows to return (1-100).')->default(25),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/QueryTransactionStatusTool.php
+++ b/src/Mcp/Tools/Ops/QueryTransactionStatusTool.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Facades\Sisp;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Throwable;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[Description('Query the live status of a transaction at the SISP gateway by transaction id or merchant reference.')]
+final class QueryTransactionStatusTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $request->validate(['transaction' => ['required', 'string']]);
+
+        try {
+            $status = Sisp::queryTransactionStatus((string) $request->get('transaction'));
+        } catch (Throwable $e) {
+            return Response::error('Could not query transaction status: '.$e->getMessage());
+        }
+
+        return Response::json([
+            'result' => $status->result,
+            'transaction_success' => $status->transactionSuccess,
+            'payment_status' => $status->paymentStatus()->value,
+            'description' => $status->transactionStatusDescription,
+            'message' => $status->message,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'transaction' => $schema->string()
+                ->description('Transaction id (numeric) or merchant reference to query at SISP.')
+                ->required(),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/ReconcileTransactionTool.php
+++ b/src/Mcp/Tools/Ops/ReconcileTransactionTool.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Mcp\Concerns\ResolvesTransaction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Throwable;
+
+#[IsIdempotent]
+#[Description('Reconcile a stored transaction against the SISP gateway and persist the resolved status. Safe to call repeatedly.')]
+final class ReconcileTransactionTool extends Tool
+{
+    use ResolvesTransaction;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['transaction' => ['required', 'string']]);
+
+        $transaction = $this->resolveTransaction((string) $request->get('transaction'));
+
+        if (! $transaction instanceof \Akira\Sisp\Models\Transaction) {
+            return Response::error('No transaction found for "'.$request->get('transaction').'".');
+        }
+
+        try {
+            $transaction = Sisp::reconcileTransactionStatus($transaction);
+        } catch (Throwable $e) {
+            return Response::error('Could not reconcile transaction: '.$e->getMessage());
+        }
+
+        return Response::json($this->transactionSummary($transaction));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'transaction' => $schema->string()
+                ->description('Transaction id (numeric) or merchant reference to reconcile.')
+                ->required(),
+        ];
+    }
+}

--- a/src/Mcp/Tools/Ops/RefundTransactionTool.php
+++ b/src/Mcp/Tools/Ops/RefundTransactionTool.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Mcp\Tools\Ops;
+
+use Akira\Sisp\Facades\Sisp;
+use Akira\Sisp\Mcp\Concerns\AuthorizesTransactionOps;
+use Akira\Sisp\Mcp\Concerns\ResolvesTransaction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Throwable;
+
+#[IsDestructive]
+#[Description('Refund a completed SISP transaction, fully or partially. This moves money and cannot be undone.')]
+final class RefundTransactionTool extends Tool
+{
+    use AuthorizesTransactionOps;
+    use ResolvesTransaction;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'transaction' => ['required', 'string'],
+            'amount' => ['nullable', 'numeric', 'gt:0'],
+            'reason' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $transaction = $this->resolveTransaction((string) $request->get('transaction'));
+
+        if (! $transaction instanceof \Akira\Sisp\Models\Transaction) {
+            return Response::error('No transaction found for "'.$request->get('transaction').'".');
+        }
+
+        if (! $this->isAuthorized($request, $transaction)) {
+            return Response::error('Not authorized to refund this transaction.');
+        }
+
+        $builder = Sisp::refund($transaction);
+
+        $amount = $request->get('amount');
+        $amount !== null ? $builder->amount((float) $amount) : $builder->full();
+
+        if ($request->get('reason') !== null) {
+            $builder->reason((string) $request->get('reason'));
+        }
+
+        try {
+            $transaction = $builder->process();
+        } catch (Throwable $e) {
+            return Response::error('Refund failed: '.$e->getMessage());
+        }
+
+        return Response::json($this->transactionSummary($transaction));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'transaction' => $schema->string()
+                ->description('Transaction id (numeric) or merchant reference to refund.')
+                ->required(),
+            'amount' => $schema->number()
+                ->description('Amount to refund in major currency units. Omit to refund the full amount.'),
+            'reason' => $schema->string()
+                ->description('Reason recorded with the refund.'),
+        ];
+    }
+}

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -9,7 +9,6 @@ use Akira\Sisp\Commands\LaravelSispInstallCommand;
 use Akira\Sisp\Commands\ReconcilePendingTransactionsCommand;
 use Akira\Sisp\Commands\RegenerateMissingInvoicePdfsCommand;
 use Akira\Sisp\Commands\TransactionStatusCommand;
-use Akira\Sisp\Configuration\LoadConfig;
 use Akira\Sisp\Contracts\SispDriver;
 use Akira\Sisp\Drivers\SispManager;
 use Illuminate\Contracts\Foundation\Application;
@@ -43,20 +42,10 @@ final class SispServiceProvider extends PackageServiceProvider
             ]);
     }
 
-    /**
-     * Container bindings are declared with native container
-     * attributes: #[Bind] on the contracts and #[Singleton] on
-     * LoadConfig, SispManager, and Sisp. Only the driver contract needs
-     * an explicit closure since it is resolved through the manager.
-     */
     public function register(): void
     {
         parent::register();
 
-        // #[Bind] container attributes are only consulted when an environment
-        // resolver is present. Full applications register one during bootstrap,
-        // but lighter harnesses such as Testbench do not, so mirror the
-        // framework's default resolver here.
         $this->app->resolveEnvironmentUsing(fn (array $environments): bool => (bool) $this->app->environment($environments));
 
         $this->app->bind(SispDriver::class, fn (Application $app): SispDriver => $app->make(SispManager::class)->driver());
@@ -66,8 +55,22 @@ final class SispServiceProvider extends PackageServiceProvider
     {
         $this->registerComponents();
         $this->registerFactories();
+        $this->registerMcp();
 
         return parent::boot();
+    }
+
+    private function registerMcp(): void
+    {
+        if (! class_exists(\Laravel\Mcp\Server::class)) {
+            return;
+        }
+
+        if (! config('sisp.mcp.enabled', false)) {
+            return;
+        }
+
+        $this->loadRoutesFrom(__DIR__.'/../routes/ai.php');
     }
 
     private function registerFactories(): void

--- a/src/Support/Diagnostics.php
+++ b/src/Support/Diagnostics.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Support;
+
+use Akira\Sisp\Enums\InvoiceStatus;
+use Akira\Sisp\Models\Invoice;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+final class Diagnostics
+{
+    /**
+     * @return array{disk: string, path: string, driver: ?string, root: ?string, bucket: ?string}
+     */
+    public function configuration(): array
+    {
+        $disk = (string) config('sisp.invoice.disk', 'public');
+
+        return [
+            'disk' => $disk,
+            'path' => $this->invoiceStoragePath(),
+            'driver' => config("filesystems.disks.{$disk}.driver"),
+            'root' => $disk === 'public' ? config('filesystems.disks.public.root') : null,
+            'bucket' => $disk === 's3' ? config('filesystems.disks.s3.bucket') : null,
+        ];
+    }
+
+    /**
+     * @return array{accessible: bool, directory_writable: bool, error: ?string}
+     */
+    public function storage(): array
+    {
+        $disk = (string) config('sisp.invoice.disk', 'public');
+        $path = $this->invoiceStoragePath();
+
+        try {
+            $accessible = Storage::disk($disk)->exists('');
+            Storage::disk($disk)->makeDirectory($path);
+            $testFile = $path.'/sisp-doctor-test.txt';
+            Storage::disk($disk)->put($testFile, 'test');
+            Storage::disk($disk)->delete($testFile);
+
+            return ['accessible' => $accessible, 'directory_writable' => true, 'error' => null];
+        } catch (Throwable $e) {
+            return ['accessible' => false, 'directory_writable' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * @return array{total: int, paid: int, with_pdf: int, paid_without_pdf: int}
+     */
+    public function invoices(): array
+    {
+        return [
+            'total' => Invoice::query()->count(),
+            'paid' => Invoice::query()->where('status', InvoiceStatus::paid->value)->count(),
+            'with_pdf' => Invoice::query()->whereNotNull('pdf_path')->count(),
+            'paid_without_pdf' => Invoice::query()
+                ->where('status', InvoiceStatus::paid->value)
+                ->whereNull('pdf_path')
+                ->count(),
+        ];
+    }
+
+    /**
+     * @return array{configuration: array<string, mixed>, storage: array<string, mixed>, invoices: array<string, mixed>}
+     */
+    public function all(): array
+    {
+        return [
+            'configuration' => $this->configuration(),
+            'storage' => $this->storage(),
+            'invoices' => $this->invoices(),
+        ];
+    }
+
+    private function invoiceStoragePath(): string
+    {
+        return mb_trim((string) config('sisp.invoice.path', 'invoices'), '/') ?: 'invoices';
+    }
+}

--- a/tests/Feature/Mcp/DevToolsTest.php
+++ b/tests/Feature/Mcp/DevToolsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Mcp\Servers\SispDevServer;
+use Akira\Sisp\Mcp\Tools\Dev\ConfigReferenceTool;
+use Akira\Sisp\Mcp\Tools\Dev\CountryReferenceTool;
+use Akira\Sisp\Mcp\Tools\Dev\DoctorTool;
+use Akira\Sisp\Mcp\Tools\Dev\EnumReferenceTool;
+use Akira\Sisp\Mcp\Tools\Dev\EnvScaffoldTool;
+use Akira\Sisp\Mcp\Tools\Dev\ErrorCodeLookupTool;
+use Akira\Sisp\Mcp\Tools\Dev\SearchDocsTool;
+use Akira\Sisp\Mcp\Tools\Dev\SimulateSandboxCallbackTool;
+use Akira\Sisp\Models\Transaction;
+
+it('searches the documentation', function (): void {
+    SispDevServer::tool(SearchDocsTool::class, ['query' => 'idempotency'])
+        ->assertOk()
+        ->assertSee('idempotency');
+});
+
+it('rejects an empty docs query', function (): void {
+    SispDevServer::tool(SearchDocsTool::class, ['query' => '  '])
+        ->assertHasErrors();
+});
+
+it('lists enum cases', function (): void {
+    SispDevServer::tool(EnumReferenceTool::class, ['enum' => 'transaction_status'])
+        ->assertOk()
+        ->assertSee('completed')
+        ->assertSee('refunded');
+});
+
+it('rejects an unknown enum', function (): void {
+    SispDevServer::tool(EnumReferenceTool::class, ['enum' => 'nope'])
+        ->assertHasErrors();
+});
+
+it('resolves a known error code', function (): void {
+    SispDevServer::tool(ErrorCodeLookupTool::class, ['code' => '51'])
+        ->assertOk()
+        ->assertSee('funds');
+});
+
+it('errors on an unknown error code', function (): void {
+    SispDevServer::tool(ErrorCodeLookupTool::class, ['code' => '4242'])
+        ->assertHasErrors();
+});
+
+it('returns the numeric code for a country', function (): void {
+    SispDevServer::tool(CountryReferenceTool::class, ['alpha2' => 'cv'])
+        ->assertOk()
+        ->assertSee('132');
+});
+
+it('describes a config key', function (): void {
+    SispDevServer::tool(ConfigReferenceTool::class, ['key' => 'currency'])
+        ->assertOk()
+        ->assertSee('currency');
+});
+
+it('redacts the pos auth code in the config reference', function (): void {
+    SispDevServer::tool(ConfigReferenceTool::class, ['key' => 'posAutCode'])
+        ->assertOk()
+        ->assertSee('redacted');
+});
+
+it('scaffolds env variables', function (): void {
+    SispDevServer::tool(EnvScaffoldTool::class, ['mode' => 'production'])
+        ->assertOk()
+        ->assertSee('SISP_POS_ID');
+});
+
+it('runs diagnostics without throwing', function (): void {
+    SispDevServer::tool(DoctorTool::class, [])
+        ->assertOk()
+        ->assertSee('invoices');
+});
+
+it('simulates a sandbox callback without persisting a transaction', function (): void {
+    config()->set('sisp.sandbox', true);
+
+    SispDevServer::tool(SimulateSandboxCallbackTool::class, ['amount' => 100, 'status' => 'success'])
+        ->assertOk();
+
+    expect(Transaction::query()->count())->toBe(0);
+});

--- a/tests/Feature/Mcp/OpsToolsTest.php
+++ b/tests/Feature/Mcp/OpsToolsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Enums\TransactionStatus;
+use Akira\Sisp\Mcp\Servers\SispOpsServer;
+use Akira\Sisp\Mcp\Tools\Ops\BuildPaymentRequestTool;
+use Akira\Sisp\Mcp\Tools\Ops\CancelTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\GetTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\ListTransactionsTool;
+use Akira\Sisp\Mcp\Tools\Ops\QueryTransactionStatusTool;
+use Akira\Sisp\Mcp\Tools\Ops\ReconcileTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\RefundTransactionTool;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Http;
+
+it('builds a payment request without persisting a transaction', function (): void {
+    SispOpsServer::tool(BuildPaymentRequestTool::class, ['amount' => 1500.0])
+        ->assertOk()
+        ->assertSee('payment_request');
+
+    expect(Transaction::query()->count())->toBe(0);
+});
+
+it('rejects a non-positive amount', function (): void {
+    SispOpsServer::tool(BuildPaymentRequestTool::class, ['amount' => 0])
+        ->assertHasErrors();
+});
+
+it('fetches a transaction by merchant reference', function (): void {
+    $transaction = Transaction::factory()->create(['merchant_ref' => 'REF-123']);
+
+    SispOpsServer::tool(GetTransactionTool::class, ['transaction' => 'REF-123'])
+        ->assertOk()
+        ->assertSee('REF-123');
+});
+
+it('fetches a transaction by id', function (): void {
+    $transaction = Transaction::factory()->create();
+
+    SispOpsServer::tool(GetTransactionTool::class, ['transaction' => (string) $transaction->id])
+        ->assertOk()
+        ->assertSee($transaction->merchant_ref);
+});
+
+it('errors when a transaction is not found', function (): void {
+    SispOpsServer::tool(GetTransactionTool::class, ['transaction' => 'missing'])
+        ->assertHasErrors();
+});
+
+it('lists transactions filtered by status', function (): void {
+    Transaction::factory()->completed()->create();
+    Transaction::factory()->pending()->create();
+
+    SispOpsServer::tool(ListTransactionsTool::class, ['status' => 'completed'])
+        ->assertOk()
+        ->assertSee('completed');
+});
+
+it('rejects an invalid status filter', function (): void {
+    SispOpsServer::tool(ListTransactionsTool::class, ['status' => 'bogus'])
+        ->assertHasErrors();
+});
+
+it('queries the live transaction status', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake(['*' => Http::response([
+        'result' => true,
+        'transactionSuccess' => true,
+        'transactionStatusDescription' => 'C-SUCESSO',
+        'msg' => 'Approved',
+    ])]);
+
+    $transaction = Transaction::factory()->create(['merchant_ref' => 'REF-Q']);
+
+    SispOpsServer::tool(QueryTransactionStatusTool::class, ['transaction' => 'REF-Q'])
+        ->assertOk()
+        ->assertSee('completed');
+});
+
+it('reconciles a pending transaction', function (): void {
+    config()->set('sisp.transaction_status.portal_id', 'portal');
+    config()->set('sisp.transaction_status.portal_password', 'secret');
+
+    Http::fake(['*' => Http::response([
+        'result' => true,
+        'transactionSuccess' => true,
+        'transactionStatusDescription' => 'C-SUCESSO',
+        'msg' => 'Approved',
+    ])]);
+
+    $transaction = Transaction::factory()->create(['status' => 'pending', 'merchant_ref' => 'REF-R']);
+
+    SispOpsServer::tool(ReconcileTransactionTool::class, ['transaction' => 'REF-R'])
+        ->assertOk()
+        ->assertSee('completed');
+
+    expect($transaction->fresh()->status)->toBe(TransactionStatus::completed);
+});
+
+it('refunds a completed transaction in full', function (): void {
+    $transaction = Transaction::factory()->completed()->create([
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    SispOpsServer::tool(RefundTransactionTool::class, ['transaction' => (string) $transaction->id])
+        ->assertOk()
+        ->assertSee('refunded');
+
+    expect($transaction->fresh()->status)->toBe(TransactionStatus::refunded);
+});
+
+it('refunds a completed transaction partially', function (): void {
+    $transaction = Transaction::factory()->completed()->create([
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    SispOpsServer::tool(RefundTransactionTool::class, [
+        'transaction' => (string) $transaction->id,
+        'amount' => 40.0,
+        'reason' => 'partial_return',
+    ])->assertOk();
+});
+
+it('fails to refund a pending transaction', function (): void {
+    $transaction = Transaction::factory()->pending()->create();
+
+    SispOpsServer::tool(RefundTransactionTool::class, ['transaction' => (string) $transaction->id])
+        ->assertHasErrors();
+});
+
+it('cancels a pending transaction', function (): void {
+    $transaction = Transaction::factory()->pending()->create();
+
+    SispOpsServer::tool(CancelTransactionTool::class, ['transaction' => (string) $transaction->id])
+        ->assertOk()
+        ->assertSee('cancelled');
+
+    expect($transaction->fresh()->status)->toBe(TransactionStatus::cancelled);
+});
+
+it('fails to cancel a completed transaction', function (): void {
+    $transaction = Transaction::factory()->completed()->create();
+
+    SispOpsServer::tool(CancelTransactionTool::class, ['transaction' => (string) $transaction->id])
+        ->assertHasErrors();
+});

--- a/tests/Feature/Mcp/RegistrationTest.php
+++ b/tests/Feature/Mcp/RegistrationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Facades\Mcp;
+
+function loadAiRoutes(): void
+{
+    require dirname(__DIR__, 3).'/routes/ai.php';
+}
+
+it('registers both local servers', function (): void {
+    config()->set('sisp.mcp.local', true);
+    config()->set('sisp.mcp.web.enabled', false);
+
+    loadAiRoutes();
+
+    expect(Mcp::getLocalServer('sisp-dev'))->not->toBeNull()
+        ->and(Mcp::getLocalServer('sisp-ops'))->not->toBeNull();
+});
+
+it('does not register the web server when the web transport is disabled', function (): void {
+    config()->set('sisp.mcp.local', false);
+    config()->set('sisp.mcp.web.enabled', false);
+
+    loadAiRoutes();
+
+    expect(Mcp::getWebServer('sisp/mcp'))->toBeNull();
+});
+
+it('registers the web server when the web transport is enabled', function (): void {
+    config()->set('sisp.mcp.local', false);
+    config()->set('sisp.mcp.web.enabled', true);
+    config()->set('sisp.mcp.web.path', '/sisp/mcp');
+
+    loadAiRoutes();
+
+    expect(Mcp::getWebServer('sisp/mcp'))->not->toBeNull();
+});

--- a/tests/Feature/Mcp/ServersTest.php
+++ b/tests/Feature/Mcp/ServersTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Mcp\Prompts\DiagnosePaymentFailurePrompt;
+use Akira\Sisp\Mcp\Prompts\IntegrateSispPrompt;
+use Akira\Sisp\Mcp\Resources\CountryCatalogResource;
+use Akira\Sisp\Mcp\Resources\DocsIndexResource;
+use Akira\Sisp\Mcp\Resources\EnumCatalogResource;
+use Akira\Sisp\Mcp\Resources\ErrorCodeCatalogResource;
+use Akira\Sisp\Mcp\Servers\SispDevServer;
+use Akira\Sisp\Mcp\Servers\SispWebOpsServer;
+use Akira\Sisp\Mcp\Tools\Ops\CancelTransactionTool;
+use Akira\Sisp\Mcp\Tools\Ops\RefundTransactionTool;
+use Laravel\Mcp\Server\Transport\FakeTransporter;
+
+it('exposes the docs index resource', function (): void {
+    SispDevServer::resource(DocsIndexResource::class)
+        ->assertOk()
+        ->assertSee('installation');
+});
+
+it('exposes the enum, country, and error-code catalog resources', function (): void {
+    SispDevServer::resource(EnumCatalogResource::class)->assertOk()->assertSee('transaction_status');
+    SispDevServer::resource(CountryCatalogResource::class)->assertOk()->assertSee('132');
+    SispDevServer::resource(ErrorCodeCatalogResource::class)->assertOk()->assertSee('insufficientFunds');
+});
+
+it('renders the integration prompt for a stack', function (): void {
+    SispDevServer::prompt(IntegrateSispPrompt::class, ['stack' => 'inertia-react'])
+        ->assertOk()
+        ->assertSee('inertia-react');
+});
+
+it('renders the failure diagnosis prompt for a code', function (): void {
+    SispDevServer::prompt(DiagnosePaymentFailurePrompt::class, ['code' => '51'])
+        ->assertOk()
+        ->assertSee('funds');
+});
+
+it('hides destructive tools on the web server by default', function (): void {
+    config()->set('sisp.mcp.web.expose_destructive', false);
+
+    expect(webOpsTools())
+        ->not->toContain(RefundTransactionTool::class)
+        ->not->toContain(CancelTransactionTool::class);
+});
+
+it('exposes destructive tools on the web server when opted in', function (): void {
+    config()->set('sisp.mcp.web.expose_destructive', true);
+
+    expect(webOpsTools())
+        ->toContain(RefundTransactionTool::class)
+        ->toContain(CancelTransactionTool::class);
+});
+
+function webOpsTools(): array
+{
+    $server = new SispWebOpsServer(new FakeTransporter);
+
+    $property = new ReflectionProperty($server, 'tools');
+
+    return $property->getValue($server);
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,10 +42,8 @@ abstract class TestCase extends Orchestra
         config()->set('sisp.transaction_code', '1');
         config()->set('sisp.url_merchant_response', 'https://localhost/sisp/callback');
 
-        // App key for encryption
         $app->make(Repository::class)->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
 
-        // Set application namespace for Blade component compilation
         $app->singleton('namespace', fn (): string => 'App\\');
     }
 
@@ -57,6 +55,7 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [
+            \Laravel\Mcp\Server\McpServiceProvider::class,
             SispServiceProvider::class,
         ];
     }

--- a/tests/ValueObjects/PaymentRequestDataTest.php
+++ b/tests/ValueObjects/PaymentRequestDataTest.php
@@ -169,10 +169,7 @@ it('reports missing three d secure fields', function (): void {
     $data = new PaymentRequestData(
         amount: 120.00,
         customerEmail: 'customer@example.com',
-        customerCountry: null,
         customerCity: 'Lisbon',
-        customerAddress: null,
-        customerPostalCode: null,
     );
 
     expect($data->hasThreeDSecureData())->toBeFalse()
@@ -186,9 +183,7 @@ it('reports missing three d secure fields', function (): void {
 it('reports missing email and city for three d secure data', function (): void {
     $data = new PaymentRequestData(
         amount: 120.00,
-        customerEmail: null,
         customerCountry: 'PT',
-        customerCity: null,
         customerAddress: 'Rua Augusta',
         customerPostalCode: '1100-048',
     );


### PR DESCRIPTION
## Summary

Adds an opt-in [laravel/mcp](https://github.com/laravel/mcp) server inside the package so AI agents can **integrate** laravel-sisp into a host app and **operate** the gateway. Rebased on the 3.0 work on `main` and hardened after a security review of the whole MCP surface.

| Server | Handle | Transport | Surface |
| --- | --- | --- | --- |
| `SispDevServer` | `sisp-dev` | local | Read-only developer assistance |
| `SispOpsServer` | `sisp-ops` | local | Runtime payment operations |
| `SispWebOpsServer` | `sisp-ops` | web | Runtime operations over HTTP; destructive tools behind a flag |

**Dev tools (8):** docs search/get, config reference, env scaffold, enum and country reference, sandbox callback simulation, doctor. Resources `sisp://docs|enums|countries` and two prompts (integration walkthrough, failure diagnosis from a stored transaction).

**Ops tools (7):** payment request preview, status query, get, list, reconcile, refund, cancel.

## Security model

- Disabled by default (`sisp.mcp.enabled`); `routes/ai.php` only loads when it is on.
- Every web tool call asks the `sisp.mcp.web.ability` Gate (default `sisp-mcp`, undefined, so everything is denied until the host defines it) with the operation name and the transaction. A web call without a user is denied even if the route middleware is removed. Default middleware: `auth:sanctum`, `throttle:60,1`.
- Listings ask `view` for every row, so a gate scoped per merchant or owner scopes the list too. A missing and a denied transaction return the same error on the web.
- Refund validates with `RefundTransactionRequest` rules, checks the same `refund` policy as the HTTP route and runs through `RefundTransactionAction` (row lock, balance check). Cancel runs through `CancelTransactionAction` and reports why terminal statuses cannot be cancelled.
- Refund and cancel stay off the web transport unless `expose_destructive` is on.
- The transaction summary never returns `merchant_session` (it cancels a pending payment through the public callback), payloads, the PAN or 3-D Secure data; the email is masked. `error_code`/`error_message` are returned, the latter only stored with a valid fingerprint and capped at 255 characters.
- The config reference redacts nested credentials through the same `SensitiveData` rule as request metadata.
- The payment request tool returns a preview without the fingerprint, so it cannot start an unrecorded charge. The sandbox simulation refuses outside sandbox mode.
- Only `LogicException` becomes a tool error; anything else goes to laravel/mcp, which hides it unless `app.debug` is on.

## Alignment with 3.0

- No error-code catalogue: `ErrorMessageType` is deprecated on main because SISP's `messageType` is not an ISO-8583 code. Diagnosis works from the stored `error_code` and `error_message`.
- `refunded` status on transactions and invoices, `LogicException` from cancel for `failed`/`refunded`, refund payload validation, error fingerprint formula for simulated failures.

## Packaging

- `laravel/mcp: ^0.8|^1.0` (suite passes on both).
- `docs/*.md` now ship in the archive, since the docs tools read them; only `docs/superpowers` stays out.
- The stale v2 audit report is removed.

## Tests

113 feature tests under `tests/Feature/Mcp` plus `tests/Support/SensitiveDataTest.php`, including an HTTP call to the web route without auth middleware and a simulated sandbox callback posted to `/sisp/callback`. Full suite: 735 passing, each commit green. pint, rector, peck, arch, phpstan and 100% type coverage pass; MCP classes are at 100% line coverage.
