### PR TITLE
fix(refund)!: validate the refund request payload

### DIFF
--- a/docs/05-transaction-management.md
+++ b/docs/05-transaction-management.md
@@ -336,9 +336,19 @@ POST to `/sisp/refund/{transaction}`:
 ```php
 POST /sisp/refund/{transaction}
 {
-    "amount": 500.00
+    "amount": 500.00,
+    "reason": "customer_request"
 }
 ```
+
+`amount` is required, numeric and must be greater than zero. `reason` is optional, a string of at most 255 characters, and defaults to `user_refund`.
+
+Responses:
+
+- `200` the refund succeeded, with the updated transaction in the body
+- `400` the transaction cannot be refunded, or the amount exceeds the refundable balance
+- `403` the authenticated user is not allowed to refund this transaction
+- `422` the payload failed validation, with the messages under `errors`
 
 Dispatches `TransactionRefunded` event.
 

--- a/src/Http/Controllers/RefundTransactionController.php
+++ b/src/Http/Controllers/RefundTransactionController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Akira\Sisp\Http\Controllers;
 
 use Akira\Sisp\Actions\RefundTransactionAction;
+use Akira\Sisp\Http\Requests\RefundTransactionRequest;
 use Akira\Sisp\Models\Transaction;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use LogicException;
 
 final readonly class RefundTransactionController
@@ -16,20 +16,14 @@ final readonly class RefundTransactionController
         private RefundTransactionAction $refundTransaction,
     ) {}
 
-    public function __invoke(Transaction $transaction, Request $request): JsonResponse
+    public function __invoke(Transaction $transaction, RefundTransactionRequest $request): JsonResponse
     {
-        if (! $this->isAuthorizedForTransaction($request, $transaction)) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Unauthorized to refund this transaction.',
-            ], 403);
-        }
-
-        $refundAmount = (float) $request->input('amount');
-        $reason = $request->input('reason', 'user_refund');
-
         try {
-            $transaction = $this->refundTransaction->handle($transaction, $refundAmount, $reason);
+            $transaction = $this->refundTransaction->handle(
+                $transaction,
+                $request->refundAmount(),
+                $request->refundReason(),
+            );
 
             return response()->json([
                 'success' => true,
@@ -42,16 +36,5 @@ final readonly class RefundTransactionController
                 'message' => $e->getMessage(),
             ], 400);
         }
-    }
-
-    private function isAuthorizedForTransaction(Request $request, Transaction $transaction): bool
-    {
-        $user = $request->user();
-
-        if (! $user) {
-            return false;
-        }
-
-        return $user->can('refund', $transaction);
     }
 }

--- a/src/Http/Requests/RefundTransactionRequest.php
+++ b/src/Http/Requests/RefundTransactionRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Sisp\Http\Requests;
+
+use Akira\Sisp\Models\Transaction;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+final class RefundTransactionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        $transaction = $this->route('transaction');
+
+        if (! $user || ! $transaction instanceof Transaction) {
+            return false;
+        }
+
+        return $user->can('refund', $transaction);
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'amount' => ['required', 'numeric', 'gt:0'],
+            'reason' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+
+    public function refundAmount(): float
+    {
+        return (float) $this->validated('amount');
+    }
+
+    public function refundReason(): string
+    {
+        return $this->string('reason', 'user_refund')->toString();
+    }
+
+    protected function failedAuthorization(): never
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => 'Unauthorized to refund this transaction.',
+        ], 403));
+    }
+
+    protected function failedValidation(Validator $validator): never
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => 'The refund request is invalid.',
+            'errors' => $validator->errors()->toArray(),
+        ], 422));
+    }
+}

--- a/tests/Controllers/RefundTransactionControllerTest.php
+++ b/tests/Controllers/RefundTransactionControllerTest.php
@@ -3,213 +3,214 @@
 declare(strict_types=1);
 
 use Akira\Sisp\Enums\TransactionStatus;
-use Akira\Sisp\Http\Controllers\RefundTransactionController;
 use Akira\Sisp\Models\Transaction;
