### PR TITLE
fix(payments): pgsql-safe attempt numbering and v1 payment parity

### DIFF
--- a/database/migrations/create_sisp_transaction_attempts_table.php
+++ b/database/migrations/create_sisp_transaction_attempts_table.php
@@ -25,6 +25,7 @@ return new class extends Migration
             $table->unsignedInteger('attempt_number');
             $table->string('merchant_ref');
             $table->string('merchant_session');
+            $table->string('attempt_session')->nullable();
             $table->string('status')->default('pending');
             $table->string('gateway_transaction_id')->nullable();
             $table->string('message_type')->nullable();
@@ -44,6 +45,7 @@ return new class extends Migration
             $table->unique(['transaction_id', 'attempt_number']);
             $table->index(['transaction_id', 'status']);
             $table->index('gateway_transaction_id');
+            $table->index('attempt_session');
         });
 
         $this->backfillCurrentAttempts($transactionsTable, $attemptsTable);

--- a/src/Actions/CreateTransactionAttemptAction.php
+++ b/src/Actions/CreateTransactionAttemptAction.php
@@ -11,9 +11,9 @@ use Akira\Sisp\ValueObjects\PaymentRequest;
 
 final readonly class CreateTransactionAttemptAction
 {
-    public function handle(Transaction $transaction, PaymentRequest $paymentRequest, bool $supersedeCurrent = false): TransactionAttempt
+    public function handle(Transaction $transaction, PaymentRequest $paymentRequest, bool $supersedeCurrent = false, ?string $attemptSession = null): TransactionAttempt
     {
-        $attemptNumber = ((int) $transaction->attempts()->lockForUpdate()->max('attempt_number')) + 1;
+        $attemptNumber = ((int) $transaction->attempts()->max('attempt_number')) + 1;
 
         if ($supersedeCurrent) {
             $transaction->attempts()
@@ -26,6 +26,7 @@ final readonly class CreateTransactionAttemptAction
             'attempt_number' => $attemptNumber,
             'merchant_ref' => $paymentRequest->merchantRef,
             'merchant_session' => $paymentRequest->merchantSession,
+            'attempt_session' => $attemptSession ?? $paymentRequest->merchantSession,
             'status' => TransactionStatus::pending,
             'payload' => $paymentRequest->toArray(),
             'submitted_at' => now(),
@@ -34,13 +35,14 @@ final readonly class CreateTransactionAttemptAction
 
     public function createFromTransaction(Transaction $transaction): TransactionAttempt
     {
-        $attemptNumber = ((int) $transaction->attempts()->lockForUpdate()->max('attempt_number')) + 1;
+        $attemptNumber = ((int) $transaction->attempts()->max('attempt_number')) + 1;
 
         return TransactionAttempt::query()->create([
             'transaction_id' => $transaction->id,
             'attempt_number' => $attemptNumber,
             'merchant_ref' => $transaction->merchant_ref,
             'merchant_session' => $transaction->merchant_session,
+            'attempt_session' => $transaction->merchant_session,
             'status' => $transaction->status,
             'gateway_transaction_id' => $transaction->transaction_id,
             'message_type' => $transaction->message_type,

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -42,6 +42,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read  \Illuminate\Database\Eloquent\Collection<int, TransactionAttempt> $attempts
  * @property-read  TransactionAttempt|null $currentAttempt
  * @property-read  Invoice|null $invoice
+ * @property-read  \Illuminate\Support\Carbon|null $created_at
+ * @property-read  \Illuminate\Support\Carbon|null $updated_at
  */
 #[UseFactory(TransactionFactory::class)]
 #[Fillable([
@@ -79,11 +81,13 @@ final class Transaction extends Model
         return config('sisp.tables.transactions', 'sisp_transactions');
     }
 
+    /** @return HasMany<TransactionItem, $this> */
     public function items(): HasMany
     {
         return $this->hasMany(TransactionItem::class, 'transaction_id');
     }
 
+    /** @return HasMany<TransactionAttempt, $this> */
     public function attempts(): HasMany
     {
         return $this->hasMany(TransactionAttempt::class, 'transaction_id');

--- a/src/Models/TransactionAttempt.php
+++ b/src/Models/TransactionAttempt.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $attempt_number
  * @property string $merchant_ref
  * @property string $merchant_session
+ * @property string|null $attempt_session
  * @property TransactionStatus $status
  * @property string|null $gateway_transaction_id
  * @property string|null $message_type
@@ -39,6 +40,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
     'attempt_number',
     'merchant_ref',
     'merchant_session',
+    'attempt_session',
     'status',
     'gateway_transaction_id',
     'message_type',

--- a/src/Pipelines/Payment/Pipes/ApplyPaymentIntent.php
+++ b/src/Pipelines/Payment/Pipes/ApplyPaymentIntent.php
@@ -10,9 +10,7 @@ use Akira\Sisp\Contracts\PaymentPipe;
 use Akira\Sisp\Exceptions\PaymentIntentAlreadyProcessingException;
 use Akira\Sisp\Models\PaymentIntent;
 use Akira\Sisp\Models\Transaction;
-use Akira\Sisp\Models\TransactionAttempt;
 use Akira\Sisp\Pipelines\Payment\PaymentContext;
-use Akira\Sisp\ValueObjects\PaymentRequest;
 use Closure;
 use Illuminate\Support\Facades\DB;
 use Throwable;
@@ -124,26 +122,7 @@ final readonly class ApplyPaymentIntent implements PaymentPipe
             return $context;
         }
 
-        $context->paymentRequest = $this->paymentRequestFrom($transaction, $paymentIntentKey);
-
-        return $context;
-    }
-
-    private function paymentRequestFrom(Transaction $transaction, string $paymentIntentKey): PaymentRequest
-    {
-        $attempt = $transaction->currentAttempt()->first()
-            ?? $transaction->attempts()->latest('attempt_number')->first();
-
-        $payload = $attempt instanceof TransactionAttempt ? $attempt->payload : null;
-
-        if ($payload === null || $payload === []) {
-            $transactionPayload = $transaction->getAttribute('payload');
-            $payload = is_array($transactionPayload) ? $transactionPayload : null;
-        }
-
-        throw_if($payload === null || $payload === [], PaymentIntentAlreadyProcessingException::class, $paymentIntentKey);
-
-        return PaymentRequest::from($payload);
+        throw new PaymentIntentAlreadyProcessingException($paymentIntentKey);
     }
 
     private function submit(string $paymentIntentKey, Transaction $transaction): void

--- a/tests/Actions/CreateTransactionAttemptActionTest.php
+++ b/tests/Actions/CreateTransactionAttemptActionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Actions\CreateTransactionAttemptAction;
+use Akira\Sisp\Models\Transaction;
+use Akira\Sisp\ValueObjects\PaymentRequest;
+use Illuminate\Support\Facades\DB;
+
+function makeAttemptPaymentRequest(string $merchantRef, string $merchantSession): PaymentRequest
+{
+    return new PaymentRequest(
+        posID: 'POS1',
+        merchantRef: $merchantRef,
+        merchantSession: $merchantSession,
+        amount: 30.0,
+        currency: '132',
+        is3DSec: '1',
+        urlMerchantResponse: 'https://example.test/response',
+        languageMessages: 'pt',
+        timeStamp: '2026-01-01 01:01:01',
+        fingerprintversion: '1',
+        transactionCode: '1',
+        fingerprint: 'fingerprint',
+    );
+}
+
+it('numbers attempts sequentially per transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'R-ATTEMPT-SEQ',
+        'merchant_session' => 'S-ATTEMPT-SEQ',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $action = resolve(CreateTransactionAttemptAction::class);
+
+    $first = $action->handle($transaction, makeAttemptPaymentRequest('R-ATTEMPT-SEQ', 'S-ATTEMPT-SEQ'));
+    $second = $action->handle($transaction, makeAttemptPaymentRequest('R-ATTEMPT-SEQ', 'S-ATTEMPT-SEQ-2'), supersedeCurrent: true);
+
+    expect($first->attempt_number)->toBe(1)
+        ->and($second->attempt_number)->toBe(2)
+        ->and($first->refresh()->superseded_at)->not->toBeNull()
+        ->and($second->superseded_at)->toBeNull();
+});
+
+it('computes the next attempt number without a row lock on the aggregate', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'R-ATTEMPT-LOCK',
+        'merchant_session' => 'S-ATTEMPT-LOCK',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    $other = Transaction::factory()->create([
+        'merchant_ref' => 'R-ATTEMPT-LOCK-2',
+        'merchant_session' => 'S-ATTEMPT-LOCK-2',
+        'amount' => 30.0,
+        'currency' => '132',
+        'transaction_code' => '1',
+        'status' => 'pending',
+    ]);
+
+    resolve(CreateTransactionAttemptAction::class)
+        ->handle($transaction, makeAttemptPaymentRequest('R-ATTEMPT-LOCK', 'S-ATTEMPT-LOCK'));
+    resolve(CreateTransactionAttemptAction::class)
+        ->createFromTransaction($other);
+
+    $aggregateQueries = array_values(array_filter(
+        $queries,
+        fn (string $sql): bool => str_contains($sql, 'max("attempt_number")'),
+    ));
+
+    expect($aggregateQueries)->toHaveCount(2);
+
+    foreach ($aggregateQueries as $sql) {
+        expect($sql)->not->toContain('for update');
+    }
+});

--- a/tests/Http/TransactionAttemptsTest.php
+++ b/tests/Http/TransactionAttemptsTest.php
@@ -60,7 +60,9 @@ it('creates the initial attempt when a payment transaction is stored', function 
         ->and($transaction->currentAttempt->attempt_number)->toBe(1);
 });
 
-it('reuses an existing pending transaction when the checkout intent is posted twice', function (): void {
+it('rejects a duplicate submission while the pending checkout intent is processing', function (): void {
+    config()->set('session.driver', 'array');
+
     $payload = transaction_attempts_payment_payload(overrides: [
         'checkout_intent_id' => 'checkout-intent-duplicate',
     ]);
@@ -71,8 +73,10 @@ it('reuses an existing pending transaction when the checkout intent is posted tw
     $transaction = Transaction::query()->sole();
 
     $this->post(route('sisp.payment'), $payload)
-        ->assertOk()
-        ->assertSee($transaction->merchant_ref);
+        ->assertStatus(303)
+        ->assertSessionHasErrors([
+            'payment' => __('sisp::messages.validation.payment_in_progress'),
+        ]);
 
     expect(Transaction::query()->count())->toBe(1)
         ->and(TransactionAttempt::query()->count())->toBe(1)


### PR DESCRIPTION
## Problem

Three regressions in the 2.x attempts rewrite (#214), caught by the nosferry.com app suite while preparing its 2.x release:

1. **Every checkout 500s on PostgreSQL.** `CreateTransactionAttemptAction` computes `attempts()->lockForUpdate()->max('attempt_number')`, generating `SELECT max(...) FOR UPDATE`. PostgreSQL rejects it: `FOR UPDATE is not allowed with aggregate functions` (SQLSTATE 0A000). Hits transaction creation, retries and callback processing.
2. **attempt_session dropped.** v1.0.3 wrote a local session per attempt; the 2.x rewrite lost the column, fillable entry and writes. Consumers with existing data get null on all new attempts.
3. **Duplicate submissions re-render instead of rejecting.** v1.0.3 threw `PaymentIntentAlreadyProcessingException` (controller answers 303 + `payment_in_progress`) when the intent was already submitted and not retryable. The 2.x pipe silently re-rendered the payment form, turning the controller catch into dead code.

## Fix

- Remove the row lock from the aggregate. Serialization is already guaranteed: retry and callback paths lock the parent transaction row before creating attempts, the create path operates on an uncommitted row, and `unique(transaction_id, attempt_number)` backstops any future unlocked path (the retry loop already handles `UniqueConstraintViolation`).
- Restore `attempt_session`: optional `$attemptSession` param defaulting to the payment request merchant session; column + index back in the create migration (additive, nullable); model fillable + docblock.
- `ApplyPaymentIntent::existingPayment` throws `PaymentIntentAlreadyProcessingException` again when the transaction is not retryable, restoring the 303 flow.
- Transaction docblock: add `created_at`/`updated_at` and relation generics (`HasMany<TransactionItem, $this>`), required by consumer-side PHPStan.

## Tests

- New `CreateTransactionAttemptActionTest`: sequential numbering + SQL-level assert that the aggregate carries no `for update` (suite runs sqlite, which silently accepts the invalid lock, so a behavioral test alone cannot catch the pgsql break).
- `TransactionAttemptsTest` duplicate-submission test updated to expect 303 + session error.
- `composer test` green (lint, refactor, typos, arch, PHPStan, 100% type coverage). Pest suite 432 passing; the 2 `CancelTransactionControllerTest` failures are pre-existing on clean 2.x (same `ErrorException` without this diff).

Verified downstream: nosferry.com 2.x suite goes 418/418 (plus full composer test green) with this change in vendor.