### PR TITLE
fix(invoice)!: refund the invoice when the transaction is refunded

### DIFF
--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -88,7 +88,7 @@ $invoice = $transaction->invoice;
 
 if ($invoice) {
     echo $invoice->pdf_path;       // Path to PDF file
-    echo $invoice->status;         // pending/issued/paid/overdue/cancelled
+    echo $invoice->status;         // pending/issued/paid/overdue/cancelled/refunded
 }
 ```
 
@@ -312,6 +312,7 @@ Cannot be refunded:
 - Refund operations use the dedicated refund FingerPrint with version `2`
 - Successful full refunds preserve the original transaction amount and change status to `refunded`
 - Successful partial refunds preserve the transaction as `completed` until the known refunded balance reaches the original amount
+- A full refund moves the associated invoice to `refunded` in the same database transaction; partial refunds leave the invoice on `paid`
 - For refunds on a different day, SISP may require enough daily purchase liquidity to cover the refunded amount
 - For DCC transactions, refund in the original transaction currency
 

--- a/docs/06-invoice-generation.md
+++ b/docs/06-invoice-generation.md
@@ -41,7 +41,7 @@ These are used on every invoice PDF.
 $invoice->invoice_number;     // Generated number (e.g., INV-20250101-001)
 $invoice->invoice_date;       // Date invoice was created
 $invoice->due_date;           // Due date (7 days from creation by default)
-$invoice->status;             // pending/issued/paid/overdue/cancelled
+$invoice->status;             // pending/issued/paid/overdue/cancelled/refunded
 $invoice->customer_name;      // Customer name from transaction
 $invoice->customer_email;     // Customer email from transaction
 $invoice->customer_city;      // Customer city from transaction
@@ -76,6 +76,7 @@ match ($invoice->status) {
     InvoiceStatus::paid => /* Payment confirmed */,
     InvoiceStatus::overdue => /* Past due date */,
     InvoiceStatus::cancelled => /* Cancelled */,
+    InvoiceStatus::refunded => /* Payment refunded in full */,
 };
 ```
 

--- a/docs/11-api-reference.md
+++ b/docs/11-api-reference.md
@@ -472,6 +472,7 @@ InvoiceStatus::issued             // Sent to customer
 InvoiceStatus::paid               // Payment confirmed
 InvoiceStatus::overdue            // Past due date
 InvoiceStatus::cancelled          // Cancelled
