### PR TITLE
docs(models): Transaction docblock timestamps and relation generics

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$created_at\.$#'
-			identifier: property.notFound
-			count: 2
-			path: src/Actions/Generators/InvoiceNumberGeneratorAction.php
-
-		-
 			message: '#^Access to an undefined property Akira\\Sisp\\Models\\Transaction\:\:\$currency\.$#'
 			identifier: property.notFound
 			count: 1

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -42,6 +42,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read  \Illuminate\Database\Eloquent\Collection<int, TransactionAttempt> $attempts
  * @property-read  TransactionAttempt|null $currentAttempt
  * @property-read  Invoice|null $invoice
+ * @property-read  \Illuminate\Support\Carbon|null $created_at
+ * @property-read  \Illuminate\Support\Carbon|null $updated_at
  */
 #[UseFactory(TransactionFactory::class)]
 #[Fillable([
@@ -79,11 +81,13 @@ final class Transaction extends Model
         return config('sisp.tables.transactions', 'sisp_transactions');
     }
 
+    /** @return HasMany<TransactionItem, $this> */
     public function items(): HasMany
     {
         return $this->hasMany(TransactionItem::class, 'transaction_id');
     }
 
+    /** @return HasMany<TransactionAttempt, $this> */
     public function attempts(): HasMany
     {
         return $this->hasMany(TransactionAttempt::class, 'transaction_id');


### PR DESCRIPTION
Adds `created_at`/`updated_at` `@property-read` entries and `HasMany<TransactionItem, $this>` / `HasMany<TransactionAttempt, $this>` return generics to the Transaction model.

Consumer apps running PHPStan (nosferry.com at max level) fail without these: `property.notFound` on timestamp access and `Collection<int, Model>` degradation on `items()->get()`.

Static-analysis annotations only; no behavior change. Carries the last remaining piece of #252 (closed as superseded by #218/#247).