-use Illuminate\Http\Request;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Gate;
+
+final class RefundRouteUser implements Authenticatable
+{
+    public function __construct(
+        public int $id = 1,
+        public string $email = 'buyer@example.com',
+    ) {}
+
+    public function getAuthIdentifierName(): string
+    {
+        return 'id';
+    }
+
+    public function getAuthIdentifier(): int
+    {
+        return $this->id;
+    }
+
+    public function getAuthPasswordName(): string
+    {
+        return 'password';
+    }
+
+    public function getAuthPassword(): string
+    {
+        return '';
+    }
+
+    public function getRememberToken(): ?string
+    {
+        return null;
+    }
+
+    public function setRememberToken($value): void {}
+
+    public function getRememberTokenName(): string
+    {
+        return 'remember_token';
+    }
+
+    public function can(string $ability, mixed $arguments = []): bool
+    {
+        return Gate::forUser($this)->check($ability, $arguments);
+    }
+}
+
+function refundableTransaction(float $amount = 100.0): Transaction
+{
+    return Transaction::factory()->create([
+        'status' => TransactionStatus::completed->value,
+        'amount' => $amount,
+        'customer_email' => 'buyer@example.com',
+        'transaction_id' => '123',
+        'response_code' => '5',
+    ]);
+}
+
+function allowRefunds(bool $allowed = true): void
+{
+    Gate::define('refund', fn (RefundRouteUser $user, Transaction $transaction): bool => $allowed);
+}
 
 it('refunds a completed transaction and returns json', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => TransactionStatus::completed->value,
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 100.0, 'reason' => 'test']);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public string $email = 'buyer@example.com';
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 100.0, 'reason' => 'test'])
+        ->assertOk()
+        ->assertJsonPath('success', true);
 
-        public function can(string $ability, mixed $subject): bool
-        {
-            return $ability === 'refund' && $subject instanceof Transaction;
-        }
-    });
-
-    $response = $controller($t, $request);
-
-    expect($response->getStatusCode())->toBe(200);
-    $data = $response->getData(true);
-    expect($data['success'])->toBeTrue();
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::refunded)
+        ->and($transaction->merchant_response)->toBe('test::100');
 });
 
-it('returns 400 when refund amount exceeds transaction', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => 'completed',
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+it('defaults the reason when the payload omits it', function (): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 150.0]);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public string $email = 'buyer@example.com';
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 100.0])
+        ->assertOk();
 
-        public function can(string $ability, mixed $subject): bool
-        {
-            return $ability === 'refund' && $subject instanceof Transaction;
-        }
-    });
-
-    $response = $controller($t, $request);
-    expect($response->getStatusCode())->toBe(400);
+    expect($transaction->refresh()->merchant_response)->toBe('user_refund::100');
 });
 
 it('allows partial refund amounts', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => 'completed',
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 50.0]);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public function can(string $ability, mixed $subject): bool
-        {
-            return $ability === 'refund' && $subject instanceof Transaction;
-        }
-    });
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 50.0])
+        ->assertOk()
+        ->assertJsonPath('success', true);
 
-    $response = $controller($t, $request);
-    expect($response->getStatusCode())->toBe(200)
-        ->and($response->getData(true)['success'])->toBeTrue()
-        ->and($t->refresh()->payload['refunds'][0]['request']['transactionCode'])->toBe('8');
+    expect($transaction->refresh()->payload['refunds'][0]['request']['transactionCode'])->toBe('8');
 });
 
-it('returns 403 when user is not authorized for the transaction', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => TransactionStatus::completed->value,
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+it('returns 400 when refund amount exceeds transaction', function (): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public string $email = 'intruder@example.com';
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 150.0])
+        ->assertStatus(400)
+        ->assertJsonPath('success', false);
 
-        public function can(string $ability, mixed $subject): bool
-        {
-            return false;
-        }
-    });
-
-    $response = $controller($t, $request);
-
-    expect($response->getStatusCode())->toBe(403);
-    $data = $response->getData(true);
-    expect($data['success'])->toBeFalse();
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
 });
 
-it('returns 403 when customer email matches but user lacks refund ability', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => TransactionStatus::completed->value,
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+it('returns 403 when the gate denies the refund', function (): void {
+    allowRefunds(false);
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public string $email = 'buyer@example.com';
+    $this->actingAs(new RefundRouteUser(2, 'intruder@example.com'))
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 10.0])
+        ->assertForbidden()
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('message', 'Unauthorized to refund this transaction.');
 
-        public function can(string $ability, mixed $subject): bool
-        {
-            return false;
-        }
-    });
-
-    $response = $controller($t, $request);
-
-    expect($response->getStatusCode())->toBe(403)
-        ->and($response->getData(true)['success'])->toBeFalse()
-        ->and($t->refresh()->status)->toBe(TransactionStatus::completed);
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
 });
 
-it('returns 403 when no authenticated user is present', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => TransactionStatus::completed->value,
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+it('returns 403 when the customer email matches but the gate still denies', function (): void {
+    allowRefunds(false);
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 10.0])
+        ->assertForbidden();
 
-    $response = $controller($t, $request);
-
-    expect($response->getStatusCode())->toBe(403);
-    $data = $response->getData(true);
-    expect($data['success'])->toBeFalse();
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
 });
 
-it('returns 403 when user has no email and no refund ability', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => TransactionStatus::completed->value,
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+it('rejects unauthenticated refund attempts', function (): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 10.0]);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public function can(string $ability, mixed $subject): bool
-        {
-            return false;
-        }
-    });
+    $this->postJson(route('sisp.refund', $transaction), ['amount' => 10.0])
+        ->assertUnauthorized();
 