+InvoiceStatus::refunded           // Payment refunded in full
 ```
 
 ## Facade API

--- a/src/Actions/RefundTransactionAction.php
+++ b/src/Actions/RefundTransactionAction.php
@@ -10,53 +10,69 @@ use Akira\Sisp\Models\Transaction;
 use Akira\Sisp\Support\SispAmount;
 use Akira\Sisp\Support\TransactionLogContext;
 use Akira\Sisp\ValueObjects\RefundRequest;
+use Illuminate\Support\Facades\DB;
 use LogicException;
 
 final readonly class RefundTransactionAction
 {
-    public function __construct(private BuildRefundRequestAction $buildRefundRequest) {}
+    public function __construct(
+        private BuildRefundRequestAction $buildRefundRequest,
+        private UpdateInvoiceStatusAction $updateInvoiceStatus,
+    ) {}
 
     public function handle(
         Transaction $transaction,
         float $refundAmount,
         string $reason = 'user_refund',
     ): Transaction {
-        if (! $this->canBeRefunded($transaction)) {
-            throw new LogicException(
-                "Transaction with status '{$transaction->status->value}' cannot be refunded."
-            );
-        }
-
         throw_if($refundAmount <= 0, LogicException::class, 'Refund amount must be greater than 0.');
 
-        $refundThousandths = SispAmount::toThousandths($refundAmount);
-        $refundableThousandths = $this->refundableThousandths($transaction);
+        $refunded = DB::transaction(function () use ($transaction, $refundAmount, $reason): Transaction {
+            $locked = $transaction->newQuery()->whereKey($transaction->getKey())->lockForUpdate()->first();
 
-        throw_if($refundThousandths <= 0, LogicException::class, 'Refund amount must be greater than 0.');
+            if (! $locked instanceof Transaction || ! $this->canBeRefunded($locked)) {
+                $status = $locked instanceof Transaction ? $locked->status->value : $transaction->status->value;
 
-        throw_if(
-            $refundThousandths > $refundableThousandths,
-            LogicException::class,
-            "Refund amount ({$refundAmount}) exceeds refundable balance."
-        );
+                throw new LogicException("Transaction with status '{$status}' cannot be refunded.");
+            }
 
-        $request = $this->buildRefundRequest($transaction, $refundAmount);
-        $payload = $this->appendRefundPayload($transaction, $request->toArray(), $reason);
-        $remainingThousandths = $refundableThousandths - $refundThousandths;
+            $refundThousandths = SispAmount::toThousandths($refundAmount);
+            $refundableThousandths = $this->refundableThousandths($locked);
 
-        TransactionLogContext::run(
-            'refund',
-            fn (): bool => $transaction->update([
-                'status' => $remainingThousandths === 0 ? TransactionStatus::refunded->value : TransactionStatus::completed->value,
-                'merchant_response' => "{$reason}::{$refundAmount}",
-                'payload' => $payload,
-                'refunded_at' => now(),
-            ])
-        );
+            throw_if($refundThousandths <= 0, LogicException::class, 'Refund amount must be greater than 0.');
 
-        event(new TransactionRefunded($transaction, $refundAmount, $reason));
+            throw_if(
+                $refundThousandths > $refundableThousandths,
+                LogicException::class,
+                "Refund amount ({$refundAmount}) exceeds refundable balance."
+            );
 
-        return $transaction;
+            $request = $this->buildRefundRequest($locked, $refundAmount);
+            $payload = $this->appendRefundPayload($locked, $request->toArray(), $reason);
+            $status = $refundableThousandths === $refundThousandths
+                ? TransactionStatus::refunded
+                : TransactionStatus::completed;
+
+            TransactionLogContext::run(
+                'refund',
+                fn (): bool => $locked->update([
+                    'status' => $status->value,
+                    'merchant_response' => "{$reason}::{$refundAmount}",
+                    'payload' => $payload,
+                    'refunded_at' => now(),
+                ])
+            );
+
+            if ($status === TransactionStatus::refunded) {
+                $this->updateInvoiceStatus->handle($locked, $status);
+            }
+
+            return $locked;
+        });
+
+        event(new TransactionRefunded($refunded, $refundAmount, $reason));
+
+        return $refunded;
     }
 
     private function canBeRefunded(Transaction $transaction): bool

--- a/src/Actions/UpdateInvoiceStatusAction.php
+++ b/src/Actions/UpdateInvoiceStatusAction.php
@@ -30,7 +30,8 @@ final readonly class UpdateInvoiceStatusAction
             TransactionStatus::completed => InvoiceStatus::paid,
             TransactionStatus::failed => InvoiceStatus::cancelled,
             TransactionStatus::pending => InvoiceStatus::pending,
-            TransactionStatus::cancelled, TransactionStatus::refunded => InvoiceStatus::cancelled,
+            TransactionStatus::cancelled => InvoiceStatus::cancelled,
+            TransactionStatus::refunded => InvoiceStatus::refunded,
         };
 
         $invoice->update(['status' => $invoiceStatus->value]);

--- a/src/Enums/InvoiceStatus.php
+++ b/src/Enums/InvoiceStatus.php
@@ -11,4 +11,5 @@ enum InvoiceStatus: string
     case paid = 'paid';
     case overdue = 'overdue';
     case cancelled = 'cancelled';
+    case refunded = 'refunded';
 }

--- a/tests/Actions/RefundTransactionActionTest.php
+++ b/tests/Actions/RefundTransactionActionTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Akira\Sisp\Actions\GenerateInvoiceAction;
 use Akira\Sisp\Actions\RefundTransactionAction;
+use Akira\Sisp\Enums\InvoiceStatus;
 use Akira\Sisp\Enums\TransactionStatus;
 use Akira\Sisp\Models\Transaction;
 
@@ -119,4 +121,85 @@ it('does not allow refunds above the remaining local balance', function (): void
 
     expect(fn () => resolve(RefundTransactionAction::class)->handle($t, 50.0))
         ->toThrow(LogicException::class, 'Refund amount (50) exceeds refundable balance.');
+});
+
+it('marks the invoice as refunded when the transaction is fully refunded', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($t);
+    $invoice->update(['status' => InvoiceStatus::paid->value]);
+
+    resolve(RefundTransactionAction::class)->handle($t, 100.0, 'customer_request');
+
+    expect($invoice->refresh()->status)->toBe(InvoiceStatus::refunded);
+});
+
+it('leaves the invoice untouched when only part of the transaction is refunded', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($t);
+    $invoice->update(['status' => InvoiceStatus::issued->value]);
+
+    resolve(RefundTransactionAction::class)->handle($t, 40.0, 'partial_request');
+
+    expect($invoice->refresh()->status)->toBe(InvoiceStatus::issued)
+        ->and($invoice->pdf_path)->toBeNull();
+});
+
+it('rereads the refunded balance so a stale instance cannot refund twice', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+    $stale = Transaction::query()->whereKey($t->getKey())->sole();
+
+    resolve(RefundTransactionAction::class)->handle($t, 60.0, 'partial_request');
+
+    expect(fn () => resolve(RefundTransactionAction::class)->handle($stale, 60.0, 'partial_request'))
+        ->toThrow(LogicException::class, 'Refund amount (60) exceeds refundable balance.');
+});
+
+it('marks the invoice as refunded once successive partial refunds cover the amount', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($t);
+    $invoice->update(['status' => InvoiceStatus::paid->value]);
+
+    $action = resolve(RefundTransactionAction::class);
+    $action->handle($t, 60.0, 'partial_request');
+
+    expect($invoice->refresh()->status)->toBe(InvoiceStatus::paid);
+
+    $action->handle($t->refresh(), 40.0, 'partial_request');
+
+    expect($t->refresh()->status)->toBe(TransactionStatus::refunded)
+        ->and($invoice->refresh()->status)->toBe(InvoiceStatus::refunded);
+});
+
+it('refunds a transaction that has no invoice', function (): void {
+    $t = Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => 100.0,
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+
+    $updated = resolve(RefundTransactionAction::class)->handle($t, 100.0, 'customer_request');
+
+    expect($updated->status)->toBe(TransactionStatus::refunded)
+        ->and($updated->invoice)->toBeNull();
 });

--- a/tests/Actions/UpdateInvoiceStatusActionTest.php
+++ b/tests/Actions/UpdateInvoiceStatusActionTest.php
@@ -84,7 +84,6 @@ it('does not generate pdf if it already exists when transaction completes', func
     $transaction = Transaction::factory()->create(['status' => 'completed']);
     $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
 
-    // Simulate PDF already exists
     $invoice->update(['pdf_path' => 'invoices/existing.pdf']);
 
     $action = resolve(UpdateInvoiceStatusAction::class);
@@ -108,10 +107,8 @@ it('does not generate pdf when transaction is not completed', function (): void 
 
 it('handles transaction without invoice gracefully', function (): void {
     $transaction = Transaction::factory()->create(['status' => 'pending']);
-    // Don't create an invoice
 
     $action = resolve(UpdateInvoiceStatusAction::class);
-    // Should not throw an exception
     $action->handle($transaction, TransactionStatus::pending);
 
     expect(true)->toBeTrue();
@@ -143,5 +140,30 @@ it('does not fail the payment flow when pdf generation throws', function (): voi
     $invoice->refresh();
 
     expect($invoice->status)->toBe(InvoiceStatus::paid)
+        ->and($invoice->pdf_path)->toBeNull();
+});
+
+it('updates invoice status to cancelled when transaction is cancelled', function (): void {
+    $transaction = Transaction::factory()->create(['status' => 'cancelled']);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+
+    resolve(UpdateInvoiceStatusAction::class)->handle($invoice->transaction, TransactionStatus::cancelled);
+
+    $invoice->refresh();
+
+    expect($invoice->status)->toBe(InvoiceStatus::cancelled)
+        ->and($invoice->pdf_path)->toBeNull();
+});
+
+it('updates invoice status to refunded when transaction is refunded', function (): void {
+    $transaction = Transaction::factory()->create(['status' => 'refunded']);
+    $invoice = resolve(GenerateInvoiceAction::class)->handle($transaction);
+    $invoice->update(['status' => InvoiceStatus::paid->value]);
+
+    resolve(UpdateInvoiceStatusAction::class)->handle($invoice->transaction, TransactionStatus::refunded);
+
+    $invoice->refresh();
+
+    expect($invoice->status)->toBe(InvoiceStatus::refunded)
         ->and($invoice->pdf_path)->toBeNull();
 });


### PR DESCRIPTION
Closes #279.

## Problem

`RefundTransactionAction` set the transaction to `refunded` and stopped there. No listener on `TransactionRefunded` picked up the invoice either, so the `Invoice` kept the status it had before the refund, typically `paid`. A returned payment still read as a paid invoice in listings, in the `DoctorCommand` counters, in `RegenerateMissingInvoicePdfsCommand` and on the generated PDF. The cancellation path already does the right thing since #278; the refund path never got the same treatment.

## Fix

`UpdateInvoiceStatusAction` is now called from inside the action, in the same database transaction as the status write, mirroring `CancelTransactionAction` rather than pushing it into the controller. Only a full refund flips the invoice: a partial refund leaves the transaction on `completed` and the invoice untouched.

`InvoiceStatus` gains a `refunded` case. A refunded invoice is not a cancelled one, and reusing `cancelled` would erase that distinction in reports permanently. The `invoices.status` column is a plain `string`, so no data migration is required. The `match` in `UpdateInvoiceStatusAction` also gains its own `cancelled` arm, which retires the stale PHPStan baseline entry.

## Concurrency

Reviewing the branch surfaced a second defect in the same code path: the status and balance guards read the caller's in-memory model, outside any transaction and with no row lock, while the cancellation path re-reads with `lockForUpdate` and revalidates inside. Two concurrent refunds of the same 100.00 transaction both passed the balance guard and both wrote - 200.00 refunded, with the second `update` overwriting the first one's `refunds[]` audit entry. The guards now run against the locked row, and `handle()` returns that instance, which also fixes a stale `invoice` relation silently skipping the invoice write.

## Tests

Seven new Pest tests, real container and database, no mocks: full refund, partial refund, successive partials reaching the total, a transaction with no invoice, a stale instance that must not refund twice, plus the `cancelled` and `refunded` arms of `UpdateInvoiceStatusAction`. The partial-refund test asserts against a status the mapping never produces for a partial (`issued`), so it fails if the full-refund guard is removed - verified by mutation.

`pint` clean, 498 tests green, PHPStan clean, arch, typos and 100% type coverage.

## Breaking change

`InvoiceStatus` has a new `refunded` case, and a fully refunded transaction moves its invoice to `refunded` instead of keeping `paid`. A consumer with an exhaustive `match` over `InvoiceStatus` and no default arm raises `UnhandledMatchError`; a query reaching refunded invoices through `cancelled` stops seeing them.

## Out of scope, found while reviewing

- `RefundTransactionController` does not validate its input: `(float)` on an array yields `1.0`, so `amount[]=x` refunds 1.00 ECV, and `reason[]=x` raises a `TypeError` and a 500 instead of a 400. It has no controller test. Pre-existing and independent of the invoice status.
- `SispAmount::toThousandths` truncates below three decimals, so partial refunds with a sub-thousandth residue never sum to the total. Pre-existing arithmetic.
- `docs/05-transaction-management.md` documents the refund route without mentioning that the package registers no policy, so a consumer following it gets a 403 until the ability is registered.
