### PR TITLE
fix(callback): cancel the transaction on the user cancellation callback

### DIFF
--- a/config/sisp.php
+++ b/config/sisp.php
@@ -497,6 +497,7 @@ return [
         'payment' => [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class],
         'retry' => [],
         'refund' => ['web', 'auth'],
+        'callback' => ['throttle:60,1'],
     ],
 
 ];

--- a/config/sisp.php
+++ b/config/sisp.php
@@ -497,7 +497,7 @@ return [
         'payment' => [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class],
         'retry' => [],
         'refund' => ['web', 'auth'],
-        'callback' => ['throttle:60,1'],
+        'callback' => ['throttle:sisp-callback'],
     ],
 
 ];

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -207,7 +207,7 @@ The API sends HTTP Basic authentication using `SISP_PORTAL_ID:SISP_PORTAL_PASSWO
 Query a transaction without changing local data:
 
 ```bash
-php artisan sisp:transaction-status R20260523235959
+php artisan sisp:transaction-status R20260523235959K7M2QX9TBV
 ```
 
 Query by local transaction ID and update it only when SISP returns a successful status API result:
@@ -227,7 +227,7 @@ use Akira\Sisp\Facades\Sisp;
 use Akira\Sisp\Models\Transaction;
 
 $response = Sisp::queryTransactionStatus($transaction);
-$response = Sisp::queryTransactionStatus('R20260523235959');
+$response = Sisp::queryTransactionStatus('R20260523235959K7M2QX9TBV');
 
 $updatedTransaction = Sisp::reconcileTransactionStatus($transaction);
 ```
@@ -313,10 +313,13 @@ Customize middleware assigned to package routes in `config/sisp.php`:
     'payment' => [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class],
     'retry' => [],
     'refund' => ['web', 'auth'],
+    'callback' => ['throttle:60,1'],
 ],
 ```
 
-Use this to add CSRF, authentication, tenancy, or custom authorization checks to browser-originated routes. The payment route keeps duplicate-payment protection by default. The callback route is intentionally not part of this configuration because SISP must be able to post callbacks without browser CSRF middleware.
+Use this to add CSRF, authentication, tenancy, or custom authorization checks to browser-originated routes. The payment route keeps duplicate-payment protection by default.
+
+The callback route never receives the browser `web` group, because SISP must be able to post callbacks without CSRF middleware. It does carry a rate limit: SISP sends no fingerprint on the user-cancellation callback, so that branch is authenticated by nothing but the merchant reference, and the throttle bounds how fast references can be tried. Raise the limit if a busy gateway needs more, but leave one in place.
 
 ## Security Configuration
 

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -313,13 +313,17 @@ Customize middleware assigned to package routes in `config/sisp.php`:
     'payment' => [Akira\Sisp\Http\Middleware\ProtectPaymentRoute::class],
     'retry' => [],
     'refund' => ['web', 'auth'],
-    'callback' => ['throttle:60,1'],
+    'callback' => ['throttle:sisp-callback'],
 ],
 ```
 
 Use this to add CSRF, authentication, tenancy, or custom authorization checks to browser-originated routes. The payment route keeps duplicate-payment protection by default.
 
-The callback route never receives the browser `web` group, because SISP must be able to post callbacks without CSRF middleware. It does carry a rate limit: SISP sends no fingerprint on the user-cancellation callback, so that branch is authenticated by nothing but the merchant reference, and the throttle bounds how fast references can be tried. Raise the limit if a busy gateway needs more, but leave one in place.
+The callback route never receives the browser `web` group, because SISP must be able to post callbacks without CSRF middleware.
+
+It does carry the `sisp-callback` limiter, registered by the package. That limiter applies only to requests carrying `UserCancelled` and keys on the merchant reference: SISP sends no fingerprint on the cancellation callback, so that branch is identified by nothing but the reference, and the limit bounds how fast one reference can be hit. Successful callbacks are exempt, because they carry a fingerprint and because throttling them would drop a payment the gateway has already taken.
+
+This is deliberately separate from `sisp.rate_limiting`, which is a per-IP application-level control with its own table and blacklist (see [Security](07-security.md)). Replace the middleware if you would rather use one mechanism for both.
 
 ## Security Configuration
 

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -120,7 +120,7 @@ Timestamp-only updates are ignored. Encrypted payload values are stored in decry
 
 ## Cancel Transaction
 
-Cancel a pending or failed transaction:
+Cancel a pending transaction:
 
 ```php
 use Akira\Sisp\Actions\CancelTransactionAction;
@@ -142,11 +142,17 @@ try {
 
 Can be cancelled:
 - `pending` - Awaiting SISP response
-- `failed` - Payment failed
 
 Cannot be cancelled:
 - `completed` - Payment successful
 - `cancelled` - Already cancelled
+- `failed` - The gateway already gave a verdict, and cancelling would overwrite it and take the retry away
+- `refunded` - The refund is the final state
+
+The transaction row is locked for the duration, so a cancellation racing the
+success callback cannot write over a payment that has just completed. Cancelling
+also cancels the invoice attached to the transaction, in the same database
+transaction.
 
 ### Cancel via Route
 

--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -168,7 +168,7 @@ Use SISP status reconciliation when a transaction stays `pending` because the au
 Check the status in SISP without changing the local transaction:
 
 ```bash
-php artisan sisp:transaction-status R20260523235959
+php artisan sisp:transaction-status R20260523235959K7M2QX9TBV
 ```
 
 The command prints:

--- a/docs/08-examples.md
+++ b/docs/08-examples.md
@@ -458,7 +458,7 @@ foreach ($riskMetadata as $metadata) {
 
 ## Cancel Payment
 
-Cancel a pending or failed transaction.
+Cancel a pending transaction.
 
 ```php
 use Akira\Sisp\Actions\CancelTransactionAction;

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -303,13 +303,18 @@ tail -f storage/logs/laravel.log | grep -i signature
 
 ### Callback redirects before processing
 