-    $response = $controller($t, $request);
-
-    expect($response->getStatusCode())->toBe(403);
-    $data = $response->getData(true);
-    expect($data['success'])->toBeFalse();
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
 });
 
-it('allows authorized users through can refund ability', function (): void {
-    $t = Transaction::factory()->create([
-        'status' => TransactionStatus::completed->value,
-        'amount' => 100.0,
-        'customer_email' => 'buyer@example.com',
-        'transaction_id' => '123',
-        'response_code' => '5',
-    ]);
+it('rejects an array amount instead of refunding one unit', function (): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    $controller = resolve(RefundTransactionController::class);
-    $request = Request::create(route('sisp.refund', $t), 'POST', ['amount' => 100.0, 'reason' => 'policy_allowed']);
-    $request->setUserResolver(fn (): object => new class
-    {
-        public string $email = 'intruder@example.com';
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => ['x']])
+        ->assertStatus(422)
+        ->assertJsonPath('success', false)
+        ->assertJsonValidationErrors('amount');
 
-        public function can(string $ability, mixed $subject): bool
-        {
-            return $ability === 'refund' && $subject instanceof Transaction;
-        }
-    });
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed)
+        ->and($transaction->payload['refunds'] ?? [])->toBe([]);
+});
 
-    $response = $controller($t, $request);
-    $data = $response->getData(true);
+it('rejects an array reason instead of failing with a type error', function (): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
 
-    expect($response->getStatusCode())->toBe(200)
-        ->and($data['success'])->toBeTrue();
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => 10.0, 'reason' => ['x']])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('reason');
+
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
+});
+
+it('rejects invalid amounts', function (mixed $amount): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
+
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => $amount])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('amount');
+
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
+})->with([
+    'zero' => [0],
+    'negative' => [-5],
+    'non numeric' => ['abc'],
+    'empty' => [''],
+]);
+
+it('requires an amount', function (): void {
+    allowRefunds();
+    $transaction = refundableTransaction();
+
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('amount');
+});
+
+it('answers 403 before validating when the gate denies the refund', function (): void {
+    allowRefunds(false);
+    $transaction = refundableTransaction();
+
+    $this->actingAs(new RefundRouteUser())
+        ->postJson(route('sisp.refund', $transaction), ['amount' => ['x']])
+        ->assertForbidden()
+        ->assertJsonMissingPath('errors');
+
+    expect($transaction->refresh()->status)->toBe(TransactionStatus::completed);
 });


### PR DESCRIPTION
Closes #283.

## What was wrong

`RefundTransactionController` read its payload straight off the request, with nothing validating it before `RefundTransactionAction`.

`(float) $request->input("amount")` on an array yields `1.0` in PHP, so `amount[]=x` refunded 1.00 ECV that nobody asked for, and the action saw a perfectly valid amount. On the next line `reason` went through untouched into a `string` parameter under `declare(strict_types=1)`, so `reason[]=x` threw a `TypeError` and answered 500 where the input was simply malformed. PHPStan runs at level 5, so the `mixed` reaching a `string` parameter was never reported.

Nothing covered the shape of the payload: the controller test exercised authorization only.

## What changed

`RefundTransactionRequest` validates `amount` as required, numeric and greater than zero, and `reason` as an optional string of at most 255 characters defaulting to `user_refund`. It also carries the `can("refund", $transaction)` check, so the 403 still precedes validation rather than being reordered behind it — there is a test that fixes that precedence. Both failure paths answer JSON instead of the default redirect.

The controller is left with the delegation to the action and the `LogicException` to 400 mapping.

The test file now drives the real HTTP stack with `actingAs` and `Gate::define` instead of invoking the controller by hand, which is the only way the 422 is genuinely exercised. Fifteen tests, including `amount[]` and `reason[]` answering 422 with the transaction untouched.

## Breaking changes

- `RefundTransactionController::__invoke()` takes a `RefundTransactionRequest` instead of a generic `Request`. Only affects a caller invoking the controller directly; the router is unaffected.
- The endpoint answers 422 on an invalid payload where it previously answered 400, 500, or silently refunded 1.00.

## Notes for the reviewer

- An unauthenticated request now answers 401 instead of 403. The controller 403 was unreachable: the route auth middleware answers first. The old test only observed it because it called the controller directly.
- `reason` has no `nullable` rule on purpose. An explicit null is rejected with 422 rather than quietly becoming an empty string, which is what `Request::string()` would return for a present null.
- Amounts below one thousandth (`0.0004`) pass `gt:0` and collapse to zero in `SispAmount::toThousandths`; the action rejects them with 400, same as before.

## Verification

`composer test` passes in full (pint, rector, peck, arch, phpstan, type coverage at 100%) with `memory_limit=1G`; phpstan exhausts the 128M default. Full Pest suite green: 504 tests, 2449 assertions.