### PR TITLE
fix(migrations): index created_at on the transactions table

### DIFF
--- a/database/migrations/update_laravel_sisp_transactions_add_created_at_index.php
+++ b/database/migrations/update_laravel_sisp_transactions_add_created_at_index.php
@@ -20,8 +20,10 @@ return new class extends Migration
             return;
         }
 
-        Schema::table($transactionsTable, function (Blueprint $table): void {
-            $table->index(['created_at']);
+        $indexName = $this->indexName($transactionsTable);
+
+        Schema::table($transactionsTable, function (Blueprint $table) use ($indexName): void {
+            $table->index(['created_at'], $indexName);
         });
     }
 
@@ -46,7 +48,7 @@ return new class extends Migration
 
     private function indexName(string $table): string
     {
-        return mb_strtolower($table.'_created_at_index');
+        return str_replace(['-', '.'], '_', mb_strtolower($table.'_created_at_index'));
     }
 
     private function hasIndex(string $table, ?string $name = null): bool

--- a/database/migrations/update_laravel_sisp_transactions_add_created_at_index.php
+++ b/database/migrations/update_laravel_sisp_transactions_add_created_at_index.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $transactionsTable = config('sisp.tables.transactions', 'sisp_transactions');
+
+        if (! Schema::hasTable($transactionsTable)) {
+            return;
+        }
+
+        if ($this->hasIndex($transactionsTable)) {
+            return;
+        }
+
+        Schema::table($transactionsTable, function (Blueprint $table): void {
+            $table->index(['created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        $transactionsTable = config('sisp.tables.transactions', 'sisp_transactions');
+
+        if (! Schema::hasTable($transactionsTable) || ! $this->hasIndex($transactionsTable)) {
+            return;
+        }
+
+        Schema::table($transactionsTable, function (Blueprint $table): void {
+            $table->dropIndex(['created_at']);
+        });
+    }
+
+    private function hasIndex(string $table): bool
+    {
+        foreach (Schema::getIndexes($table) as $index) {
+            if ($index['columns'] === ['created_at']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};

--- a/database/migrations/update_laravel_sisp_transactions_add_created_at_index.php
+++ b/database/migrations/update_laravel_sisp_transactions_add_created_at_index.php
@@ -29,19 +29,34 @@ return new class extends Migration
     {
         $transactionsTable = config('sisp.tables.transactions', 'sisp_transactions');
 
-        if (! Schema::hasTable($transactionsTable) || ! $this->hasIndex($transactionsTable)) {
+        if (! Schema::hasTable($transactionsTable)) {
             return;
         }
 
-        Schema::table($transactionsTable, function (Blueprint $table): void {
-            $table->dropIndex(['created_at']);
+        $indexName = $this->indexName($transactionsTable);
+
+        if (! $this->hasIndex($transactionsTable, $indexName)) {
+            return;
+        }
+
+        Schema::table($transactionsTable, function (Blueprint $table) use ($indexName): void {
+            $table->dropIndex($indexName);
         });
     }
 
-    private function hasIndex(string $table): bool
+    private function indexName(string $table): string
+    {
+        return mb_strtolower($table.'_created_at_index');
+    }
+
+    private function hasIndex(string $table, ?string $name = null): bool
     {
         foreach (Schema::getIndexes($table) as $index) {
-            if ($index['columns'] === ['created_at']) {
+            if ($index['columns'] !== ['created_at']) {
+                continue;
+            }
+
+            if ($name === null || mb_strtolower((string) $index['name']) === $name) {
                 return true;
             }
         }

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -27,6 +27,7 @@ final class SispServiceProvider extends PackageServiceProvider
             ->hasMigrations([
                 'create_laravel_sisp_table',
                 'update_laravel_sisp_transactions_add_amount_cents',
+                'update_laravel_sisp_transactions_add_created_at_index',
                 'create_sisp_transaction_logs_table',
                 'create_sisp_transaction_attempts_table',
                 'create_sisp_payment_intents_table',

--- a/tests/Database/CreatedAtIndexMigrationTest.php
+++ b/tests/Database/CreatedAtIndexMigrationTest.php
@@ -60,3 +60,23 @@ it('drops the index it created on rollback', function (): void {
 
     expect(array_column(Schema::getIndexes($table), 'columns'))->toContain(['created_at']);
 });
+
+it('rolls back the index on a table name laravel normalizes', function (): void {
+    $table = 'sisp-legacy-transactions';
+    config()->set('sisp.tables.transactions', $table);
+
+    Schema::create($table, function (Blueprint $blueprint): void {
+        $blueprint->id();
+        $blueprint->timestamps();
+    });
+
+    $migration = require __DIR__.'/../../database/migrations/update_laravel_sisp_transactions_add_created_at_index.php';
+
+    $migration->up();
+
+    expect(array_column(Schema::getIndexes($table), 'columns'))->toContain(['created_at']);
+
+    $migration->down();
+
+    expect(array_column(Schema::getIndexes($table), 'columns'))->not->toContain(['created_at']);
+});

--- a/tests/Database/CreatedAtIndexMigrationTest.php
+++ b/tests/Database/CreatedAtIndexMigrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 it('indexes created_at on the transactions table', function (): void {
@@ -24,4 +25,38 @@ it('leaves the index alone when it is already there', function (): void {
     );
 
     expect($matching)->toHaveCount(1);
+});
+
+it('leaves a custom-named created_at index alone on rollback', function (): void {
+    $table = config('sisp.tables.transactions', 'sisp_transactions');
+    $migration = require __DIR__.'/../../database/migrations/update_laravel_sisp_transactions_add_created_at_index.php';
+
+    Schema::table($table, function (Blueprint $blueprint): void {
+        $blueprint->dropIndex(['created_at']);
+    });
+
+    Schema::table($table, function (Blueprint $blueprint): void {
+        $blueprint->index(['created_at'], 'custom_created_at_idx');
+    });
+
+    $migration->down();
+
+    $names = array_column(Schema::getIndexes($table), 'name');
+
+    expect($names)->toContain('custom_created_at_idx');
+});
+
+it('drops the index it created on rollback', function (): void {
+    $table = config('sisp.tables.transactions', 'sisp_transactions');
+    $migration = require __DIR__.'/../../database/migrations/update_laravel_sisp_transactions_add_created_at_index.php';
+
+    $migration->down();
+
+    $columns = array_column(Schema::getIndexes($table), 'columns');
+
+    expect($columns)->not->toContain(['created_at']);
+
+    $migration->up();
+
+    expect(array_column(Schema::getIndexes($table), 'columns'))->toContain(['created_at']);
 });

--- a/tests/Database/CreatedAtIndexMigrationTest.php
+++ b/tests/Database/CreatedAtIndexMigrationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+
+it('indexes created_at on the transactions table', function (): void {
+    $columns = array_map(
+        fn (array $index): array => $index['columns'],
+        Schema::getIndexes(config('sisp.tables.transactions', 'sisp_transactions')),
+    );
+
+    expect($columns)->toContain(['created_at']);
+});
+
+it('leaves the index alone when it is already there', function (): void {
+    $migration = require __DIR__.'/../../database/migrations/update_laravel_sisp_transactions_add_created_at_index.php';
+
+    $migration->up();
+
+    $matching = array_filter(
+        Schema::getIndexes(config('sisp.tables.transactions', 'sisp_transactions')),
+        fn (array $index): bool => $index['columns'] === ['created_at'],
+    );
+
+    expect($matching)->toHaveCount(1);
+});


### PR DESCRIPTION
Closes #257

Listing transactions over a period reads every row. The table indexes merchant_ref with merchant_session, status and message_type, plus transaction_id and customer_email; none covers created_at, and Laravel does not index timestamps on its own.

The index arrives in its own migration rather than in the create one, since every released version has already run that. It checks for the index first, so a fresh install that gets it from the create migration is left untouched and the migration is safe to re-run.

Two tests: the index exists after migrating, and running the migration again does not duplicate it. 449 tests pass.

Two things I hit that predate this branch, worth a look on their own: the suite is unstable under --parallel, giving 4, 1 and 0 failures across runs of identical code, all QueryException or FileNotFoundException; and composer test does not run the suite at all, only lint, rector, typos, arch, types and type coverage.