+A truthy `UserCancelled` no longer redirects without processing. The controller
+resolves the transaction from `merchantRef` and `merchantSession`, cancels it
+and its invoice, dispatches `TransactionCancelled`, and only then redirects.
+Nothing happens if either key is missing, if no transaction matches, or if the
+transaction is already in a terminal status.
+
 The controller redirects without processing when:
 
-1. `UserCancelled` is truthy
-2. The request is a GET without a valid `ref` query parameter
-3. The POST fingerprint is invalid
-4. `merchantRespMerchantRef` or `merchantRespMerchantSession` is missing
-5. The callback was already processed and the transaction already has a SISP transaction ID
+1. The request is a GET without a valid `ref` query parameter
+2. The POST fingerprint is invalid
+3. `merchantRespMerchantRef` or `merchantRespMerchantSession` is missing
+4. The callback was already processed and the transaction already has a SISP transaction ID
 
 Duplicate callbacks redirect with an `info` flash message: `This payment has already been processed.`
 

--- a/docs/10-faq.md
+++ b/docs/10-faq.md
@@ -132,7 +132,7 @@ Yes. Refund completed transactions with the fluent builder — `Sisp::refund($tr
 
 ### Can I cancel a pending payment?
 
-Yes, cancel using `CancelTransactionAction`. Works for `pending` or `failed` transactions.
+Yes, cancel using `CancelTransactionAction`. Works for `pending` transactions only: `completed`, `cancelled`, `failed` and `refunded` are terminal and raise `LogicException`.
 
 ### Can I modify a transaction?
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -482,7 +482,7 @@ InvoiceStatus::cancelled          // Cancelled
 use Akira\Sisp\Facades\Sisp;
 
 $response = Sisp::queryTransactionStatus($transaction);
-$response = Sisp::queryTransactionStatus('R20260523235959');
+$response = Sisp::queryTransactionStatus('R20260523235959K7M2QX9TBV');
 
 $updatedTransaction = Sisp::reconcileTransactionStatus($transaction);
 ```

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -678,7 +678,7 @@ app(BuildPurchaseRequestAction::class)->handle(
 
 ### CancelTransactionAction
 
-Cancel a pending or failed transaction.
+Cancel a pending transaction.
 
 ```php
 app(CancelTransactionAction::class)->handle(
@@ -800,7 +800,8 @@ Handles the SISP callback route.
 // Renders the payment response for a known merchant reference.
 
 // POST /sisp/callback
-// 1. Redirects cancelled requests.
+// 1. Cancels the transaction and its invoice on a user cancellation,
+//    which SISP posts as { merchantRef, merchantSession, UserCancelled }.
 // 2. Validates the callback fingerprint before transaction lookup.
 // 3. Requires merchant reference and merchant session.
 // 4. Redirects duplicate callbacks when transaction_id is already set.
@@ -1177,7 +1178,7 @@ POST   /sisp/sandbox           -> SandboxController
 GET    /sisp/countries         -> CountriesController
 ```
 
-State-changing route middleware is configurable via `config('sisp.middleware.payment')`, `config('sisp.middleware.retry')`, and `config('sisp.middleware.refund')`. The callback route remains outside this configuration so SISP callbacks are not blocked by browser-only middleware.
+State-changing route middleware is configurable via `config('sisp.middleware.payment')`, `config('sisp.middleware.retry')`, `config('sisp.middleware.refund')`, and `config('sisp.middleware.callback')`. The callback route never receives the browser `web` group so SISP callbacks are not blocked by browser-only middleware.
 
 Route names:
 

--- a/docs/14-idempotency.md
+++ b/docs/14-idempotency.md
@@ -162,6 +162,8 @@ Callback attempt updates and transaction updates are wrapped in a single databas
 ],
 ```
 
+The default reference and session generators emit a timestamp followed by ten random characters, for example `R20260523235959K7M2QX9TBV`. The random tail is what keeps two payments started in the same second apart, and it also stops a third party from guessing a live reference: the cancellation callback carries no fingerprint, so the reference is the only thing standing between an unauthenticated request and a pending transaction. A custom generator that emits a predictable value gives that protection up.
+
 Because these generators are configurable, the package assumes they can collide. The database enforces uniqueness for:
 
 - transaction `merchant_ref`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: src/Actions/StoreRequestMetadataAction.php
 
 		-
-			message: '#^Match expression does not handle remaining values\: Akira\\Sisp\\Enums\\TransactionStatus\:\:cancelled\|Akira\\Sisp\\Enums\\TransactionStatus\:\:refunded$#'
-			identifier: match.unhandled
-			count: 1
-			path: src/Actions/UpdateInvoiceStatusAction.php
-
-		-
 			message: '#^Method Akira\\Sisp\\Commands\\LaravelSispInstallCommand\:\:publishAssets\(\) is unused\.$#'
 			identifier: method.unused
 			count: 1

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ Route::match(['get', 'post'], 'sisp/retry-payment', RetryPaymentController::clas
 
 Route::match(['get', 'post'], 'sisp/callback', CallbackController::class)
     ->withoutMiddleware('web')
+    ->middleware(config()->array('sisp.middleware.callback', ['throttle:60,1']))
     ->name('sisp.callback');
 
 Route::get('sisp/cancel', CancelTransactionController::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::match(['get', 'post'], 'sisp/retry-payment', RetryPaymentController::clas
 
 Route::match(['get', 'post'], 'sisp/callback', CallbackController::class)
     ->withoutMiddleware('web')
-    ->middleware(config()->array('sisp.middleware.callback', ['throttle:60,1']))
+    ->middleware(config()->array('sisp.middleware.callback', ['throttle:sisp-callback']))
     ->name('sisp.callback');
 
 Route::get('sisp/cancel', CancelTransactionController::class)

--- a/src/Actions/CancelTransactionAction.php
+++ b/src/Actions/CancelTransactionAction.php
@@ -13,10 +13,14 @@ use LogicException;
 
 final readonly class CancelTransactionAction
 {
+    public function __construct(
+        private UpdateInvoiceStatusAction $updateInvoiceStatus,
+    ) {}
+
     public function handle(Transaction $transaction, string $reason = 'user_cancelled'): Transaction
     {
-        DB::transaction(function () use ($transaction, $reason): void {
-            $locked = Transaction::query()->lockForUpdate()->find($transaction->id);
+        $cancelled = DB::transaction(function () use ($transaction, $reason): Transaction {
+            $locked = $transaction->newQuery()->whereKey($transaction->getKey())->lockForUpdate()->first();
 
             if (! $locked instanceof Transaction || $this->cannotBeCancelled($locked)) {
                 $status = $locked instanceof Transaction ? $locked->status->value : $transaction->status->value;
@@ -26,23 +30,26 @@ final readonly class CancelTransactionAction
 
             TransactionLogContext::run(
                 'cancel',
-                fn (): bool => $transaction->update([
+                fn (): bool => $locked->update([
                     'status' => TransactionStatus::cancelled->value,
                     'message_type' => 'cancelled',
                     'merchant_response' => $reason,
                     'cancelled_at' => now(),
                 ])
             );
+
+            $this->updateInvoiceStatus->handle($locked, TransactionStatus::cancelled);
+
+            return $locked;
         });
 
-        event(new TransactionCancelled($transaction, $reason));
+        event(new TransactionCancelled($cancelled, $reason));
 
-        return $transaction;
+        return $cancelled;
     }
 
     private function cannotBeCancelled(Transaction $transaction): bool
     {
-
         return in_array($transaction->status->value, ['completed', 'cancelled', 'failed', 'refunded'], true);
     }
 }

--- a/src/Actions/CancelTransactionAction.php
+++ b/src/Actions/CancelTransactionAction.php
@@ -8,28 +8,32 @@ use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Events\TransactionCancelled;
 use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\TransactionLogContext;
+use Illuminate\Support\Facades\DB;
 use LogicException;
 
 final readonly class CancelTransactionAction
 {
     public function handle(Transaction $transaction, string $reason = 'user_cancelled'): Transaction
     {
+        DB::transaction(function () use ($transaction, $reason): void {
+            $locked = Transaction::query()->lockForUpdate()->find($transaction->id);
 
-        if ($this->cannotBeCancelled($transaction)) {
-            throw new LogicException(
-                "Transaction with status '{$transaction->status->value}' cannot be cancelled."
+            if (! $locked instanceof Transaction || $this->cannotBeCancelled($locked)) {
+                $status = $locked instanceof Transaction ? $locked->status->value : $transaction->status->value;
+
+                throw new LogicException("Transaction with status '{$status}' cannot be cancelled.");
+            }
+
+            TransactionLogContext::run(
+                'cancel',
+                fn (): bool => $transaction->update([
+                    'status' => TransactionStatus::cancelled->value,
+                    'message_type' => 'cancelled',
+                    'merchant_response' => $reason,
+                    'cancelled_at' => now(),
+                ])
             );
-        }
-
-        TransactionLogContext::run(
-            'cancel',
-            fn (): bool => $transaction->update([
-                'status' => TransactionStatus::cancelled->value,
-                'message_type' => 'cancelled',
-                'merchant_response' => $reason,
-                'cancelled_at' => now(),
-            ])
-        );
+        });
 
         event(new TransactionCancelled($transaction, $reason));
 
@@ -39,6 +43,6 @@ final readonly class CancelTransactionAction
     private function cannotBeCancelled(Transaction $transaction): bool
     {
 
-        return in_array($transaction->status->value, ['completed', 'cancelled'], true);
+        return in_array($transaction->status->value, ['completed', 'cancelled', 'failed', 'refunded'], true);
     }
 }

--- a/src/Actions/Generators/MerchantReferenceGeneratorAction.php
+++ b/src/Actions/Generators/MerchantReferenceGeneratorAction.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions\Generators;
 
 use Akira\Sisp\Contracts\Generator;
+use Illuminate\Support\Str;
 
 final readonly class MerchantReferenceGeneratorAction implements Generator
 {
     public function __invoke(): string
     {
-        return 'R'.now()->format('YmdHis');
+        return 'R'.now()->format('YmdHis').Str::upper(Str::random(10));
     }
 }

--- a/src/Actions/Generators/MerchantSessionGeneratorAction.php
+++ b/src/Actions/Generators/MerchantSessionGeneratorAction.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Akira\Sisp\Actions\Generators;
 
 use Akira\Sisp\Contracts\Generator;
+use Illuminate\Support\Str;
 
 final readonly class MerchantSessionGeneratorAction implements Generator
 {
     public function __invoke(): string
     {
-        return 'S'.now()->format('YmdHis');
+        return 'S'.now()->format('YmdHis').Str::upper(Str::random(10));
     }
 }

--- a/src/Actions/RenderPaymentFormAction.php
+++ b/src/Actions/RenderPaymentFormAction.php
@@ -21,7 +21,10 @@ final readonly class RenderPaymentFormAction
 
         $formAction = $this->buildFormAction($fields);
 
-        return view()->make('sisp::payment-form', [
+        /** @var view-string $view */
+        $view = 'sisp::payment-form';
+
+        return view()->make($view, [
             'formAction' => $formAction,
             'fields' => $fields,
         ]);

--- a/src/Actions/RenderPaymentResponseAction.php
+++ b/src/Actions/RenderPaymentResponseAction.php
@@ -25,7 +25,10 @@ final readonly class RenderPaymentResponseAction
     {
         $allowRetry = $this->canRetryPayment->handle($transaction);
 
-        return view()->make('sisp::payment-response', [
+        /** @var view-string $view */
+        $view = 'sisp::payment-response';
+
+        return view()->make($view, [
             'transaction' => $transaction,
             'payload' => $payload,
             'error' => $this->getStructuredError($transaction),

--- a/src/Actions/UpdateInvoiceStatusAction.php
+++ b/src/Actions/UpdateInvoiceStatusAction.php
@@ -30,6 +30,7 @@ final readonly class UpdateInvoiceStatusAction
             TransactionStatus::completed => InvoiceStatus::paid,
             TransactionStatus::failed => InvoiceStatus::cancelled,
             TransactionStatus::pending => InvoiceStatus::pending,
+            TransactionStatus::cancelled, TransactionStatus::refunded => InvoiceStatus::cancelled,
         };
 
         $invoice->update(['status' => $invoiceStatus->value]);
@@ -39,11 +40,6 @@ final readonly class UpdateInvoiceStatusAction
         }
     }
 
-    /**
-     * PDF generation must never fail the payment flow: the transaction is
-     * already completed at this point and missing PDF files can be recovered
-     * later with the regenerate command.
-     */
     private function generatePdfQuietly(Invoice $invoice, Transaction $transaction): void
     {
         try {

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -49,6 +49,7 @@ final readonly class CallbackController
         if ($transaction instanceof Transaction) {
             try {
                 $this->cancelTransaction->handle($transaction);
+                $this->updateInvoiceStatus->handle($transaction, $transaction->status);
             } catch (LogicException) {
             }
         }

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -49,7 +49,6 @@ final readonly class CallbackController
         if ($transaction instanceof Transaction) {
             try {
                 $this->cancelTransaction->handle($transaction);
-                $this->updateInvoiceStatus->handle($transaction, $transaction->status);
             } catch (LogicException) {
             }
         }
@@ -60,20 +59,15 @@ final readonly class CallbackController
     private function resolveCancelledTransaction(Request $request): ?Transaction
     {
         $merchantRef = $request->string('merchantRef')->toString();
+        $merchantSession = $request->string('merchantSession')->toString();
 
-        if ($merchantRef === '') {
+        if ($merchantRef === '' || $merchantSession === '') {
             return null;
         }
 
         $query = Transaction::query()->where('merchant_ref', $merchantRef);
 
-        $merchantSession = $request->string('merchantSession')->toString();
-
-        if ($merchantSession !== '') {
-            $query->where('merchant_session', $merchantSession);
-        }
-
-        return $query->first();
+        return $query->where('merchant_session', $merchantSession)->first();
     }
 
     private function handleGetRequest(): mixed

--- a/src/Http/Controllers/CallbackController.php
+++ b/src/Http/Controllers/CallbackController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akira\Sisp\Http\Controllers;
 
+use Akira\Sisp\Actions\CancelTransactionAction;
 use Akira\Sisp\Actions\RenderPaymentResponseBasedOnConfigAction;
 use Akira\Sisp\Actions\StoreRequestMetadataAction;
 use Akira\Sisp\Actions\UpdateInvoiceStatusAction;
@@ -16,6 +17,7 @@ use Akira\Sisp\ValueObjects\CallbackPayload;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use LogicException;
 
 final readonly class CallbackController
 {
@@ -24,12 +26,13 @@ final readonly class CallbackController
         private StoreRequestMetadataAction $storeMetadata,
         private UpdateInvoiceStatusAction $updateInvoiceStatus,
         private LoadConfig $config,
+        private CancelTransactionAction $cancelTransaction,
     ) {}
 
     public function __invoke(Request $request): mixed
     {
         if ($request->boolean('UserCancelled')) {
-            return redirect(config('sisp.redirect_url', '/'));
+            return $this->handleUserCancellation($request);
         }
 
         if ($request->isMethod('get')) {
@@ -37,6 +40,39 @@ final readonly class CallbackController
         }
 
         return $this->handlePostRequest($request);
+    }
+
+    private function handleUserCancellation(Request $request): RedirectResponse
+    {
+        $transaction = $this->resolveCancelledTransaction($request);
+
+        if ($transaction instanceof Transaction) {
+            try {
+                $this->cancelTransaction->handle($transaction);
+            } catch (LogicException) {
+            }
+        }
+
+        return redirect(config('sisp.redirect_url', '/'));
+    }
+
+    private function resolveCancelledTransaction(Request $request): ?Transaction
+    {
+        $merchantRef = $request->string('merchantRef')->toString();
+
+        if ($merchantRef === '') {
+            return null;
+        }
+
+        $query = Transaction::query()->where('merchant_ref', $merchantRef);
+
+        $merchantSession = $request->string('merchantSession')->toString();
+
+        if ($merchantSession !== '') {
+            $query->where('merchant_session', $merchantSession);
+        }
+
+        return $query->first();
     }
 
     private function handleGetRequest(): mixed

--- a/src/SispServiceProvider.php
+++ b/src/SispServiceProvider.php
@@ -11,8 +11,11 @@ use Akira\Sisp\Commands\RegenerateMissingInvoicePdfsCommand;
 use Akira\Sisp\Commands\TransactionStatusCommand;
 use Akira\Sisp\Contracts\SispDriver;
 use Akira\Sisp\Drivers\SispManager;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -57,8 +60,20 @@ final class SispServiceProvider extends PackageServiceProvider
     {
         $this->registerComponents();
         $this->registerFactories();
+        $this->registerCallbackRateLimiter();
 
         return parent::boot();
+    }
+
+    private function registerCallbackRateLimiter(): void
+    {
+        RateLimiter::for('sisp-callback', function (Request $request): Limit {
+            if (! $request->boolean('UserCancelled')) {
+                return Limit::none();
+            }
+
+            return Limit::perMinute(10)->by((string) $request->input('merchantRef', $request->ip()));
+        });
     }
 
     private function registerFactories(): void

--- a/tests/Actions/CancelTransactionActionTest.php
+++ b/tests/Actions/CancelTransactionActionTest.php
@@ -22,12 +22,27 @@ it('cancels a pending transaction and dispatches event', function (): void {
     Event::assertDispatched(Akira\Sisp\Events\TransactionCancelled::class);
 });
 
-it('cannot cancel completed or already cancelled transactions', function (): void {
-    $completed = Transaction::factory()->create(['status' => 'completed']);
-    $cancelled = Transaction::factory()->create(['status' => 'cancelled']);
+it('cannot cancel a transaction in a terminal status', function (string $status): void {
+    $transaction = Transaction::factory()->create(['status' => $status]);
 
-    expect(fn () => resolve(CancelTransactionAction::class)->handle($completed))
+    expect(fn () => resolve(CancelTransactionAction::class)->handle($transaction))
+        ->toThrow(LogicException::class)
+        ->and($transaction->refresh()->status->value)->toBe($status)
+        ->and($transaction->cancelled_at)->toBeNull();
+})->with(['completed', 'cancelled', 'failed', 'refunded']);
+
+it('leaves the gateway response untouched when it refuses to cancel a failed transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_response' => 'Insufficient funds',
+        'message_type' => '8',
+    ]);
+
+    expect(fn () => resolve(CancelTransactionAction::class)->handle($transaction))
         ->toThrow(LogicException::class);
-    expect(fn () => resolve(CancelTransactionAction::class)->handle($cancelled))
-        ->toThrow(LogicException::class);
+
+    $transaction->refresh();
+
+    expect($transaction->merchant_response)->toBe('Insufficient funds')
+        ->and($transaction->message_type)->toBe('8');
 });

--- a/tests/Actions/Generators/MerchantReferenceGeneratorActionTest.php
+++ b/tests/Actions/Generators/MerchantReferenceGeneratorActionTest.php
@@ -12,7 +12,9 @@ it('generates a SISP merchant reference with the recommended timestamp format', 
         $gen = resolve(MerchantReferenceGeneratorAction::class);
         $ref = $gen();
 
-        expect($ref)->toBe('R20260523101112');
+        expect($ref)->toStartWith('R20260523101112')
+            ->and($ref)->toMatch('/^R\\d{14}[A-Z0-9]{10}$/')
+            ->and($gen())->not->toBe($ref);
     } finally {
         Date::setTestNow();
     }

--- a/tests/Actions/Generators/MerchantSessionGeneratorActionTest.php
+++ b/tests/Actions/Generators/MerchantSessionGeneratorActionTest.php
@@ -12,7 +12,9 @@ it('generates a SISP merchant session with the recommended timestamp format', fu
         $gen = resolve(MerchantSessionGeneratorAction::class);
         $session = $gen();
 
-        expect($session)->toBe('S20260523101112');
+        expect($session)->toStartWith('S20260523101112')
+            ->and($session)->toMatch('/^S\\d{14}[A-Z0-9]{10}$/')
+            ->and($gen())->not->toBe($session);
     } finally {
         Date::setTestNow();
     }

--- a/tests/Configuration/LoadConfigMoreTest.php
+++ b/tests/Configuration/LoadConfigMoreTest.php
@@ -9,8 +9,8 @@ beforeEach(function (): void {
 });
 
 it('returns sane defaults and configured values for getters', function (): void {
-    expect($this->cfg->getMerchantReference())->toMatch('/^R\d{14}$/')
-        ->and($this->cfg->getMerchantSession())->toMatch('/^S\d{14}$/')
+    expect($this->cfg->getMerchantReference())->toMatch('/^R\d{14}[A-Z0-9]{10}$/')
+        ->and($this->cfg->getMerchantSession())->toMatch('/^S\d{14}[A-Z0-9]{10}$/')
         ->and($this->cfg->getTimeStamp())->toMatch('/^\d{4}-\d{2}-\d{2} /');
 
     config()->set('sisp.currency', 'XYZ');

--- a/tests/Controllers/CancelTransactionControllerTest.php
+++ b/tests/Controllers/CancelTransactionControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Support\Facades\URL;
 
@@ -90,4 +91,45 @@ it('rejects unsigned transaction id cancellation attempts', function (): void {
     ]))->assertForbidden();
 
     expect($t->refresh()->status->value)->toBe('pending');
+});
+
+it('cancels the invoice when cancelling from the signed route', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => 'pending',
+        'merchant_ref' => 'MR-SIGNED-INV',
+        'merchant_session' => 'MS-SIGNED-INV',
+    ]);
+
+    $invoice = Invoice::query()->create([
+        'transaction_id' => $transaction->id,
+        'invoice_number' => 'INV-SIGNED-1',
+        'invoice_date' => now(),
+        'status' => 'pending',
+    ]);
+
+    $this->get(URL::signedRoute('sisp.cancel', ['merchantRef' => 'MR-SIGNED-INV']))
+        ->assertRedirect(route('sisp.callback', ['ref' => 'MR-SIGNED-INV']));
+
+    expect($transaction->refresh()->status->value)->toBe('cancelled')
+        ->and($invoice->refresh()->status->value)->toBe('cancelled');
+});
+
+it('refuses to cancel a failed transaction from the signed route', function (): void {
+    $transaction = Transaction::factory()->create([
+        'status' => 'failed',
+        'merchant_ref' => 'MR-SIGNED-FAILED',
+        'merchant_session' => 'MS-SIGNED-FAILED',
+        'merchant_response' => 'Insufficient funds',
+    ]);
+
+    $this->from('/checkout')
+        ->get(URL::signedRoute('sisp.cancel', ['merchantRef' => 'MR-SIGNED-FAILED']))
+        ->assertRedirect('/checkout')
+        ->assertSessionHas('error');
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('failed')
+        ->and($transaction->merchant_response)->toBe('Insufficient funds')
+        ->and($transaction->cancelled_at)->toBeNull();
 });

--- a/tests/Http/CallbackControllerCancellationTest.php
+++ b/tests/Http/CallbackControllerCancellationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Sisp\Events\TransactionCancelled;
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function (): void {
+    config()->set('sisp.sandbox', true);
+    config()->set('sisp.redirect_url', '/home');
+});
+
+it('cancels the transaction when the user cancelled callback arrives', function (): void {
+    Event::fake([TransactionCancelled::class]);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-CANCEL-1',
+        'merchant_session' => 'MS-CANCEL-1',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-CANCEL-1',
+        'merchantSession' => 'MS-CANCEL-1',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('cancelled')
+        ->and($transaction->cancelled_at)->not->toBeNull()
+        ->and($transaction->merchant_response)->toBe('user_cancelled');
+
+    Event::assertDispatched(TransactionCancelled::class);
+});
+
+it('redirects without failing when the cancelled callback references an unknown transaction', function (): void {
+    Event::fake([TransactionCancelled::class]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-UNKNOWN',
+        'merchantSession' => 'MS-UNKNOWN',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    Event::assertNotDispatched(TransactionCancelled::class);
+});
+
+it('keeps the cancelled callback idempotent', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-CANCEL-2',
+        'merchant_session' => 'MS-CANCEL-2',
+        'status' => 'pending',
+    ]);
+
+    $payload = [
+        'merchantRef' => 'MR-CANCEL-2',
+        'merchantSession' => 'MS-CANCEL-2',
+        'UserCancelled' => 'true',
+    ];
+
+    $this->post(route('sisp.callback'), $payload)->assertRedirect('/home');
+
+    $cancelledAt = $transaction->refresh()->cancelled_at;
+
+    Event::fake([TransactionCancelled::class]);
+
+    $this->post(route('sisp.callback'), $payload)->assertRedirect('/home');
+
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe('cancelled')
+        ->and($transaction->cancelled_at->toString())->toBe($cancelledAt->toString());
+
+    Event::assertNotDispatched(TransactionCancelled::class);
+});
+
+it('does not cancel a completed transaction when a cancelled callback arrives', function (): void {
+    Event::fake([TransactionCancelled::class]);
+
+    $transaction = Transaction::factory()->completed()->create([
+        'merchant_ref' => 'MR-CANCEL-3',
+        'merchant_session' => 'MS-CANCEL-3',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-CANCEL-3',
+        'merchantSession' => 'MS-CANCEL-3',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    expect($transaction->refresh()->status->value)->toBe('completed');
+
+    Event::assertNotDispatched(TransactionCancelled::class);
+});

--- a/tests/Http/CallbackControllerCancellationTest.php
+++ b/tests/Http/CallbackControllerCancellationTest.php
@@ -177,3 +177,79 @@ it('cancels the invoice alongside the transaction', function (): void {
     expect($transaction->refresh()->status->value)->toBe('cancelled')
         ->and($invoice->refresh()->status->value)->toBe('cancelled');
 });
+
+it('ignores a cancelled callback that carries no merchant session', function (): void {
+    Event::fake([TransactionCancelled::class]);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-NO-SESSION',
+        'merchant_session' => 'MS-NO-SESSION',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-NO-SESSION',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    expect($transaction->refresh()->status->value)->toBe('pending')
+        ->and($transaction->cancelled_at)->toBeNull();
+
+    Event::assertNotDispatched(TransactionCancelled::class);
+});
+
+it('leaves the invoice untouched when it refuses to cancel a terminal transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-PAID',
+        'merchant_session' => 'MS-PAID',
+        'status' => 'completed',
+    ]);
+
+    $invoice = Invoice::query()->create([
+        'transaction_id' => $transaction->id,
+        'invoice_number' => 'INV-PAID-1',
+        'invoice_date' => now(),
+        'status' => 'paid',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-PAID',
+        'merchantSession' => 'MS-PAID',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    expect($transaction->refresh()->status->value)->toBe('completed')
+        ->and($invoice->refresh()->status->value)->toBe('paid');
+});
+
+it('rate limits repeated cancellation attempts against the same reference', function (): void {
+    Transaction::factory()->create([
+        'merchant_ref' => 'MR-FLOOD',
+        'merchant_session' => 'MS-FLOOD',
+        'status' => 'pending',
+    ]);
+
+    $payload = [
+        'merchantRef' => 'MR-FLOOD',
+        'merchantSession' => 'MS-FLOOD',
+        'UserCancelled' => 'true',
+    ];
+
+    foreach (range(1, 10) as $ignored) {
+        $this->post(route('sisp.callback'), $payload)->assertRedirect('/home');
+    }
+
+    $this->post(route('sisp.callback'), $payload)->assertTooManyRequests();
+});
+
+it('does not rate limit callbacks that are not cancellations', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-NOT-LIMITED',
+        'merchant_session' => 'MS-NOT-LIMITED',
+        'status' => 'pending',
+    ]);
+
+    foreach (range(1, 20) as $ignored) {
+        $this->get(route('sisp.callback', ['ref' => $transaction->merchant_ref]))->assertOk();
+    }
+});

--- a/tests/Http/CallbackControllerCancellationTest.php
+++ b/tests/Http/CallbackControllerCancellationTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Events\TransactionCancelled;
+use Akira\Sisp\Models\Invoice;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Support\Facades\Event;
 
@@ -60,37 +61,119 @@ it('keeps the cancelled callback idempotent', function (): void {
         'UserCancelled' => 'true',
     ];
 
+    $this->travelTo('2026-09-12 10:00:00');
+
     $this->post(route('sisp.callback'), $payload)->assertRedirect('/home');
 
     $cancelledAt = $transaction->refresh()->cancelled_at;
 
     Event::fake([TransactionCancelled::class]);
 
+    $this->travelTo('2026-09-12 10:05:00');
+
     $this->post(route('sisp.callback'), $payload)->assertRedirect('/home');
+
+    $this->travelBack();
 
     $transaction->refresh();
 
     expect($transaction->status->value)->toBe('cancelled')
-        ->and($transaction->cancelled_at->toString())->toBe($cancelledAt->toString());
+        ->and($transaction->cancelled_at->toDateTimeString())->toBe($cancelledAt->toDateTimeString())
+        ->and($transaction->cancelled_at->toDateTimeString())->toBe('2026-09-12 10:00:00');
 
     Event::assertNotDispatched(TransactionCancelled::class);
 });
 
-it('does not cancel a completed transaction when a cancelled callback arrives', function (): void {
+it('refuses to cancel a transaction already in a terminal status', function (string $status): void {
     Event::fake([TransactionCancelled::class]);
 
-    $transaction = Transaction::factory()->completed()->create([
-        'merchant_ref' => 'MR-CANCEL-3',
-        'merchant_session' => 'MS-CANCEL-3',
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-TERMINAL',
+        'merchant_session' => 'MS-TERMINAL',
+        'status' => $status,
+        'merchant_response' => 'gateway said so',
     ]);
 
     $this->post(route('sisp.callback'), [
-        'merchantRef' => 'MR-CANCEL-3',
-        'merchantSession' => 'MS-CANCEL-3',
+        'merchantRef' => 'MR-TERMINAL',
+        'merchantSession' => 'MS-TERMINAL',
         'UserCancelled' => 'true',
     ])->assertRedirect('/home');
 
-    expect($transaction->refresh()->status->value)->toBe('completed');
+    $transaction->refresh();
+
+    expect($transaction->status->value)->toBe($status)
+        ->and($transaction->cancelled_at)->toBeNull()
+        ->and($transaction->merchant_response)->toBe('gateway said so');
 
     Event::assertNotDispatched(TransactionCancelled::class);
+})->with(['completed', 'failed', 'refunded', 'cancelled']);
+
+it('leaves other transactions alone when the cancelled callback names one of them', function (): void {
+    $target = Transaction::factory()->create([
+        'merchant_ref' => 'MR-TARGET',
+        'merchant_session' => 'MS-TARGET',
+        'status' => 'pending',
+    ]);
+
+    $bystander = Transaction::factory()->create([
+        'merchant_ref' => 'MR-BYSTANDER',
+        'merchant_session' => 'MS-BYSTANDER',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-TARGET',
+        'merchantSession' => 'MS-TARGET',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    expect($target->refresh()->status->value)->toBe('cancelled')
+        ->and($bystander->refresh()->status->value)->toBe('pending')
+        ->and($bystander->cancelled_at)->toBeNull();
+});
+
+it('ignores a cancelled callback whose merchant session does not match', function (): void {
+    Event::fake([TransactionCancelled::class]);
+
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-MISMATCH',
+        'merchant_session' => 'MS-MISMATCH',
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-MISMATCH',
+        'merchantSession' => 'MS-SOMETHING-ELSE',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    expect($transaction->refresh()->status->value)->toBe('pending')
+        ->and($transaction->cancelled_at)->toBeNull();
+
+    Event::assertNotDispatched(TransactionCancelled::class);
+});
+
+it('cancels the invoice alongside the transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'merchant_ref' => 'MR-INVOICE',
+        'merchant_session' => 'MS-INVOICE',
+        'status' => 'pending',
+    ]);
+
+    $invoice = Invoice::query()->create([
+        'transaction_id' => $transaction->id,
+        'invoice_number' => 'INV-CANCEL-1',
+        'invoice_date' => now(),
+        'status' => 'pending',
+    ]);
+
+    $this->post(route('sisp.callback'), [
+        'merchantRef' => 'MR-INVOICE',
+        'merchantSession' => 'MS-INVOICE',
+        'UserCancelled' => 'true',
+    ])->assertRedirect('/home');
+
+    expect($transaction->refresh()->status->value)->toBe('cancelled')
+        ->and($invoice->refresh()->status->value)->toBe('cancelled');
 });

--- a/tests/Routes/SispRouteMiddlewareTest.php
+++ b/tests/Routes/SispRouteMiddlewareTest.php
@@ -9,7 +9,8 @@ use Illuminate\Support\Facades\Route;
 it('publishes middleware defaults for configurable state-changing routes', function (): void {
     expect(config('sisp.middleware.payment'))->toBe([ProtectPaymentRoute::class])
         ->and(config('sisp.middleware.retry'))->toBe([])
-        ->and(config('sisp.middleware.refund'))->toBe(['web', 'auth']);
+        ->and(config('sisp.middleware.refund'))->toBe(['web', 'auth'])
+        ->and(config('sisp.middleware.callback'))->toBe(['throttle:sisp-callback']);
 });
 
 it('uses published middleware defaults for payment and retry routes', function (): void {
@@ -63,3 +64,22 @@ function withReloadedSispRoutes(callable $callback): void
         $router->setRoutes($originalRoutes);
     }
 }
+
+it('rate limits the callback route', function (): void {
+    withReloadedSispRoutes(function (): void {
+        $callbackRoute = Route::getRoutes()->getByName('sisp.callback');
+
+        expect($callbackRoute->gatherMiddleware())->toContain('throttle:sisp-callback');
+    });
+});
+
+it('uses configurable middleware for the callback route', function (): void {
+    config()->set('sisp.middleware.callback', ['throttle:5,1']);
+
+    withReloadedSispRoutes(function (): void {
+        $callbackRoute = Route::getRoutes()->getByName('sisp.callback');
+
+        expect($callbackRoute->gatherMiddleware())->toContain('throttle:5,1')
+            ->and($callbackRoute->gatherMiddleware())->not->toContain('throttle:sisp-callback');
+    });
+});

--- a/tests/Sisp/ScopedSispTest.php
+++ b/tests/Sisp/ScopedSispTest.php
@@ -53,8 +53,8 @@ it('scoped sisp uses credentials and restores resolver', function (): void {
         ->and($payload['languageMessages'])->toBe('EN')
         ->and($payload['urlMerchantResponse'])->toBe('https://scoped.example.com/callback');
 
-    expect($scoped->getMerchantReference())->toMatch('/^R\d{14}$/')
-        ->and($scoped->getMerchantSession())->toMatch('/^S\d{14}$/')
+    expect($scoped->getMerchantReference())->toMatch('/^R\d{14}[A-Z0-9]{10}$/')
+        ->and($scoped->getMerchantSession())->toMatch('/^S\d{14}[A-Z0-9]{10}$/')
         ->and($scoped->getTimeStamp())->toBeString()
         ->and($scoped->getTimeStamp())->not->toBe('')
         ->and($scoped->getDefaultTransactionCode())->toBe('7')


### PR DESCRIPTION
Closes #277.

## The defect

The callback's user-cancellation branch redirected and did nothing else. The transaction stayed `pending` forever: no `cancelled_at`, no `TransactionCancelled`, no trace that the customer cancelled. Anything polling for a final state never got one, and reconciliation could not tell a cancellation from an abandoned request.

Cancellation is not an edge case. In seven runs against the production gateway on 12 September 2026, four ended this way: three by abandoning the form, one by the Cancel button.

## What SISP actually sends

Four real captures, all the same shape, no `messageType` and no fingerprint:

```json
{ "merchantRef": "...", "merchantSession": "...", "UserCancelled": "true" }
```

Uppercase `U` in all four. That spelling is now the only one the controller reads.

## The fix, and what it exposed

The branch resolves the transaction from `merchantRef` and `merchantSession` and runs it through `CancelTransactionAction`. Making that path write to the database from a public, unauthenticated route exposed four adjacent defects, and the branch closes all of them.

**`failed` and `refunded` were not terminal.** `cannotBeCancelled` refused only `completed` and `cancelled`. Cancelling a `failed` transaction overwrote the gateway's own `merchant_response` and moved it out of the one status `CanRetryPaymentAction` accepts, taking the retry away from a customer whose card had simply been declined. Cancelling a `refunded` one erased the refund.

**The reference was guessable.** The default generator emitted `'R'` plus a timestamp to the second: 86 400 values a day, enumerable, and collidable on a column the transactions table holds unique. SISP signs no fingerprint on the cancellation callback, so the reference is the only thing identifying the transaction a cancellation names. Both generators now append ten characters from `Str::random`, and the cancellation branch carries a rate limiter keyed on the reference. Successful callbacks are exempt from it: they carry a fingerprint, and throttling them would drop a payment the gateway had already taken.

**The status was read without holding the row.** A cancellation racing the success callback could write `cancelled` over a payment that had just completed. The row is now re-read under `lockForUpdate` inside the transaction, and the decision is taken there.

**The invoice was never updated.** A cancelled transaction left its invoice `pending` forever, the same defect as #277 one level up. `UpdateInvoiceStatusAction` had no arm for `cancelled` or `refunded`, so calling it would have thrown `UnhandledMatchError`. The invoice is now cancelled inside the same database transaction, for both the callback and the signed `sisp/cancel` route.

## Breaking changes

Two commits are marked `!`.

`CancelTransactionAction::handle` now throws `LogicException` for `failed` and `refunded`, where it previously cancelled them.

The default merchant reference and session change shape, from `R20260523235959` to `R20260523235959K7M2QX9TBV`. Anything parsing the timestamp out of a reference, or sizing a column to 15 characters, needs the 25-character form. Applications that need the old shape can restore it with their own generator through `sisp.generators`.

## Tests

491 tests, 2403 assertions. `composer test` green: pint, rector, peck, arch, PHPStan clean, type coverage 100%.

Covered: terminal statuses through both callers, invoice cancelled by both paths and untouched when the cancellation is refused, missing and mismatched session, a neighbouring transaction left alone, the limiter firing on cancellation and not on a successful callback, idempotency pinned with time travel rather than a same-second timestamp comparison.

One gap, stated plainly: nothing exercises the `lockForUpdate`, and nothing can where it is. The suite runs on SQLite, where `FOR UPDATE` is inert, so removing the lock would leave the suite green. Proving it needs a two-process concurrency test against PostgreSQL or MySQL, which this repository does not have set up.

## Left out, deliberately

`RefundTransactionAction` never updates the invoice, so a refunded transaction's invoice stays `paid`. Pre-existing, tracked separately.

The merchant reference travels in the query string of the post-callback redirect, so it reaches browser history, proxy logs and the `Referer` header. Now that the reference is what identifies a cancellation, a `Referrer-Policy: no-referrer` on the response view is worth adding. Pre-existing, not in this branch.